### PR TITLE
docs(#5): Add business rule documentation template and example

### DIFF
--- a/docs-site/docs/templates/business-rule-example.md
+++ b/docs-site/docs/templates/business-rule-example.md
@@ -1,0 +1,192 @@
+---
+id: "ACCT-BR-001"
+title: "Account withdrawal requires sufficient balance and active status"
+domain: "account-management"
+cobol_source: "CBACT01C.cbl:120-145"
+requirement_id: "ACCT-BR-001"
+regulations:
+  - "PSD2 Art. 97"
+  - "FFFS 2014:5 Ch. 4 §3"
+status: "validated"
+validated_by: "Erik Lindström"
+validated_date: "2026-02-10"
+priority: "critical"
+---
+
+# ACCT-BR-001: Account withdrawal requires sufficient balance and active status
+
+## Summary
+
+A withdrawal from a customer account may only be processed if the account status is active and the available balance is sufficient to cover the withdrawal amount. This rule prevents overdrafts on standard accounts and ensures that frozen, closed, or suspended accounts cannot be debited. It is a core safety check executed on every withdrawal transaction in the online banking and teller systems.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM VALIDATE-WITHDRAWAL:
+    READ account record from DB2 using account-id
+    IF account-status NOT = 'ACTIVE' THEN
+        SET error-code = 'ACCT-INACTIVE'
+        SET error-message = 'Account is not in active status'
+        PERFORM ERROR-HANDLER
+        EXIT
+    END-IF
+
+    COMPUTE available-balance = current-balance - hold-amount
+
+    IF available-balance < withdrawal-amount THEN
+        SET error-code = 'INSUFF-FUNDS'
+        SET error-message = 'Insufficient available balance'
+        PERFORM ERROR-HANDLER
+        EXIT
+    END-IF
+
+    COMPUTE new-balance = current-balance - withdrawal-amount
+    UPDATE account SET balance = new-balance
+    WRITE transaction-log (account-id, withdrawal-amount, timestamp, teller-id)
+    COMMIT
+```
+
+### Decision Table
+
+| Account Status | Available Balance >= Amount | Outcome |
+|---------------|---------------------------|---------|
+| ACTIVE        | Yes                       | Withdrawal processed, balance updated |
+| ACTIVE        | No                        | Rejected: insufficient funds (INSUFF-FUNDS) |
+| FROZEN        | Yes                       | Rejected: account inactive (ACCT-INACTIVE) |
+| FROZEN        | No                        | Rejected: account inactive (ACCT-INACTIVE) |
+| CLOSED        | Yes                       | Rejected: account inactive (ACCT-INACTIVE) |
+| CLOSED        | No                        | Rejected: account inactive (ACCT-INACTIVE) |
+| SUSPENDED     | Yes                       | Rejected: account inactive (ACCT-INACTIVE) |
+| SUSPENDED     | No                        | Rejected: account inactive (ACCT-INACTIVE) |
+
+## Source COBOL Reference
+
+**Program:** `CBACT01C.cbl`
+**Lines:** 120-145
+
+```cobol
+000120 2000-VALIDATE-WITHDRAWAL.
+000121     READ ACCOUNT-MASTER INTO WS-ACCOUNT-REC
+000122         KEY IS WS-ACCT-ID
+000123         INVALID KEY
+000124             MOVE 'ACCT-NOT-FOUND' TO WS-ERROR-CODE
+000125             PERFORM 9000-ERROR-HANDLER
+000126             GO TO 2000-EXIT
+000127     END-READ.
+000128
+000129     IF WS-ACCT-STATUS NOT = 'A'
+000130         MOVE 'ACCT-INACTIVE' TO WS-ERROR-CODE
+000131         MOVE 'Account is not in active status'
+000132             TO WS-ERROR-MSG
+000133         PERFORM 9000-ERROR-HANDLER
+000134         GO TO 2000-EXIT
+000135     END-IF.
+000136
+000137     COMPUTE WS-AVAIL-BAL =
+000138         WS-CURRENT-BAL - WS-HOLD-AMT.
+000139
+000140     IF WS-AVAIL-BAL < WS-WITHDRAWAL-AMT
+000141         MOVE 'INSUFF-FUNDS' TO WS-ERROR-CODE
+000142         MOVE 'Insufficient available balance'
+000143             TO WS-ERROR-MSG
+000144         PERFORM 9000-ERROR-HANDLER
+000145         GO TO 2000-EXIT
+000146     END-IF.
+000147
+000148     COMPUTE WS-NEW-BAL =
+000149         WS-CURRENT-BAL - WS-WITHDRAWAL-AMT.
+000150     PERFORM 3000-UPDATE-BALANCE.
+000151     PERFORM 4000-WRITE-TRANSACTION-LOG.
+000152
+000153 2000-EXIT.
+000154     EXIT.
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Successful withdrawal from active account with sufficient balance
+
+```gherkin
+GIVEN an account with status "ACTIVE"
+  AND a current balance of 10000.00 SEK
+  AND a hold amount of 0.00 SEK
+WHEN a withdrawal of 5000.00 SEK is requested
+THEN the withdrawal is processed successfully
+  AND the account balance is updated to 5000.00 SEK
+  AND a transaction log entry is created with the withdrawal details
+```
+
+### Scenario 2: Withdrawal rejected due to insufficient funds
+
+```gherkin
+GIVEN an account with status "ACTIVE"
+  AND a current balance of 3000.00 SEK
+  AND a hold amount of 1000.00 SEK
+WHEN a withdrawal of 2500.00 SEK is requested
+THEN the withdrawal is rejected with error code "INSUFF-FUNDS"
+  AND the account balance remains unchanged at 3000.00 SEK
+  AND no transaction log entry is created
+```
+
+### Scenario 3: Withdrawal rejected due to inactive account status
+
+```gherkin
+GIVEN an account with status "FROZEN"
+  AND a current balance of 50000.00 SEK
+WHEN a withdrawal of 1000.00 SEK is requested
+THEN the withdrawal is rejected with error code "ACCT-INACTIVE"
+  AND the account balance remains unchanged
+  AND no transaction log entry is created
+```
+
+### Scenario 4: Withdrawal for exact available balance (boundary)
+
+```gherkin
+GIVEN an account with status "ACTIVE"
+  AND a current balance of 5000.00 SEK
+  AND a hold amount of 2000.00 SEK
+WHEN a withdrawal of 3000.00 SEK is requested
+THEN the withdrawal is processed successfully
+  AND the account balance is updated to 2000.00 SEK
+```
+
+### Scenario 5: Account not found
+
+```gherkin
+GIVEN an account ID that does not exist in the system
+WHEN a withdrawal is requested for that account
+THEN the withdrawal is rejected with error code "ACCT-NOT-FOUND"
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 97 | Strong customer authentication for electronic payment transactions | The withdrawal validation is a prerequisite check before SCA is invoked; ensures only valid accounts proceed to authentication |
+| FFFS 2014:5 | Ch. 4 §3 | Credit institutions must maintain adequate systems for managing operational risk | Balance validation prevents unauthorized overdrafts and ensures account state consistency |
+| GDPR | Art. 6(1)(b) | Processing necessary for performance of a contract | Account balance check is necessary to fulfill the contractual obligation of maintaining accurate account records |
+
+## Edge Cases
+
+1. **Hold amount exceeds current balance**: If administrative holds placed on the account exceed the current balance (e.g., balance = 1000, hold = 1500), the available balance becomes negative. The COBOL code handles this correctly — any withdrawal amount will be greater than the negative available balance, resulting in rejection. The migrated code must preserve this behavior.
+
+2. **Concurrent withdrawals**: The original COBOL/IMS system uses record-level locking (PROCOPT=E) to prevent race conditions on balance updates. Two simultaneous withdrawals for the same account are serialized at the database level. The migrated implementation must use equivalent pessimistic locking or optimistic concurrency with retry.
+
+3. **Zero-amount withdrawal**: The COBOL code does not explicitly check for zero or negative withdrawal amounts — this is validated earlier in the IMS transaction input processing (program CBTRN00C). The migrated system should validate this at the API boundary.
+
+4. **Maximum transaction amount**: The COBOL copybook defines `WS-WITHDRAWAL-AMT PIC S9(11)V99`, allowing amounts up to 99,999,999,999.99. In practice, daily transaction limits are enforced by a separate rule (ACCT-BR-015). The migrated code should use `decimal` type to match COBOL precision.
+
+## Domain Expert Notes
+
+- **Erik Lindström** (2026-02-10): The `WS-HOLD-AMT` field was added in 1998 when Finansinspektionen required banks to support administrative freezes without changing account status. Before that, the only way to block withdrawals was to change the status to 'F' (frozen). Some old batch jobs still set status to 'F' instead of using holds — both paths must be supported.
+
+- **Erik Lindström** (2026-02-10): The error handler at paragraph 9000 writes to both the IMS message queue and the Db2 audit log. In the migrated system, make sure both the user-facing error response and the audit trail are maintained. FSA auditors specifically check the audit log for rejected transaction attempts.
+
+- **Margareta Johansson** (2026-02-08): The available balance calculation (`current-balance - hold-amount`) does not account for pending clearinghouse transactions from Bankgirot. Those are tracked in a separate file (VSAM dataset PEND.TRANS) and reconciled during the nightly batch run. The migrated system should consider whether to include pending transactions in real-time available balance.
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/templates/business-rule-template.md
+++ b/docs-site/docs/templates/business-rule-template.md
@@ -1,0 +1,153 @@
+---
+id: "{DOMAIN}-BR-{NNN}"
+title: "{Short descriptive title of the business rule}"
+domain: "{account-management | card-management | transactions | user-security | billing | reporting}"
+cobol_source: "{PROGRAM.cbl}:{start-line}-{end-line}"
+requirement_id: "{DOMAIN}-BR-{NNN}"
+regulations:
+  - "{Regulation reference, e.g., PSD2 Art. 97}"
+status: "{extracted | validated | implemented | tested}"
+validated_by: null
+validated_date: null
+priority: "{critical | high | medium | low}"
+---
+
+<!-- INSTRUCTIONS: Copy this template and fill in each section below.
+     Replace all {placeholder} values in the YAML front matter and body.
+     Remove these instruction comments before submitting for review. -->
+
+# {DOMAIN}-BR-{NNN}: {Title}
+
+## Summary
+
+<!-- INSTRUCTIONS: Write 1-3 sentences describing what this business rule does,
+     why it exists, and which business process it belongs to. This should be
+     understandable by a non-technical stakeholder. -->
+
+{Describe the business rule in plain language. What does it enforce? Why does it exist?}
+
+## Business Logic
+
+<!-- INSTRUCTIONS: Describe the rule's logic in enough detail for a developer
+     to implement it. Use pseudocode, structured narrative, or decision tables.
+     Include all conditions, thresholds, and outcomes. -->
+
+### Pseudocode
+
+```
+{Write pseudocode or structured narrative describing the rule logic.}
+
+Example format:
+IF condition_a AND condition_b THEN
+    perform action_x
+    SET field_y = calculated_value
+ELSE IF condition_c THEN
+    perform action_z
+    RAISE error "description"
+END-IF
+```
+
+### Decision Table (if applicable)
+
+<!-- INSTRUCTIONS: Use a decision table when the rule has multiple input
+     conditions that combine to produce different outcomes. -->
+
+| Condition A | Condition B | Outcome |
+|-------------|-------------|---------|
+| True        | True        | {outcome_1} |
+| True        | False       | {outcome_2} |
+| False       | True        | {outcome_3} |
+| False       | False       | {outcome_4} |
+
+## Source COBOL Reference
+
+<!-- INSTRUCTIONS: Paste the relevant COBOL source code that implements this
+     rule. Include enough surrounding context (5-10 lines before/after) for
+     the reader to understand the flow. Always include line numbers. -->
+
+**Program:** `{PROGRAM.cbl}`
+**Lines:** {start-line}-{end-line}
+
+```cobol
+{Paste the relevant COBOL source code with line numbers.}
+
+Example:
+000120 IF WS-ACCOUNT-STATUS = 'ACTIVE'
+000121    AND WS-BALANCE >= WS-WITHDRAWAL-AMT
+000122    PERFORM 2100-PROCESS-WITHDRAWAL
+000123 ELSE
+000124    MOVE 'INSUFFICIENT-FUNDS' TO WS-ERROR-CODE
+000125    PERFORM 9000-ERROR-HANDLER
+000126 END-IF
+```
+
+## Acceptance Criteria
+
+<!-- INSTRUCTIONS: Write acceptance criteria in GIVEN/WHEN/THEN format.
+     Each scenario should be independently testable. Cover the happy path,
+     error cases, and boundary conditions. These will be used to generate
+     SpecFlow BDD tests. -->
+
+### Scenario 1: {Happy path description}
+
+```gherkin
+GIVEN {precondition}
+  AND {additional precondition if needed}
+WHEN {action or event}
+THEN {expected outcome}
+  AND {additional expected outcome if needed}
+```
+
+### Scenario 2: {Error/rejection case description}
+
+```gherkin
+GIVEN {precondition}
+WHEN {action or event that triggers the error}
+THEN {expected error outcome}
+  AND {error handling behavior}
+```
+
+### Scenario 3: {Boundary/edge case description}
+
+```gherkin
+GIVEN {boundary precondition}
+WHEN {action at the boundary}
+THEN {expected boundary outcome}
+```
+
+## Regulatory Mapping
+
+<!-- INSTRUCTIONS: Map this business rule to the applicable regulations.
+     Every rule must trace to at least one regulation or explicitly state
+     "No direct regulatory requirement" with justification. -->
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| {e.g., PSD2} | {e.g., Art. 97} | {Requirement summary} | {How the rule addresses the requirement} |
+| {e.g., GDPR} | {e.g., Art. 6} | {Requirement summary} | {How the rule addresses the requirement} |
+| {e.g., FFFS 2014:5} | {e.g., Ch. 4 §3} | {Requirement summary} | {How the rule addresses the requirement} |
+
+## Edge Cases
+
+<!-- INSTRUCTIONS: Document known edge cases, unusual inputs, or race
+     conditions that the original COBOL code handles (or fails to handle).
+     These are critical for ensuring the migrated implementation is correct. -->
+
+1. **{Edge case title}**: {Description of the edge case and how the current system handles it.}
+2. **{Edge case title}**: {Description of the edge case and how the current system handles it.}
+3. **{Edge case title}**: {Description of the edge case and how the current system handles it.}
+
+## Domain Expert Notes
+
+<!-- INSTRUCTIONS: Record any verbal explanations, clarifications, or
+     institutional knowledge from domain experts (especially the retiring
+     COBOL developers). Include the expert's name and date for traceability.
+     This section is critical for capturing knowledge that isn't in the code. -->
+
+- **{Expert name}** ({date}): {Note or clarification about this rule.}
+- **{Expert name}** ({date}): {Note or clarification about this rule.}
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15


### PR DESCRIPTION
## Summary
- Created business rule Markdown template with YAML front matter for machine-readable metadata, regulatory traceability fields, and validation status
- Created filled-in example (ACCT-BR-001: Account withdrawal balance/status validation) with realistic COBOL source, acceptance criteria, and domain expert notes
- Template includes inline instructions for every field and section

## Changes
- `docs-site/docs/templates/business-rule-template.md` — Template with all required YAML fields (id, title, domain, cobol_source, requirement_id, regulations, status, validated_by, validated_date, priority) and body sections (Summary, Business Logic, Source COBOL Reference, Acceptance Criteria, Regulatory Mapping, Edge Cases, Domain Expert Notes)
- `docs-site/docs/templates/business-rule-example.md` — Fully populated example using account withdrawal validation rule from CBACT01C.cbl with realistic data, COBOL code snippets, Gherkin acceptance criteria, regulatory mapping (PSD2, FFFS 2014:5, GDPR), and domain expert notes

## Testing
- [x] YAML front matter validated — all 10 required fields present in both files
- [x] All 7 required body sections present in both files
- [x] Template contains inline instructions (HTML comments) for each section
- [x] Example uses valid domain value (account-management)
- [x] Example includes GIVEN/WHEN/THEN acceptance criteria format
- [x] Example includes regulatory mapping table
- [x] Example contains realistic COBOL code with line numbers
- [ ] Docusaurus rendering (blocked on #4 — Docusaurus initialization)

Closes #5

🤖 Generated with Claude Code