### PR TITLE
docs(#9): Add GitHub Actions CI/CD for Docusaurus build and deploy

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -1,0 +1,71 @@
+name: Docusaurus Build & Deploy
+
+on:
+  pull_request:
+    paths:
+      - 'docs-site/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs-site/**'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs-site
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docusaurus-build
+          path: docs-site/build
+          retention-days: 14
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docusaurus-build
+          path: build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload to GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated Docusaurus build validation on PRs and deployment to GitHub Pages on merge to main
- Workflow uses path filters to only run when `docs-site/` changes
- Build artifacts uploaded with 14-day retention per Known Gotchas in context.md

## Changes
- `.github/workflows/docs-site.yml` — New workflow with `build` and `deploy` jobs

## Testing
- [x] YAML syntax validated locally
- [x] All acceptance criteria verified programmatically (path filters, Node.js 20, npm ci/build, artifact retention, deploy-pages)
- [x] Workflow only triggers on `docs-site/**` changes (no CI run expected on this PR since docs-site/ doesn't exist yet)

## Notes
- This workflow depends on #4 (Docusaurus initialization) — it will begin triggering once the docs-site/ directory is added
- The workflow won't run on this PR since no `docs-site/**` files are modified

Closes #9

🤖 Generated with Claude Code