### PR TITLE
docs(#6): Add copybook/data structure documentation template

### DIFF
--- a/docs-site/docs/templates/data-structure-example.md
+++ b/docs-site/docs/templates/data-structure-example.md
@@ -1,0 +1,162 @@
+---
+id: DS-CARD-001
+title: "Card Record"
+copybook_name: "CVACT02Y.cpy"
+domain: "account-management"
+used_by_programs:
+  - COCRDLIC
+  - COCRDSLC
+  - COCRDUPC
+  - CBTRN02C
+record_length: 150
+status: extracted
+target_schema: "dbo.Card"
+---
+
+# Card Record (CVACT02Y.cpy)
+
+## Overview
+
+The CVACT02Y copybook defines the `CARD-RECORD` structure, representing a credit card entity in the CardDemo system. It is stored in the `CARDDATA` VSAM file as fixed-block records of 150 bytes.
+
+This structure is the primary card master record and is accessed by both online CICS programs (card list, view, and update transactions) and batch programs (daily transaction validation). Each card is linked to exactly one account via `CARD-ACCT-ID`, forming a 1:1 relationship with the account record defined in `CVACT01Y.cpy`.
+
+**Source COBOL:**
+
+```cobol
+01 CARD-RECORD.
+   05 CARD-NUM             PIC X(16).
+   05 CARD-ACCT-ID         PIC 9(11).
+   05 CARD-CVV-CD          PIC 9(03).
+   05 CARD-EMBOSSED-NAME   PIC X(50).
+   05 CARD-EXPIRAION-DATE  PIC X(10).
+   05 CARD-ACTIVE-STATUS   PIC X(01).
+   05 FILLER               PIC X(59).
+```
+
+## Field Definitions
+
+| Field Name | PIC Clause | Length (bytes) | Type | Description | Nullable | Target Column |
+|------------|-----------|----------------|------|-------------|----------|---------------|
+| CARD-NUM | X(16) | 16 | Alphanumeric | Primary card number (PAN). Left-padded with zeros for numbers shorter than 16 digits. | No | `card_number` |
+| CARD-ACCT-ID | 9(11) | 11 | Numeric (unsigned) | Account identifier linking this card to its parent account in `CVACT01Y`. | No | `account_id` |
+| CARD-CVV-CD | 9(03) | 3 | Numeric (unsigned) | Card verification value (3-digit security code). | No | `cvv_code` |
+| CARD-EMBOSSED-NAME | X(50) | 50 | Alphanumeric | Cardholder name as embossed on the physical card. Right-padded with spaces. | No | `embossed_name` |
+| CARD-EXPIRAION-DATE | X(10) | 10 | Alphanumeric | Card expiration date stored as a string (format: `YYYY-MM-DD`). Note: field name contains original typo from source. | No | `expiration_date` |
+| CARD-ACTIVE-STATUS | X(01) | 1 | Alphanumeric | Card active/inactive indicator. `Y` = active, `N` = inactive. | No | `is_active` |
+| FILLER | X(59) | 59 | Filler | Unused padding to reach 150-byte record length. | N/A | N/A |
+
+### Field Notes
+
+- **CARD-NUM**: Stored as alphanumeric (`PIC X`) rather than numeric, allowing leading zeros and non-numeric characters. The PAN is sensitive PII under GDPR and PCI-DSS — the target column must use encryption at rest and column-level access controls.
+- **CARD-CVV-CD**: Stored as display numeric (`PIC 9`), not packed. PCI-DSS prohibits storing CVV after authorization — migration must evaluate whether this field should be carried over to the target system.
+- **CARD-EXPIRAION-DATE**: The field name contains a typo (`EXPIRAION` instead of `EXPIRATION`) present in the original COBOL source. The target column corrects this to `expiration_date`. Stored as `X(10)` string in `YYYY-MM-DD` format — target maps to SQL `date` type.
+- **CARD-ACTIVE-STATUS**: Simple flag field. Target maps `Y`/`N` to SQL `bit` type (`1`/`0`).
+
+## EBCDIC Encoding Notes
+
+| Consideration | Detail |
+|---------------|--------|
+| Source encoding | EBCDIC (IBM Code Page 037 — US/Canada Latin-1) |
+| Target encoding | UTF-8 |
+| Special characters | `CARD-EMBOSSED-NAME` may contain Swedish characters (å, ä, ö, Å, Ä, Ö) for Nordic cardholders. Verify code page mapping handles these correctly. |
+| Packed decimal fields | None — all numeric fields use display format (`PIC 9`), not `COMP-3`. |
+| Binary fields | None — no `COMP` or `COMP-4` fields in this copybook. |
+| Sign handling | No signed fields in this copybook. `CARD-ACCT-ID` and `CARD-CVV-CD` are unsigned display numeric. |
+
+### Encoding Validation
+
+- Extract a sample of `CARD-EMBOSSED-NAME` values containing Nordic characters and verify round-trip conversion: EBCDIC → UTF-8 → display.
+- Confirm that trailing spaces in `CARD-EMBOSSED-NAME` are preserved or trimmed consistently.
+
+## Referential Integrity
+
+| Relationship | Source Field | Target Table | Target Column | Constraint Type |
+|-------------|-------------|-------------|---------------|-----------------|
+| Card belongs to account | CARD-ACCT-ID | dbo.Account | account_id | FK (enforced) |
+| Card linked to customer (via cross-reference) | CARD-NUM | dbo.CustomerAccountCardXref | card_number | FK (enforced) |
+
+### Integrity Notes
+
+- In the mainframe system, the 1:1:1 relationship between Account, Card, and Customer is enforced by COBOL program logic in the CICS transactions, not by database constraints.
+- The cross-reference file (`CVACT03Y.cpy` / `CARDXREF`) links cards to accounts and customers. Orphan cards (cards without a matching cross-reference entry) should be flagged during migration validation.
+- The target Azure SQL schema should enforce the Account → Card FK constraint at the database level, replacing the programmatic enforcement.
+
+## Sample Data
+
+```
+Record 1:
+  CARD-NUM:             "4532015112830366"
+  CARD-ACCT-ID:         00000012345
+  CARD-CVV-CD:          789
+  CARD-EMBOSSED-NAME:   "ERIK JOHANSSON                                    "
+  CARD-EXPIRAION-DATE:  "2027-08-31"
+  CARD-ACTIVE-STATUS:   "Y"
+
+Record 2:
+  CARD-NUM:             "4716826378940052"
+  CARD-ACCT-ID:         00000067890
+  CARD-CVV-CD:          321
+  CARD-EMBOSSED-NAME:   "ANNA BJÖRK LINDSTRÖM                              "
+  CARD-EXPIRAION-DATE:  "2025-03-31"
+  CARD-ACTIVE-STATUS:   "N"
+```
+
+> **Note**: Sample data above is entirely synthetic. No real card numbers or PII are used. The card numbers shown are generated values that pass Luhn check formatting but do not correspond to real cards.
+
+### Data Characteristics
+
+- Estimated record count: ~50,000 active cards + historical
+- Growth rate: ~500 new cards/month
+- Key distribution: `CARD-NUM` is unique, sequentially issued by card processor. `CARD-ACCT-ID` distribution mirrors account creation patterns.
+
+## Migration Notes
+
+### Schema Mapping
+
+- **Source**: VSAM file `AWS.M2.CARDDEMO.CARDDATA.PS` (FB, LRECL=150)
+- **Target**: `dbo.Card`
+- **Migration approach**: Full extract followed by incremental sync during parallel-run period
+
+### Target Table DDL
+
+```sql
+CREATE TABLE dbo.Card (
+    card_number     NVARCHAR(16)    NOT NULL,
+    account_id      BIGINT          NOT NULL,
+    cvv_code        SMALLINT        NOT NULL,
+    embossed_name   NVARCHAR(50)    NOT NULL,
+    expiration_date DATE            NOT NULL,
+    is_active       BIT             NOT NULL,
+    CONSTRAINT PK_Card PRIMARY KEY (card_number),
+    CONSTRAINT FK_Card_Account FOREIGN KEY (account_id)
+        REFERENCES dbo.Account (account_id)
+);
+```
+
+### Data Quality
+
+- Verify no orphan `CARD-ACCT-ID` values (cards pointing to non-existent accounts).
+- Validate `CARD-EXPIRAION-DATE` is a parseable date and not a placeholder (e.g., `0000-00-00`).
+- Check for duplicate `CARD-NUM` values (should be unique but no mainframe constraint enforces this).
+- Confirm `CARD-ACTIVE-STATUS` contains only `Y` or `N` — flag any other values.
+
+### Validation Strategy
+
+- Record count reconciliation: VSAM file record count vs. `SELECT COUNT(*) FROM dbo.Card`.
+- Field-level spot checks: Sample 1,000 random records and compare all field values.
+- Referential integrity: `SELECT card_number FROM dbo.Card WHERE account_id NOT IN (SELECT account_id FROM dbo.Account)` should return zero rows.
+- Business rule validation: All cards with `expiration_date < GETDATE()` should have `is_active = 0` (or be flagged for review).
+
+### Performance Considerations
+
+- `card_number` is the primary lookup key — clustered index on PK is sufficient.
+- Add non-clustered index on `account_id` for join performance with Account table.
+- No partitioning needed at current volumes (~50K records).
+- During parallel-run, use change tracking on `is_active` and `expiration_date` for incremental sync.
+
+### PCI-DSS Considerations
+
+- `card_number` (PAN) must be encrypted at rest using Azure SQL Always Encrypted or Transparent Data Encryption (TDE).
+- `cvv_code` storage must be reviewed against PCI-DSS requirement 3.2 — CVV must not be stored after authorization. If this field is only used for card issuance records, document the justification.
+- Column-level access controls should restrict `card_number` and `cvv_code` to authorized roles only.

--- a/docs-site/docs/templates/data-structure-template.md
+++ b/docs-site/docs/templates/data-structure-template.md
@@ -1,0 +1,110 @@
+---
+id: DS-XXX-000
+title: "[Copybook Title]"
+copybook_name: "EXAMPLE.cpy"
+domain: "[payments | deposits | lending | account-management]"
+used_by_programs:
+  - PROGRAM1
+  - PROGRAM2
+record_length: 0
+status: "extracted"
+target_schema: "dbo.TargetTableName"
+---
+
+# [Copybook Title]
+
+## Overview
+
+_Brief description of this data structure's purpose, the business entity it represents, and its role in the mainframe system. Include which subsystem owns it (IMS, CICS, batch) and how it relates to other data structures._
+
+## Field Definitions
+
+| Field Name | PIC Clause | Length (bytes) | Type | Description | Nullable | Target Column |
+|------------|-----------|----------------|------|-------------|----------|---------------|
+| FIELD-NAME-1 | X(10) | 10 | Alphanumeric | _Description_ | No | `column_name` |
+| FIELD-NAME-2 | 9(05) | 5 | Numeric (unsigned) | _Description_ | No | `column_name` |
+| FIELD-NAME-3 | S9(07)V99 | 9 | Packed decimal (signed, 2 decimal places) | _Description_ | Yes | `column_name` |
+| FILLER | X(nn) | nn | Filler | Unused padding to reach record length | N/A | N/A |
+
+### Field Notes
+
+_Document any field-specific considerations here, such as:_
+
+- _Implicit decimal positions (e.g., PIC 9(5)V99 stores 7 digits but represents a value with 2 decimal places)_
+- _Redefines or overlapping fields_
+- _Computed or derived fields_
+- _Business rules encoded in field values (e.g., status codes, type indicators)_
+
+## EBCDIC Encoding Notes
+
+_Document character encoding considerations for the migration from EBCDIC to Unicode/UTF-8._
+
+| Consideration | Detail |
+|---------------|--------|
+| Source encoding | EBCDIC (IBM Code Page _nnn_) |
+| Target encoding | UTF-8 |
+| Special characters | _List any Swedish characters (å, ä, ö) or special symbols that require attention_ |
+| Packed decimal fields | _List fields using COMP-3 that need binary-to-decimal conversion_ |
+| Binary fields | _List any COMP/COMP-4 fields requiring endian conversion_ |
+| Sign handling | _Describe sign representation (trailing overpunch, separate sign byte, etc.)_ |
+
+## Referential Integrity
+
+_Document relationships to other data structures and the expected integrity constraints in the target Azure SQL schema._
+
+| Relationship | Source Field | Target Table | Target Column | Constraint Type |
+|-------------|-------------|-------------|---------------|-----------------|
+| _Description_ | FIELD-NAME | dbo.OtherTable | other_column | FK / Lookup / Soft reference |
+
+### Integrity Notes
+
+_Document any referential integrity considerations:_
+
+- _Relationships that are enforced by COBOL program logic rather than database constraints_
+- _Cross-file validations performed in batch jobs_
+- _Orphan record handling strategy_
+
+## Sample Data
+
+_Provide representative (non-PII) sample records showing typical field values. Use synthetic data only._
+
+```
+Record 1:
+  FIELD-NAME-1: "VALUE1    "
+  FIELD-NAME-2: 00123
+  FIELD-NAME-3: +0001234.56
+```
+
+### Data Characteristics
+
+- _Estimated record count: nnn_
+- _Growth rate: nnn records/month_
+- _Key distribution notes (e.g., sequential, sparse, partitioned by date)_
+
+## Migration Notes
+
+_Document migration-specific considerations for moving this data structure to Azure SQL._
+
+### Schema Mapping
+
+- **Source**: _VSAM file / Db2 table name_
+- **Target**: `dbo.TargetTableName`
+- **Migration approach**: _Full extract / incremental sync / CDC_
+
+### Data Quality
+
+- _Known data quality issues (e.g., orphan references, invalid dates, truncated fields)_
+- _Cleanup rules to apply during migration_
+
+### Validation Strategy
+
+- _Record count reconciliation_
+- _Checksum or hash comparison_
+- _Business rule validation queries_
+- _Parallel-run comparison approach_
+
+### Performance Considerations
+
+- _Batch window impact during extraction_
+- _Index strategy for target table_
+- _Partitioning recommendations_


### PR DESCRIPTION
## Summary
- Add reusable data structure documentation template for COBOL copybook migration
- Include filled-in example based on CardDemo CVACT02Y.cpy (CARD-RECORD)
- YAML front matter with all required fields; body sections covering field definitions, EBCDIC encoding, referential integrity, sample data, and migration notes

## Changes
- `docs-site/docs/templates/data-structure-template.md` — Generic template with YAML front matter and placeholder sections
- `docs-site/docs/templates/data-structure-example.md` — Complete example documenting CVACT02Y.cpy (150-byte card master record) with PCI-DSS considerations

## Testing
- [x] YAML front matter validates correctly (all 8 required fields present)
- [x] All 6 required body sections present in both files
- [x] Field definitions table contains all 7 required columns
- [x] Example uses accurate CVACT02Y.cpy structure from CardDemo source

Closes #6

🤖 Generated with Claude Code