### PR TITLE
docs(#8): Add regulatory traceability matrix template and PSD2 SCA example

### DIFF
--- a/docs-site/docs/templates/regulatory-traceability-example.md
+++ b/docs-site/docs/templates/regulatory-traceability-example.md
@@ -1,0 +1,70 @@
+---
+id: "REG-PSD2-001"
+title: "PSD2 Strong Customer Authentication Traceability Matrix"
+domain: "payments"
+regulation: "PSD2"
+last_reviewed: "2026-02-15"
+reviewed_by: "Compliance Team (initial draft)"
+status: "draft"
+---
+
+# Regulatory Traceability Matrix: PSD2 Strong Customer Authentication
+
+## Regulation Overview
+
+The Payment Services Directive 2 (PSD2, EU Directive 2015/2366) requires payment service providers to apply Strong Customer Authentication (SCA) when a payer initiates an electronic payment transaction. SCA requires authentication based on two or more elements from: knowledge (something the user knows), possession (something the user has), and inherence (something the user is). The European Banking Authority's Regulatory Technical Standards (EBA RTS 2018/389) provide detailed requirements for SCA implementation.
+
+NordKredit AB, as a licensed payment service provider under Finansinspektionen supervision, must comply with PSD2 SCA for all customer-initiated electronic payments processed through the core banking system.
+
+**Regulation:** PSD2 (EU Directive 2015/2366), EBA RTS on SCA (EU 2018/389)
+**Issuing Authority:** European Commission, European Banking Authority
+**Effective Date:** 14 September 2019 (SCA enforcement)
+**Scope:** All customer-initiated electronic payment transactions at NordKredit AB
+
+## Traceability Table
+
+| Requirement ID | Regulation Article | Business Rule ID | COBOL Source | Validation Status | Implementation Status | Test Coverage |
+|---|---|---|---|---|---|---|
+| REG-PSD2-001 | Art. 97(1)(a) — SCA for online account access | PAY-BR-042 | AUTHNT01.cbl:120-185 | validated | not-started | none |
+| REG-PSD2-002 | Art. 97(1)(b) — SCA for electronic payment initiation | PAY-BR-043 | PAYMNT01.cbl:450-520 | validated | not-started | none |
+| REG-PSD2-003 | Art. 97(1)(c) — SCA for remote actions with payment fraud risk | PAY-BR-044 | PAYMNT01.cbl:525-580 | not-validated | not-started | none |
+| REG-PSD2-004 | RTS Art. 4 — Authentication code requirements | PAY-BR-045 | AUTHNT01.cbl:200-260 | validated | not-started | none |
+| REG-PSD2-005 | RTS Art. 5 — Dynamic linking for payment amount and payee | PAY-BR-046 | PAYMNT01.cbl:600-670 | validated | not-started | none |
+| REG-PSD2-006 | RTS Art. 10 — Exemption: low-value transactions (< EUR 30) | PAY-BR-047 | PAYMNT02.cbl:100-145 | validated | not-started | none |
+| REG-PSD2-007 | RTS Art. 11 — Exemption: contactless at point of sale | PAY-BR-048 | PAYMNT02.cbl:150-190 | not-validated | not-started | none |
+| REG-PSD2-008 | RTS Art. 13 — Exemption: trusted beneficiaries | PAY-BR-049 | PAYMNT02.cbl:200-250 | validated | not-started | none |
+| REG-PSD2-009 | RTS Art. 16 — Exemption: transaction risk analysis (TRA) | PAY-BR-050 | RSKSCR01.cbl:80-200 | not-validated | not-started | none |
+| REG-PSD2-010 | Art. 74 — Liability for unauthorized transactions | PAY-BR-051 | LIABTY01.cbl:50-130 | not-validated | not-started | none |
+
+## Gaps
+
+| Gap ID | Description | Risk Level | Mitigation Plan | Owner | Due Date |
+|---|---|---|---|---|---|
+| GAP-PSD2-001 | COBOL system predates PSD2 — SCA logic was added as bolt-on patches across multiple programs. Full extraction of SCA flow requires cross-program analysis (AUTHNT01, PAYMNT01, PAYMNT02, RSKSCR01). | high | Map complete SCA call chain before implementation. Schedule dedicated sessions with retiring COBOL developers who built the SCA patches. | Migration Team Lead | 2026-04-01 |
+| GAP-PSD2-002 | Transaction Risk Analysis (TRA) exemption thresholds in RSKSCR01 may not reflect current EBA fraud rate reference values. Need to verify against latest EBA published rates. | medium | Cross-reference RSKSCR01 threshold values with EBA's latest fraud rate publication. Update thresholds in target system if discrepancies found. | Compliance Team | 2026-03-15 |
+| GAP-PSD2-003 | Dynamic linking implementation in PAYMNT01 uses legacy token format. Target system must use current best-practice (e.g., FIDO2/WebAuthn) while preserving the same business rule semantics. | medium | Design new authentication flow in .NET 8 that satisfies the same PSD2 dynamic linking requirements while using modern authentication protocols. | Security Architect | 2026-05-01 |
+
+## Compliance Notes
+
+- The existing COBOL implementation handles SCA through a combination of IMS transaction codes and CICS screens (AUTHNT01 for authentication, PAYMNT01/02 for payment validation). The migration must preserve the same authentication gates while modernizing the user-facing authentication mechanism.
+- Finansinspektionen has been notified of the migration project per FSA FFFS 2014:5 requirements for significant IT system changes. Ongoing dialogue with FSA contact ensures migration approach meets supervisory expectations.
+- SCA exemptions (low-value, trusted beneficiaries, TRA) must be individually validated against the current EBA RTS before implementation in the target system. The mainframe values may be outdated.
+- Parallel-run validation for SCA is complex — the mainframe and Azure system must apply identical exemption logic during the transition period to avoid inconsistent customer experiences.
+
+---
+
+**Applicable Regulations Reference:**
+
+| Regulation | Full Name | Relevance to NordKredit |
+|---|---|---|
+| FSA FFFS 2014:5 | Finansinspektionen's regulations regarding information security | IT governance, risk management for banking systems |
+| PSD2 | Payment Services Directive 2 (EU 2015/2366) | Payment processing, SCA, third-party access |
+| GDPR | General Data Protection Regulation (EU 2016/679) | Customer data protection, data residency, right to erasure |
+| AML/KYC | Anti-Money Laundering / Know Your Customer | Transaction monitoring, PEP screening, suspicious activity |
+| DORA | Digital Operational Resilience Act (EU 2022/2554) | ICT risk management, incident reporting, third-party oversight |
+| EBA Outsourcing | EBA Guidelines on Outsourcing Arrangements (EBA/GL/2019/02) | Cloud migration as material outsourcing, exit strategy |
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/templates/regulatory-traceability-template.md
+++ b/docs-site/docs/templates/regulatory-traceability-template.md
@@ -1,0 +1,81 @@
+---
+id: "REG-XXX-000"
+title: "[Regulation Name] Traceability Matrix"
+domain: "[payments | deposits | lending | account-management]"
+regulation: "[FSA FFFS 2014:5 | PSD2 | GDPR | AML/KYC | DORA | EBA Outsourcing]"
+last_reviewed: "YYYY-MM-DD"
+reviewed_by: "[Name and role]"
+status: "draft"
+---
+
+# Regulatory Traceability Matrix: [Regulation Name]
+
+## Regulation Overview
+
+_Provide a summary of the applicable regulation, its scope, and why it applies to NordKredit AB's core banking system. Include the regulation's official reference and any relevant articles or sections that impact the migration._
+
+**Regulation:** [Full regulation name and reference]
+**Issuing Authority:** [e.g., European Commission, Finansinspektionen]
+**Effective Date:** [Date the regulation came into effect]
+**Scope:** [How this regulation applies to NordKredit AB]
+
+## Traceability Table
+
+| Requirement ID | Regulation Article | Business Rule ID | COBOL Source | Validation Status | Implementation Status | Test Coverage |
+|---|---|---|---|---|---|---|
+| REG-XXX-001 | [Article/Section ref] | [e.g., PAY-BR-042] | [e.g., PAYMNT01.cbl:450-520] | [not-validated / validated / signed-off] | [not-started / in-progress / implemented / verified] | [none / unit / integration / bdd] |
+| REG-XXX-002 | [Article/Section ref] | [Business Rule ID] | [COBOL program:lines] | [Validation Status] | [Implementation Status] | [Test Coverage] |
+
+### Column Definitions
+
+- **Requirement ID**: Unique identifier linking to this regulation (format: `REG-[REGULATION]-[SEQ]`)
+- **Regulation Article**: Specific article, section, or paragraph of the regulation
+- **Business Rule ID**: Identifier from `docs/requirements/` linking to the extracted business rule
+- **COBOL Source**: Original COBOL program name and line range where the rule is implemented
+- **Validation Status**: Whether a domain expert has validated the extraction
+  - `not-validated` — extracted but not reviewed
+  - `validated` — reviewed by domain expert
+  - `signed-off` — formally approved by compliance
+- **Implementation Status**: Current state in the .NET 8 target system
+  - `not-started` — not yet implemented
+  - `in-progress` — implementation underway
+  - `implemented` — code complete
+  - `verified` — parallel-run output matches mainframe
+- **Test Coverage**: Level of automated test coverage in the target system
+  - `none` — no tests yet
+  - `unit` — xUnit unit tests
+  - `integration` — integration tests
+  - `bdd` — SpecFlow BDD tests covering the business rule
+
+## Gaps
+
+_List any identified regulatory gaps that need attention. A gap exists when a regulation requirement cannot be mapped to an existing COBOL implementation, or when the migration introduces a compliance risk._
+
+| Gap ID | Description | Risk Level | Mitigation Plan | Owner | Due Date |
+|---|---|---|---|---|---|
+| GAP-XXX-001 | [Description of the regulatory gap] | [critical / high / medium / low] | [Proposed mitigation] | [Responsible person/team] | [Target date] |
+
+## Compliance Notes
+
+_Document any compliance-related observations, decisions, or context relevant to this regulation's traceability. Include references to FSA communications, internal audit findings, or compliance team guidance._
+
+- [Note 1]
+- [Note 2]
+
+---
+
+**Applicable Regulations Reference:**
+
+| Regulation | Full Name | Relevance to NordKredit |
+|---|---|---|
+| FSA FFFS 2014:5 | Finansinspektionen's regulations regarding information security | IT governance, risk management for banking systems |
+| PSD2 | Payment Services Directive 2 (EU 2015/2366) | Payment processing, SCA, third-party access |
+| GDPR | General Data Protection Regulation (EU 2016/679) | Customer data protection, data residency, right to erasure |
+| AML/KYC | Anti-Money Laundering / Know Your Customer | Transaction monitoring, PEP screening, suspicious activity |
+| DORA | Digital Operational Resilience Act (EU 2022/2554) | ICT risk management, incident reporting, third-party oversight |
+| EBA Outsourcing | EBA Guidelines on Outsourcing Arrangements (EBA/GL/2019/02) | Cloud migration as material outsourcing, exit strategy |
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15


### PR DESCRIPTION
## Summary

- Add regulatory traceability matrix template with YAML front matter for compliance tracking
- Add filled-in PSD2 Strong Customer Authentication example demonstrating the template in use
- Reference all six applicable regulations (FSA FFFS 2014:5, PSD2, GDPR, AML/KYC, DORA, EBA Outsourcing)

## Changes

- `docs-site/docs/templates/regulatory-traceability-template.md` — Template with YAML front matter fields (id, title, domain, regulation, last_reviewed, reviewed_by, status) and body sections (Regulation Overview, Traceability Table with 7 columns, Gaps, Compliance Notes, Applicable Regulations Reference)
- `docs-site/docs/templates/regulatory-traceability-example.md` — PSD2 SCA example with 10 traceability entries mapping regulation articles to COBOL source programs, 3 identified gaps, and compliance notes

## Testing

- [x] YAML front matter validated (all required fields present, valid status values)
- [x] All six regulations referenced in both files
- [x] All required body sections present (Regulation Overview, Traceability Table, Gaps, Compliance Notes)
- [x] Traceability table has all required columns (Requirement ID, Regulation Article, Business Rule ID, COBOL Source, Validation Status, Implementation Status, Test Coverage)
- [x] Docusaurus-compatible Markdown structure

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)