### PR TITLE
docs(#13): Extract User/Security domain business rules from COBOL

### DIFF
--- a/docs-site/docs/business-rules/user-security/USEC-BR-001.md
+++ b/docs-site/docs/business-rules/user-security/USEC-BR-001.md
@@ -1,0 +1,301 @@
+---
+id: "USEC-BR-001"
+title: "User authentication via credential validation against USRSEC file"
+domain: "user-security"
+cobol_source: "COSGN00C.cbl:108-257"
+requirement_id: "USEC-BR-001"
+regulations:
+  - "PSD2 Art. 97 — Strong Customer Authentication (SCA)"
+  - "FFFS 2014:5 Ch. 6 — IT security and access control"
+  - "DORA Art. 9 — ICT access control policies"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# USEC-BR-001: User authentication via credential validation against USRSEC file
+
+## Summary
+
+The CICS sign-on program (COSGN00C) authenticates users by validating a User ID and Password against the USRSEC VSAM file. Both fields are required and converted to uppercase before lookup. The system performs a keyed read on the USRSEC file using the User ID, then compares the stored password with the entered password. Authentication is a single-factor mechanism (knowledge-based only — no second factor). On success, the user is routed to either the Admin menu (COADM01C) or the regular user menu (COMEN01C) based on their user type.
+
+## Business Logic
+
+### Pseudocode
+
+```
+RECEIVE screen input from CICS MAP COSGN0A
+
+// Phase 1: Required field validation
+IF User-ID is empty (spaces or low-values):
+    ERROR 'Please enter User ID ...'
+    Position cursor on User ID field
+    Re-display sign-on screen
+
+IF Password is empty (spaces or low-values):
+    ERROR 'Please enter Password ...'
+    Position cursor on Password field
+    Re-display sign-on screen
+
+// Phase 2: Case normalization
+CONVERT User-ID to UPPER-CASE
+CONVERT Password to UPPER-CASE
+STORE User-ID in COMMAREA (CDEMO-USER-ID)
+
+// Phase 3: Credential verification
+READ USRSEC file using User-ID as key
+
+EVALUATE read response:
+  WHEN record found (RESP = 0):
+    IF stored-password = entered-password:
+        SET COMMAREA fields (from-tranid, from-program, user-id, user-type)
+        RESET program context to 0
+        IF user-type = 'A' (Admin):
+            XCTL to COADM01C (Admin Menu)
+        ELSE:
+            XCTL to COMEN01C (Regular Menu)
+    ELSE:
+        ERROR 'Wrong Password. Try again ...'
+        Position cursor on Password field
+
+  WHEN record not found (RESP = 13):
+    ERROR 'User not found. Try again ...'
+    Position cursor on User ID field
+
+  WHEN other error:
+    ERROR 'Unable to verify the User ...'
+    Position cursor on User ID field
+```
+
+### Decision Table
+
+| User ID Provided | Password Provided | User ID Found | Password Matches | Outcome |
+|-------------------|-------------------|---------------|------------------|---------|
+| No | - | - | - | Error: "Please enter User ID ..." |
+| Yes | No | - | - | Error: "Please enter Password ..." |
+| Yes | Yes | No | - | Error: "User not found. Try again ..." |
+| Yes | Yes | Yes | No | Error: "Wrong Password. Try again ..." |
+| Yes | Yes | Yes | Yes (type=A) | Route to Admin Menu (COADM01C) |
+| Yes | Yes | Yes | Yes (type=U) | Route to Regular Menu (COMEN01C) |
+
+## Source COBOL Reference
+
+**Program:** `COSGN00C.cbl`
+**Lines:** 108-257
+
+```cobol
+       PROCESS-ENTER-KEY.
+
+           EXEC CICS RECEIVE
+                     MAP('COSGN0A')
+                     MAPSET('COSGN00')
+                     RESP(WS-RESP-CD)
+                     RESP2(WS-REAS-CD)
+           END-EXEC.
+
+           EVALUATE TRUE
+               WHEN USERIDI OF COSGN0AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'      TO WS-ERR-FLG
+                   MOVE 'Please enter User ID ...' TO WS-MESSAGE
+                   MOVE -1       TO USERIDL OF COSGN0AI
+                   PERFORM SEND-SIGNON-SCREEN
+               WHEN PASSWDI OF COSGN0AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'      TO WS-ERR-FLG
+                   MOVE 'Please enter Password ...' TO WS-MESSAGE
+                   MOVE -1       TO PASSWDL OF COSGN0AI
+                   PERFORM SEND-SIGNON-SCREEN
+               WHEN OTHER
+                   CONTINUE
+           END-EVALUATE.
+
+           MOVE FUNCTION UPPER-CASE(USERIDI OF COSGN0AI) TO
+                           WS-USER-ID
+                           CDEMO-USER-ID
+           MOVE FUNCTION UPPER-CASE(PASSWDI OF COSGN0AI) TO
+                           WS-USER-PWD
+
+           IF NOT ERR-FLG-ON
+               PERFORM READ-USER-SEC-FILE
+           END-IF.
+
+       READ-USER-SEC-FILE.
+
+           EXEC CICS READ
+                DATASET   (WS-USRSEC-FILE)
+                INTO      (SEC-USER-DATA)
+                LENGTH    (LENGTH OF SEC-USER-DATA)
+                RIDFLD    (WS-USER-ID)
+                KEYLENGTH (LENGTH OF WS-USER-ID)
+                RESP      (WS-RESP-CD)
+                RESP2     (WS-REAS-CD)
+           END-EXEC.
+
+           EVALUATE WS-RESP-CD
+               WHEN 0
+                   IF SEC-USR-PWD = WS-USER-PWD
+                       MOVE WS-TRANID    TO CDEMO-FROM-TRANID
+                       MOVE WS-PGMNAME   TO CDEMO-FROM-PROGRAM
+                       MOVE WS-USER-ID   TO CDEMO-USER-ID
+                       MOVE SEC-USR-TYPE TO CDEMO-USER-TYPE
+                       MOVE ZEROS        TO CDEMO-PGM-CONTEXT
+
+                       IF CDEMO-USRTYP-ADMIN
+                            EXEC CICS XCTL
+                              PROGRAM ('COADM01C')
+                              COMMAREA(CARDDEMO-COMMAREA)
+                            END-EXEC
+                       ELSE
+                            EXEC CICS XCTL
+                              PROGRAM ('COMEN01C')
+                              COMMAREA(CARDDEMO-COMMAREA)
+                            END-EXEC
+                       END-IF
+                   ELSE
+                       MOVE 'Wrong Password. Try again ...' TO
+                                                          WS-MESSAGE
+                       MOVE -1       TO PASSWDL OF COSGN0AI
+                       PERFORM SEND-SIGNON-SCREEN
+                   END-IF
+               WHEN 13
+                   MOVE 'Y'      TO WS-ERR-FLG
+                   MOVE 'User not found. Try again ...' TO WS-MESSAGE
+                   MOVE -1       TO USERIDL OF COSGN0AI
+                   PERFORM SEND-SIGNON-SCREEN
+               WHEN OTHER
+                   MOVE 'Y'      TO WS-ERR-FLG
+                   MOVE 'Unable to verify the User ...' TO WS-MESSAGE
+                   MOVE -1       TO USERIDL OF COSGN0AI
+                   PERFORM SEND-SIGNON-SCREEN
+           END-EVALUATE.
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Successful authentication as admin user
+
+```gherkin
+GIVEN a user is on the CardDemo sign-on screen (COSGN0A)
+  AND user "ADMIN01" exists in the USRSEC file with password "PASS1234" and type "A"
+WHEN the user enters User ID "admin01" and Password "pass1234"
+  AND presses Enter
+THEN the system converts both fields to uppercase
+  AND reads the USRSEC file for User ID "ADMIN01"
+  AND the password matches
+  AND the user is transferred to the Admin Menu (COADM01C)
+  AND the COMMAREA contains user-type "A"
+```
+
+### Scenario 2: Successful authentication as regular user
+
+```gherkin
+GIVEN a user is on the CardDemo sign-on screen (COSGN0A)
+  AND user "USER0001" exists in the USRSEC file with password "TESTPASS" and type "U"
+WHEN the user enters User ID "user0001" and Password "testpass"
+  AND presses Enter
+THEN the system converts both fields to uppercase
+  AND reads the USRSEC file for User ID "USER0001"
+  AND the password matches
+  AND the user is transferred to the Regular Menu (COMEN01C)
+  AND the COMMAREA contains user-type "U"
+```
+
+### Scenario 3: Empty User ID
+
+```gherkin
+GIVEN a user is on the CardDemo sign-on screen (COSGN0A)
+  AND the User ID field is empty
+WHEN the user presses Enter
+THEN the system displays "Please enter User ID ..."
+  AND the cursor is positioned on the User ID field
+  AND no file read is performed
+```
+
+### Scenario 4: Empty Password
+
+```gherkin
+GIVEN a user is on the CardDemo sign-on screen (COSGN0A)
+  AND the User ID field contains a value
+  AND the Password field is empty
+WHEN the user presses Enter
+THEN the system displays "Please enter Password ..."
+  AND the cursor is positioned on the Password field
+  AND no file read is performed
+```
+
+### Scenario 5: User ID not found
+
+```gherkin
+GIVEN a user is on the CardDemo sign-on screen (COSGN0A)
+WHEN the user enters a User ID that does not exist in the USRSEC file
+  AND presses Enter
+THEN the system displays "User not found. Try again ..."
+  AND the cursor is positioned on the User ID field
+```
+
+### Scenario 6: Wrong password
+
+```gherkin
+GIVEN a user is on the CardDemo sign-on screen (COSGN0A)
+  AND user "USER0001" exists in the USRSEC file with password "CORRECT1"
+WHEN the user enters User ID "USER0001" and Password "WRONG123"
+  AND presses Enter
+THEN the system displays "Wrong Password. Try again ..."
+  AND the cursor is positioned on the Password field
+```
+
+### Scenario 7: PF3 pressed to exit
+
+```gherkin
+GIVEN a user is on the CardDemo sign-on screen (COSGN0A)
+WHEN the user presses PF3
+THEN the system displays the "Thank you" message
+  AND the CICS transaction ends (RETURN without TRANSID)
+```
+
+### Scenario 8: Invalid key pressed
+
+```gherkin
+GIVEN a user is on the CardDemo sign-on screen (COSGN0A)
+WHEN the user presses any key other than Enter or PF3
+THEN the system displays the invalid key message
+  AND the sign-on screen is re-displayed
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 97 — SCA | Payment service providers shall apply strong customer authentication where the payer accesses its payment account online | The sign-on screen provides the first authentication factor (knowledge: user ID + password). **Gap**: PSD2 SCA requires at least two independent factors — a second factor (possession or inherence) must be added in the migrated system |
+| FFFS 2014:5 | Ch. 6 — IT security | Credit institutions must have adequate access control mechanisms | Authentication gate ensures only registered users with valid credentials can access the system |
+| DORA | Art. 9 — Protection and prevention | Financial entities shall have ICT access control policies with authentication mechanisms | The USRSEC file-based authentication implements credential-based access control |
+| GDPR | Art. 32 — Security of processing | Appropriate technical measures to ensure data security | User authentication prevents unauthorized access to personal financial data |
+
+## Edge Cases
+
+1. **Case-insensitive credentials**: Both User ID and Password are converted to uppercase via `FUNCTION UPPER-CASE` before validation. This means passwords are effectively case-insensitive — "Pass1234" and "PASS1234" are treated identically. The migrated system should enforce case-sensitive passwords per modern security standards.
+
+2. **Plaintext password comparison**: Passwords are stored and compared in plaintext in the USRSEC file (PIC X(08)). The migrated system must hash passwords (e.g., bcrypt, Argon2) and never store plaintext credentials.
+
+3. **No account lockout**: There is no failed login attempt counter or account lockout mechanism. A user can attempt unlimited password guesses. The migrated system must implement account lockout or rate limiting per PSD2 SCA requirements.
+
+4. **No session timeout**: The CICS pseudo-conversational pattern returns control with a TRANSID, which will accept the next input indefinitely. The migrated system should implement session timeouts per DORA Art. 9.
+
+5. **EIBCALEN = 0 (first entry)**: If the program is invoked without a COMMAREA (first CICS transaction start), it displays the sign-on screen. This is the normal entry point for new sessions.
+
+6. **8-character credential limits**: User ID is limited to PIC X(08) and Password to PIC X(08). The migrated system should allow longer credentials per modern security standards.
+
+7. **No password complexity rules**: The COBOL code does not validate password complexity (length, special characters, etc.). The migrated system should enforce password complexity policies.
+
+## Domain Expert Notes
+
+- **Pending**: No domain expert review yet. Key questions for validation:
+  - Is the case-insensitive password behavior intentional or a limitation of the mainframe environment?
+  - Are there any external authentication systems (RACF, ACF2, Top Secret) that supplement USRSEC file authentication?
+  - What is the current password rotation policy enforced operationally (outside the code)?
+  - Should the migrated system support multi-factor authentication from day one, or can it be phased?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/user-security/USEC-BR-002.md
+++ b/docs-site/docs/business-rules/user-security/USEC-BR-002.md
@@ -1,0 +1,172 @@
+---
+id: "USEC-BR-002"
+title: "User type-based authorization routing after authentication"
+domain: "user-security"
+cobol_source: "COSGN00C.cbl:230-240"
+requirement_id: "USEC-BR-002"
+regulations:
+  - "PSD2 Art. 97 — Strong Customer Authentication (SCA)"
+  - "FFFS 2014:5 Ch. 6 — Role-based access control"
+  - "DORA Art. 9 — ICT access control policies"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# USEC-BR-002: User type-based authorization routing after authentication
+
+## Summary
+
+After successful authentication, the sign-on program (COSGN00C) routes the user to one of two menu systems based on the `SEC-USR-TYPE` field from the USRSEC file. Admin users (type `'A'`) are transferred to the Admin Menu (COADM01C), which provides access to user management functions. All other users (type `'U'` or any non-'A' value) are transferred to the Regular User Menu (COMEN01C), which provides access to account, credit card, and transaction functions. The user type is stored in the COMMAREA (`CDEMO-USER-TYPE`) and carried through the entire session.
+
+## Business Logic
+
+### Pseudocode
+
+```
+// After successful password match:
+SET CDEMO-USER-TYPE = SEC-USR-TYPE (from USRSEC record)
+
+IF CDEMO-USER-TYPE = 'A':      // Admin
+    XCTL to COADM01C (Admin Menu) with COMMAREA
+ELSE:                           // Regular user (type 'U' or any other)
+    XCTL to COMEN01C (Regular User Menu) with COMMAREA
+```
+
+### Decision Table
+
+| User Type (SEC-USR-TYPE) | 88-Level Condition | Target Program | Menu System |
+|--------------------------|-------------------|----------------|-------------|
+| 'A' | CDEMO-USRTYP-ADMIN | COADM01C | Admin Menu — User CRUD, Transaction Types |
+| 'U' | CDEMO-USRTYP-USER | COMEN01C | Regular Menu — Account/Card/Transaction operations |
+| Any other value | (falls through to ELSE) | COMEN01C | Regular Menu (treated as non-admin) |
+
+### Admin Menu Options (from COADM02Y copybook)
+
+| # | Option | Program |
+|---|--------|---------|
+| 1 | User List (Security) | COUSR00C |
+| 2 | User Add (Security) | COUSR01C |
+| 3 | User Update (Security) | COUSR02C |
+| 4 | User Delete (Security) | COUSR03C |
+| 5 | Transaction Type List/Update (Db2) | COTRTLIC |
+| 6 | Transaction Type Maintenance (Db2) | COTRTUPC |
+
+### Regular User Menu Options (from COMEN02Y copybook)
+
+| # | Option | Program | User Type |
+|---|--------|---------|-----------|
+| 1 | Account View | COACTVWC | U |
+| 2 | Account Update | COACTUPC | U |
+| 3-5 | Credit Card List/View/Update | COCRDLIC/COCRDSLC/COCRDUPC | U |
+| 6-8 | Transaction List/View/Add | COTRN00C/COTRN01C/COTRN02C | U |
+| 9 | Transaction Reports | CORPT00C | U |
+| 10 | Bill Payment | COBIL00C | U |
+| 11 | Pending Authorization View | COPAUS0C | U |
+
+## Source COBOL Reference
+
+**Program:** `COSGN00C.cbl`
+**Lines:** 230-240
+
+```cobol
+                       MOVE SEC-USR-TYPE TO CDEMO-USER-TYPE
+                       MOVE ZEROS        TO CDEMO-PGM-CONTEXT
+
+                       IF CDEMO-USRTYP-ADMIN
+                            EXEC CICS XCTL
+                              PROGRAM ('COADM01C')
+                              COMMAREA(CARDDEMO-COMMAREA)
+                            END-EXEC
+                       ELSE
+                            EXEC CICS XCTL
+                              PROGRAM ('COMEN01C')
+                              COMMAREA(CARDDEMO-COMMAREA)
+                            END-EXEC
+                       END-IF
+```
+
+**Copybook:** `COCOM01Y.cpy` (COMMAREA definition)
+
+```cobol
+       01 CARDDEMO-COMMAREA.
+          05 CDEMO-GENERAL-INFO.
+             10 CDEMO-USER-TYPE               PIC X(01).
+                88 CDEMO-USRTYP-ADMIN         VALUE 'A'.
+                88 CDEMO-USRTYP-USER          VALUE 'U'.
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Admin user routed to admin menu
+
+```gherkin
+GIVEN a user has provided valid credentials
+  AND the USRSEC record has SEC-USR-TYPE = 'A'
+WHEN authentication succeeds
+THEN the system sets CDEMO-USER-TYPE to 'A' in the COMMAREA
+  AND transfers control to COADM01C (Admin Menu)
+  AND the Admin Menu displays 6 options including User CRUD operations
+```
+
+### Scenario 2: Regular user routed to user menu
+
+```gherkin
+GIVEN a user has provided valid credentials
+  AND the USRSEC record has SEC-USR-TYPE = 'U'
+WHEN authentication succeeds
+THEN the system sets CDEMO-USER-TYPE to 'U' in the COMMAREA
+  AND transfers control to COMEN01C (Regular User Menu)
+  AND the Regular Menu displays 11 options for account/card/transaction operations
+```
+
+### Scenario 3: Unknown user type defaults to regular menu
+
+```gherkin
+GIVEN a user has provided valid credentials
+  AND the USRSEC record has SEC-USR-TYPE = 'X' (or any non-'A' value)
+WHEN authentication succeeds
+THEN the system sets CDEMO-USER-TYPE to 'X' in the COMMAREA
+  AND transfers control to COMEN01C (Regular User Menu)
+  AND the user is treated as a non-admin user
+```
+
+### Scenario 4: User type persists in session
+
+```gherkin
+GIVEN an authenticated admin user (type 'A') navigating within the Admin Menu
+WHEN the user selects any admin option
+THEN the COMMAREA carries CDEMO-USER-TYPE = 'A' to the target program
+  AND the user type remains consistent throughout the session
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 97 | Access to payment accounts must be controlled | User type segregation ensures admin functions (user management) are separated from operational functions (payments, accounts) |
+| FFFS 2014:5 | Ch. 6 | Role-based access control for IT systems | Two-tier role system (Admin/User) restricts administrative operations to authorized personnel |
+| DORA | Art. 9 | Least privilege access and segregation of duties | Admin users have access to user management; regular users are restricted to their operational scope |
+
+## Edge Cases
+
+1. **Only two roles**: The system supports only two roles — Admin ('A') and User ('U'). There is no granular RBAC (e.g., read-only admin, supervisor). The migrated system should consider more granular role definitions per DORA Art. 9 requirements.
+
+2. **No cross-menu access**: Admin users cannot access the regular user menu functions directly from the admin menu (and vice versa). However, the admin menu includes transaction type management functions. The migrated system should evaluate whether admins need access to all user-level functions as well.
+
+3. **User type stored in single character**: The `SEC-USR-TYPE` field is PIC X(01), limiting role representation to a single character. The migrated system can use a more expressive role/permission model.
+
+4. **No runtime authorization checks**: Once routed to a menu, individual programs do not re-verify the user's role. Any program invoked via XCTL with a valid COMMAREA will execute. The migrated system should implement per-endpoint authorization checks.
+
+## Domain Expert Notes
+
+- **Pending**: No domain expert review yet. Key questions for validation:
+  - Can an admin user also perform regular user operations (e.g., view accounts)?
+  - Are there any operational procedures for managing the admin role assignment?
+  - Should the migrated system implement more granular roles (e.g., Security Admin, Operations Admin)?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/user-security/USEC-BR-003.md
+++ b/docs-site/docs/business-rules/user-security/USEC-BR-003.md
@@ -1,0 +1,174 @@
+---
+id: "USEC-BR-003"
+title: "Session validation via COMMAREA presence check"
+domain: "user-security"
+cobol_source: "COSGN00C.cbl:80-96"
+requirement_id: "USEC-BR-003"
+regulations:
+  - "PSD2 Art. 97 — Strong Customer Authentication (SCA)"
+  - "DORA Art. 9 — ICT access control and session management"
+  - "FFFS 2014:5 Ch. 6 — IT security"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# USEC-BR-003: Session validation via COMMAREA presence check
+
+## Summary
+
+Every CICS program in the CardDemo application checks `EIBCALEN` (the length of the COMMAREA passed to it) as the first step of execution. If `EIBCALEN = 0`, it means the program was invoked without an established session context (no COMMAREA). In this case, the program redirects to the sign-on screen (COSGN00C), preventing unauthorized access to any function. This COMMAREA-based session check is the primary mechanism for ensuring that all program access goes through the authentication gate. The sign-on program itself uses `EIBCALEN = 0` to distinguish first-time display from returning user input.
+
+## Business Logic
+
+### Pseudocode
+
+```
+// In COSGN00C (Sign-on):
+IF EIBCALEN = 0:
+    // First entry — display sign-on screen
+    INITIALIZE screen to LOW-VALUES
+    Position cursor on User ID field
+    SEND sign-on screen
+ELSE:
+    // Returning with COMMAREA — process user input
+    EVALUATE key pressed...
+
+// In all other programs (COADM01C, COUSR00C, COUSR01C, COUSR02C, COUSR03C):
+IF EIBCALEN = 0:
+    // No COMMAREA = no authenticated session
+    SET target-program to 'COSGN00C'
+    XCTL to sign-on screen (RETURN-TO-PREV-SCREEN / RETURN-TO-SIGNON-SCREEN)
+ELSE:
+    // Valid session — copy COMMAREA and proceed
+    MOVE DFHCOMMAREA(1:EIBCALEN) TO CARDDEMO-COMMAREA
+    // Continue with normal processing...
+```
+
+### Decision Table
+
+| Program | EIBCALEN = 0 | EIBCALEN > 0 |
+|---------|-------------|-------------|
+| COSGN00C | Display sign-on screen (first entry) | Process user input (returning) |
+| COADM01C | Redirect to COSGN00C | Load COMMAREA, display admin menu |
+| COUSR00C | Redirect to COSGN00C | Load COMMAREA, display user list |
+| COUSR01C | Redirect to COSGN00C | Load COMMAREA, display user add form |
+| COUSR02C | Redirect to COSGN00C | Load COMMAREA, display user update form |
+| COUSR03C | Redirect to COSGN00C | Load COMMAREA, display user delete form |
+
+## Source COBOL Reference
+
+**Program:** `COSGN00C.cbl`
+**Lines:** 80-96
+
+```cobol
+           IF EIBCALEN = 0
+               MOVE LOW-VALUES TO COSGN0AO
+               MOVE -1       TO USERIDL OF COSGN0AI
+               PERFORM SEND-SIGNON-SCREEN
+           ELSE
+               EVALUATE EIBAID
+                   WHEN DFHENTER
+                       PERFORM PROCESS-ENTER-KEY
+                   WHEN DFHPF3
+                       MOVE CCDA-MSG-THANK-YOU        TO WS-MESSAGE
+                       PERFORM SEND-PLAIN-TEXT
+                   WHEN OTHER
+                       MOVE 'Y'                       TO WS-ERR-FLG
+                       MOVE CCDA-MSG-INVALID-KEY      TO WS-MESSAGE
+                       PERFORM SEND-SIGNON-SCREEN
+               END-EVALUATE
+           END-IF.
+```
+
+**Program:** `COADM01C.cbl`
+**Lines:** 86-89
+
+```cobol
+           IF EIBCALEN = 0
+               MOVE 'COSGN00C' TO CDEMO-FROM-PROGRAM
+               PERFORM RETURN-TO-SIGNON-SCREEN
+           ELSE
+```
+
+**Program:** `COUSR00C.cbl`
+**Lines:** 110-112
+
+```cobol
+           IF EIBCALEN = 0
+               MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+               PERFORM RETURN-TO-PREV-SCREEN
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Direct access to admin menu without session
+
+```gherkin
+GIVEN a user attempts to directly invoke the COADM01C program
+  AND no COMMAREA is passed (EIBCALEN = 0)
+WHEN the program starts
+THEN the system redirects to the sign-on screen (COSGN00C)
+  AND the user must authenticate before proceeding
+```
+
+### Scenario 2: Direct access to user management without session
+
+```gherkin
+GIVEN a user attempts to directly invoke COUSR01C (User Add)
+  AND no COMMAREA is passed (EIBCALEN = 0)
+WHEN the program starts
+THEN the system redirects to the sign-on screen (COSGN00C)
+  AND the user must authenticate before proceeding
+```
+
+### Scenario 3: Valid session with COMMAREA
+
+```gherkin
+GIVEN an authenticated user navigates from the Admin Menu to User List
+  AND the COMMAREA is passed with EIBCALEN > 0
+WHEN COUSR00C starts
+THEN the system copies the COMMAREA to local storage
+  AND proceeds with normal user list display
+  AND the user's authentication context is preserved
+```
+
+### Scenario 4: First-time sign-on screen display
+
+```gherkin
+GIVEN the CICS transaction CC00 is started for the first time
+  AND EIBCALEN = 0 (no prior COMMAREA)
+WHEN COSGN00C starts
+THEN the system displays an empty sign-on screen
+  AND the cursor is positioned on the User ID field
+  AND no authentication check is performed (this IS the authentication entry point)
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 97 | Strong customer authentication for account access | COMMAREA check ensures every program execution is preceded by authentication through the sign-on flow |
+| DORA | Art. 9 | Protection and prevention — session management | COMMAREA presence serves as a session token; absence forces re-authentication |
+| FFFS 2014:5 | Ch. 6 | IT security measures for access control | Defense-in-depth: each program independently verifies session validity |
+
+## Edge Cases
+
+1. **COMMAREA presence is not identity verification**: The EIBCALEN check only verifies that *some* COMMAREA was passed, not that it contains a valid authenticated session. A crafted COMMAREA could bypass this check. In the CICS environment, this is mitigated by the fact that COMMAREA is only passed between programs via XCTL/RETURN. The migrated system must use proper session tokens (e.g., JWT) with cryptographic validation.
+
+2. **No session expiry**: Once a COMMAREA is established, there is no timeout mechanism in the code. The CICS pseudo-conversational pattern does return control, but the TRANSID will accept input indefinitely. The migrated system must implement session timeouts.
+
+3. **COMMAREA content not validated**: Programs copy the COMMAREA into local storage but do not validate that `CDEMO-USER-TYPE` or `CDEMO-USER-ID` are still valid (e.g., user hasn't been deleted mid-session). The migrated system should validate session integrity on each request.
+
+## Domain Expert Notes
+
+- **Pending**: No domain expert review yet. Key questions for validation:
+  - Is there any CICS-level timeout configured for the CC00 transaction?
+  - Does the CICS region have any external security manager (RACF) that supplements the COMMAREA check?
+  - How long can a session remain idle before the terminal is disconnected?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/user-security/USEC-BR-004.md
+++ b/docs-site/docs/business-rules/user-security/USEC-BR-004.md
@@ -1,0 +1,221 @@
+---
+id: "USEC-BR-004"
+title: "Admin menu access control and option routing"
+domain: "user-security"
+cobol_source: "COADM01C.cbl:119-158"
+requirement_id: "USEC-BR-004"
+regulations:
+  - "FFFS 2014:5 Ch. 6 — Role-based access control"
+  - "DORA Art. 9 — Segregation of duties and least privilege"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# USEC-BR-004: Admin menu access control and option routing
+
+## Summary
+
+The Admin Menu program (COADM01C) displays a numbered list of administrative options (defined in the COADM02Y copybook) and routes the user to the selected program via CICS XCTL. The menu validates that the entered option is numeric, non-zero, and within the valid range (1 to CDEMO-ADMIN-OPT-COUNT, currently 6). It also handles the case where a selected program is not installed (PGMIDERR condition). The admin menu is only reachable by users authenticated with type 'A' through the sign-on routing in COSGN00C.
+
+## Business Logic
+
+### Pseudocode
+
+```
+// Screen handling
+IF first entry (CDEMO-PGM-REENTER is false):
+    SET CDEMO-PGM-REENTER = true
+    INITIALIZE screen
+    BUILD menu options from COADM02Y copybook
+    SEND admin menu screen
+ELSE:
+    RECEIVE screen input
+    EVALUATE key pressed:
+        WHEN Enter:
+            PERFORM PROCESS-ENTER-KEY
+        WHEN PF3:
+            XCTL to COSGN00C (return to sign-on)
+        WHEN Other:
+            ERROR 'Invalid key pressed'
+            Re-display menu
+
+// PROCESS-ENTER-KEY:
+TRIM and pad option input to 2 digits
+REPLACE spaces with '0'
+
+IF option is NOT numeric
+   OR option > CDEMO-ADMIN-OPT-COUNT (6)
+   OR option = 0:
+    ERROR 'Please enter a valid option number...'
+    Re-display menu
+
+IF program name for option starts with 'DUMMY':
+    Display 'This option is not installed ...'
+ELSE:
+    SET COMMAREA fields (from-tranid, from-program, context=0)
+    XCTL to CDEMO-ADMIN-OPT-PGMNAME(selected-option) with COMMAREA
+
+// PGMIDERR handler:
+IF program not found:
+    Display 'This option is not installed ...'
+    Re-display menu
+```
+
+### Decision Table
+
+| Option Value | Numeric? | In Range (1-6)? | Program Installed? | Outcome |
+|-------------|----------|-----------------|-------------------|---------|
+| Spaces/empty | No | - | - | Error: "Please enter a valid option number..." |
+| "AB" | No | - | - | Error: "Please enter a valid option number..." |
+| "0" or "00" | Yes | No (= 0) | - | Error: "Please enter a valid option number..." |
+| "7" | Yes | No (> 6) | - | Error: "Please enter a valid option number..." |
+| "1" | Yes | Yes | Yes | XCTL to COUSR00C (User List) |
+| "2" | Yes | Yes | Yes | XCTL to COUSR01C (User Add) |
+| "3" | Yes | Yes | Yes | XCTL to COUSR02C (User Update) |
+| "4" | Yes | Yes | Yes | XCTL to COUSR03C (User Delete) |
+| "5" | Yes | Yes | Yes | XCTL to COTRTLIC (Transaction Type List) |
+| "6" | Yes | Yes | Yes | XCTL to COTRTUPC (Transaction Type Maintenance) |
+| Any valid | Yes | Yes | No (PGMIDERR) | Message: "This option is not installed ..." |
+
+## Source COBOL Reference
+
+**Program:** `COADM01C.cbl`
+**Lines:** 119-158
+
+```cobol
+       PROCESS-ENTER-KEY.
+
+           PERFORM VARYING WS-IDX
+                   FROM LENGTH OF OPTIONI OF COADM1AI BY -1 UNTIL
+                   OPTIONI OF COADM1AI(WS-IDX:1) NOT = SPACES OR
+                   WS-IDX = 1
+           END-PERFORM
+           MOVE OPTIONI OF COADM1AI(1:WS-IDX) TO WS-OPTION-X
+           INSPECT WS-OPTION-X REPLACING ALL ' ' BY '0'
+           MOVE WS-OPTION-X              TO WS-OPTION
+           MOVE WS-OPTION                TO OPTIONO OF COADM1AO
+
+           IF WS-OPTION IS NOT NUMERIC OR
+              WS-OPTION > CDEMO-ADMIN-OPT-COUNT OR
+              WS-OPTION = ZEROS
+               MOVE 'Y'     TO WS-ERR-FLG
+               MOVE 'Please enter a valid option number...' TO
+                                       WS-MESSAGE
+               PERFORM SEND-MENU-SCREEN
+           END-IF
+
+           IF NOT ERR-FLG-ON
+               IF CDEMO-ADMIN-OPT-PGMNAME(WS-OPTION)(1:5) NOT = 'DUMMY'
+                   MOVE WS-TRANID    TO CDEMO-FROM-TRANID
+                   MOVE WS-PGMNAME   TO CDEMO-FROM-PROGRAM
+                   MOVE ZEROS        TO CDEMO-PGM-CONTEXT
+                   EXEC CICS
+                       XCTL PROGRAM(CDEMO-ADMIN-OPT-PGMNAME(WS-OPTION))
+                       COMMAREA(CARDDEMO-COMMAREA)
+                   END-EXEC
+               END-IF
+               MOVE SPACES             TO WS-MESSAGE
+               MOVE DFHGREEN           TO ERRMSGC  OF COADM1AO
+               STRING 'This option '       DELIMITED BY SIZE
+                       'is not installed ...'   DELIMITED BY SIZE
+                  INTO WS-MESSAGE
+               PERFORM SEND-MENU-SCREEN
+           END-IF.
+```
+
+**Copybook:** `COADM02Y.cpy` (Admin menu options)
+
+```cobol
+ 01 CARDDEMO-ADMIN-MENU-OPTIONS.
+   05 CDEMO-ADMIN-OPT-COUNT           PIC 9(02) VALUE 6.
+   05 CDEMO-ADMIN-OPTIONS-DATA.
+     10 FILLER  PIC 9(02) VALUE 1.
+     10 FILLER  PIC X(35) VALUE 'User List (Security)               '.
+     10 FILLER  PIC X(08) VALUE 'COUSR00C'.
+     ...
+   05 CDEMO-ADMIN-OPTIONS REDEFINES CDEMO-ADMIN-OPTIONS-DATA.
+     10 CDEMO-ADMIN-OPT OCCURS 9 TIMES.
+       15 CDEMO-ADMIN-OPT-NUM           PIC 9(02).
+       15 CDEMO-ADMIN-OPT-NAME          PIC X(35).
+       15 CDEMO-ADMIN-OPT-PGMNAME       PIC X(08).
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Valid option selected — User List
+
+```gherkin
+GIVEN an admin user is on the Admin Menu screen (COADM1A)
+WHEN the user enters option "1" and presses Enter
+THEN the system transfers control to COUSR00C (User List)
+  AND the COMMAREA contains the admin user's session context
+```
+
+### Scenario 2: Invalid option — non-numeric
+
+```gherkin
+GIVEN an admin user is on the Admin Menu screen (COADM1A)
+WHEN the user enters "AB" in the option field and presses Enter
+THEN the system displays "Please enter a valid option number..."
+  AND the admin menu is re-displayed
+```
+
+### Scenario 3: Invalid option — out of range
+
+```gherkin
+GIVEN an admin user is on the Admin Menu screen (COADM1A)
+WHEN the user enters "7" in the option field and presses Enter
+THEN the system displays "Please enter a valid option number..."
+  AND the admin menu is re-displayed
+```
+
+### Scenario 4: PF3 to return to sign-on
+
+```gherkin
+GIVEN an admin user is on the Admin Menu screen (COADM1A)
+WHEN the user presses PF3
+THEN the system transfers control to COSGN00C (sign-on screen)
+  AND the admin session ends
+```
+
+### Scenario 5: Program not installed
+
+```gherkin
+GIVEN an admin user is on the Admin Menu screen (COADM1A)
+  AND the selected program is not available in the CICS region
+WHEN the user selects that option and presses Enter
+THEN the PGMIDERR condition is raised
+  AND the system displays "This option is not installed ..."
+  AND the admin menu is re-displayed
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FFFS 2014:5 | Ch. 6 | Role-based access control | Admin menu is only reachable via admin-type authentication; options 1-4 provide user management capabilities restricted to admins |
+| DORA | Art. 9 | Segregation of duties and least privilege | Admin functions (user CRUD) are segregated into a separate menu system, accessible only to admin-type users |
+
+## Edge Cases
+
+1. **Menu options are data-driven**: The admin menu reads options from the COADM02Y copybook, which allows adding/removing options by modifying the copybook and recompiling. The option count (6) and program names are configuration, not hard-coded logic. The migrated system should similarly externalize menu configuration.
+
+2. **DUMMY program check**: The code checks if the program name starts with 'DUMMY' to handle placeholder/disabled options. This is a soft-disable mechanism. The migrated system can use feature flags or permission checks instead.
+
+3. **Array bounds**: The copybook defines `OCCURS 9 TIMES` but only 6 options are populated. The remaining 3 slots are available for future expansion. Input validation correctly limits to CDEMO-ADMIN-OPT-COUNT (6).
+
+4. **No per-option authorization**: All admin users see all admin menu options. There is no granular permission to restrict, for example, user deletion to senior admins only. The migrated system should consider per-operation authorization.
+
+## Domain Expert Notes
+
+- **Pending**: No domain expert review yet. Key questions for validation:
+  - Should all admin users have access to all admin functions, or should there be sub-roles?
+  - Are options 5-6 (Transaction Type management) used in the NordKredit context, or are they CardDemo-specific?
+  - What is the process for adding new admin menu options in production?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/user-security/USEC-BR-005.md
+++ b/docs-site/docs/business-rules/user-security/USEC-BR-005.md
@@ -1,0 +1,233 @@
+---
+id: "USEC-BR-005"
+title: "User list display with pagination from USRSEC file"
+domain: "user-security"
+cobol_source: "COUSR00C.cbl:149-332"
+requirement_id: "USEC-BR-005"
+regulations:
+  - "FFFS 2014:5 Ch. 6 — IT security audit trail"
+  - "DORA Art. 9 — ICT access control monitoring"
+  - "GDPR Art. 5 — Data minimisation in display"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# USEC-BR-005: User list display with pagination from USRSEC file
+
+## Summary
+
+The User List program (COUSR00C) displays up to 10 user records per page from the USRSEC VSAM file. It supports forward pagination (PF8) and backward pagination (PF7), maintaining the current page number and first/last User IDs for navigation. The list displays User ID, First Name, Last Name, and User Type for each record. Users can filter the list by entering a starting User ID in the input field. The list also allows selecting users for Update ('U') or Delete ('D') operations.
+
+## Business Logic
+
+### Pseudocode
+
+```
+// Initial display or Enter key:
+IF User ID filter is empty:
+    START browse from beginning of file (LOW-VALUES)
+ELSE:
+    START browse from entered User ID
+
+RESET page number to 0
+PERFORM page-forward logic
+
+// Page Forward (PF8):
+IF more pages exist (NEXT-PAGE-YES):
+    START browse from last displayed User ID
+    READ next 10 records
+    Track if more records exist beyond current page
+    Increment page counter
+ELSE:
+    Display 'You are already at the bottom of the page...'
+
+// Page Backward (PF7):
+IF current page > 1:
+    START browse from first displayed User ID
+    READ previous 10 records (in reverse)
+    Decrement page counter
+ELSE:
+    Display 'You are already at the top of the page...'
+
+// Each page displays:
+FOR each record (up to 10):
+    Display: [Selection field] [User ID] [First Name] [Last Name] [User Type]
+```
+
+### Decision Table
+
+| Key Pressed | Condition | Action |
+|-------------|-----------|--------|
+| Enter | No selection | Refresh list from entered User ID filter |
+| Enter | Selection = 'U'/'u' | Transfer to COUSR02C (User Update) with selected User ID |
+| Enter | Selection = 'D'/'d' | Transfer to COUSR03C (User Delete) with selected User ID |
+| Enter | Selection = other | Error: "Invalid selection. Valid values are U and D" |
+| PF7 | Page > 1 | Navigate to previous page |
+| PF7 | Page = 1 | Message: "You are already at the top of the page..." |
+| PF8 | More records exist | Navigate to next page |
+| PF8 | No more records | Message: "You are already at the bottom of the page..." |
+| PF3 | - | Return to Admin Menu (COADM01C) |
+| Other | - | Error: invalid key message |
+
+## Source COBOL Reference
+
+**Program:** `COUSR00C.cbl`
+**Lines:** 149-232 (PROCESS-ENTER-KEY), 282-331 (PROCESS-PAGE-FORWARD)
+
+```cobol
+       PROCESS-ENTER-KEY.
+
+           EVALUATE TRUE
+               WHEN SEL0001I OF COUSR0AI NOT = SPACES AND LOW-VALUES
+                   MOVE SEL0001I OF COUSR0AI TO CDEMO-CU00-USR-SEL-FLG
+                   MOVE USRID01I OF COUSR0AI TO CDEMO-CU00-USR-SELECTED
+               WHEN SEL0002I OF COUSR0AI NOT = SPACES AND LOW-VALUES
+                   ...
+               WHEN OTHER
+                   MOVE SPACES   TO CDEMO-CU00-USR-SEL-FLG
+                   MOVE SPACES   TO CDEMO-CU00-USR-SELECTED
+           END-EVALUATE
+
+           IF (CDEMO-CU00-USR-SEL-FLG NOT = SPACES AND LOW-VALUES) AND
+              (CDEMO-CU00-USR-SELECTED NOT = SPACES AND LOW-VALUES)
+               EVALUATE CDEMO-CU00-USR-SEL-FLG
+                   WHEN 'U'
+                   WHEN 'u'
+                        MOVE 'COUSR02C'   TO CDEMO-TO-PROGRAM
+                        ...
+                        EXEC CICS XCTL PROGRAM(CDEMO-TO-PROGRAM)
+                            COMMAREA(CARDDEMO-COMMAREA)
+                        END-EXEC
+                   WHEN 'D'
+                   WHEN 'd'
+                        MOVE 'COUSR03C'   TO CDEMO-TO-PROGRAM
+                        ...
+                   WHEN OTHER
+                       MOVE
+                       'Invalid selection. Valid values are U and D' TO
+                                       WS-MESSAGE
+               END-EVALUATE
+           END-IF
+
+           IF USRIDINI OF COUSR0AI = SPACES OR LOW-VALUES
+               MOVE LOW-VALUES TO SEC-USR-ID
+           ELSE
+               MOVE USRIDINI  OF COUSR0AI TO SEC-USR-ID
+           END-IF
+
+           MOVE 0       TO CDEMO-CU00-PAGE-NUM
+           PERFORM PROCESS-PAGE-FORWARD
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Display first page of users
+
+```gherkin
+GIVEN an admin user navigates to the User List screen (COUSR0A)
+  AND the USRSEC file contains 25 user records
+WHEN the screen is first displayed
+THEN the system shows the first 10 users sorted by User ID
+  AND the page number shows "1"
+  AND forward navigation is available (more pages exist)
+```
+
+### Scenario 2: Page forward
+
+```gherkin
+GIVEN the User List displays page 1 of 3
+WHEN the admin presses PF8 (page forward)
+THEN the system displays the next 10 user records
+  AND the page number increments to 2
+```
+
+### Scenario 3: Page backward
+
+```gherkin
+GIVEN the User List displays page 2
+WHEN the admin presses PF7 (page backward)
+THEN the system displays the previous 10 user records
+  AND the page number decrements to 1
+```
+
+### Scenario 4: Already at top of list
+
+```gherkin
+GIVEN the User List displays page 1
+WHEN the admin presses PF7 (page backward)
+THEN the system displays "You are already at the top of the page..."
+  AND the page remains at 1
+```
+
+### Scenario 5: Filter by User ID
+
+```gherkin
+GIVEN an admin is on the User List screen
+WHEN the admin enters "USER00" in the User ID filter field and presses Enter
+THEN the system starts browsing from "USER00"
+  AND displays up to 10 users starting from or after "USER00" alphabetically
+```
+
+### Scenario 6: Select user for update
+
+```gherkin
+GIVEN the User List displays users
+WHEN the admin enters "U" in the selection field next to user "USER0001"
+  AND presses Enter
+THEN the system transfers control to COUSR02C (User Update)
+  AND passes "USER0001" as the selected user in the COMMAREA
+```
+
+### Scenario 7: Select user for delete
+
+```gherkin
+GIVEN the User List displays users
+WHEN the admin enters "D" in the selection field next to user "USER0001"
+  AND presses Enter
+THEN the system transfers control to COUSR03C (User Delete)
+  AND passes "USER0001" as the selected user in the COMMAREA
+```
+
+### Scenario 8: Invalid selection value
+
+```gherkin
+GIVEN the User List displays users
+WHEN the admin enters "X" in the selection field next to a user
+  AND presses Enter
+THEN the system displays "Invalid selection. Valid values are U and D"
+  AND the user list is re-displayed
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FFFS 2014:5 | Ch. 6 | IT security — ability to review user access | User list provides admin visibility into all registered users and their types, supporting access reviews |
+| DORA | Art. 9 | ICT access control monitoring | Admin interface for reviewing user accounts supports access control monitoring requirements |
+| GDPR | Art. 5(1)(c) | Data minimisation | List displays only User ID, name, and type — minimal PII necessary for user management |
+
+## Edge Cases
+
+1. **Case-insensitive selection**: The selection flag accepts both uppercase and lowercase 'U'/'u' and 'D'/'d'. The migrated system should similarly be case-insensitive for user convenience.
+
+2. **10 records per page**: The page size is hardcoded to 10 records (limited by BMS screen real estate). The migrated system can support configurable page sizes and infinite scroll.
+
+3. **VSAM sequential browse**: The list uses CICS STARTBR/READNEXT/READPREV for pagination, which reads records in key order (User ID). The migrated system should use SQL pagination (OFFSET/FETCH or cursor-based).
+
+4. **Only first selection processed**: If multiple rows have selection flags, only the first non-empty selection in the EVALUATE chain is processed. The migrated system could support batch selection.
+
+5. **Page tracking in COMMAREA**: Page number, first/last User IDs, and next-page flag are stored in the COMMAREA for pseudo-conversational pagination state. The migrated system should use server-side pagination tokens or stateless cursor-based pagination.
+
+## Domain Expert Notes
+
+- **Pending**: No domain expert review yet. Key questions for validation:
+  - Should the user list be accessible to non-admin users (e.g., for self-service profile viewing)?
+  - Are there any sorting requirements beyond User ID order?
+  - Should the migrated system support search by name in addition to User ID?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/user-security/USEC-BR-006.md
+++ b/docs-site/docs/business-rules/user-security/USEC-BR-006.md
@@ -1,0 +1,236 @@
+---
+id: "USEC-BR-006"
+title: "User creation with required field validation and duplicate detection"
+domain: "user-security"
+cobol_source: "COUSR01C.cbl:115-274"
+requirement_id: "USEC-BR-006"
+regulations:
+  - "PSD2 Art. 97 — SCA credential provisioning"
+  - "FFFS 2014:5 Ch. 6 — User access management"
+  - "DORA Art. 9 — ICT access control provisioning"
+  - "GDPR Art. 5 — Data accuracy and minimisation"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# USEC-BR-006: User creation with required field validation and duplicate detection
+
+## Summary
+
+The User Add program (COUSR01C) allows admin users to create new user accounts in the USRSEC file. Five fields are required: First Name, Last Name, User ID, Password, and User Type. Validation is sequential — the first empty field triggers an error and halts processing. After validation, the program writes a new record to the USRSEC file using CICS WRITE. If the User ID already exists, a DUPREC/DUPKEY error is returned and the admin is notified. On success, the form is cleared and a confirmation message is displayed.
+
+## Business Logic
+
+### Pseudocode
+
+```
+RECEIVE screen input from CICS MAP COUSR1A
+
+// Phase 1: Required field validation (sequential — first error stops)
+IF First-Name is empty: ERROR 'First Name can NOT be empty...'
+IF Last-Name is empty:  ERROR 'Last Name can NOT be empty...'
+IF User-ID is empty:    ERROR 'User ID can NOT be empty...'
+IF Password is empty:   ERROR 'Password can NOT be empty...'
+IF User-Type is empty:  ERROR 'User Type can NOT be empty...'
+
+// Phase 2: Populate SEC-USER-DATA record
+MOVE User-ID   -> SEC-USR-ID
+MOVE First-Name -> SEC-USR-FNAME
+MOVE Last-Name  -> SEC-USR-LNAME
+MOVE Password   -> SEC-USR-PWD
+MOVE User-Type  -> SEC-USR-TYPE
+
+// Phase 3: Write to file
+CICS WRITE to USRSEC dataset
+
+EVALUATE response:
+  WHEN success (NORMAL):
+    Clear all fields
+    Display (green) 'User <ID> has been added ...'
+  WHEN duplicate key (DUPKEY/DUPREC):
+    ERROR 'User ID already exist...'
+    Position cursor on User ID field
+  WHEN other error:
+    ERROR 'Unable to Add User...'
+```
+
+### Decision Table
+
+| First Name | Last Name | User ID | Password | User Type | User ID Exists | Outcome |
+|-----------|----------|---------|----------|-----------|---------------|---------|
+| Empty | - | - | - | - | - | Error: "First Name can NOT be empty..." |
+| Provided | Empty | - | - | - | - | Error: "Last Name can NOT be empty..." |
+| Provided | Provided | Empty | - | - | - | Error: "User ID can NOT be empty..." |
+| Provided | Provided | Provided | Empty | - | - | Error: "Password can NOT be empty..." |
+| Provided | Provided | Provided | Provided | Empty | - | Error: "User Type can NOT be empty..." |
+| Provided | Provided | Provided | Provided | Provided | Yes | Error: "User ID already exist..." |
+| Provided | Provided | Provided | Provided | Provided | No | Success: "User <ID> has been added ..." |
+
+## Source COBOL Reference
+
+**Program:** `COUSR01C.cbl`
+**Lines:** 115-274
+
+```cobol
+       PROCESS-ENTER-KEY.
+
+           EVALUATE TRUE
+               WHEN FNAMEI OF COUSR1AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'First Name can NOT be empty...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO FNAMEL OF COUSR1AI
+                   PERFORM SEND-USRADD-SCREEN
+               WHEN LNAMEI OF COUSR1AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Last Name can NOT be empty...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO LNAMEL OF COUSR1AI
+                   PERFORM SEND-USRADD-SCREEN
+               WHEN USERIDI OF COUSR1AI = SPACES OR LOW-VALUES
+                   ...
+               WHEN PASSWDI OF COUSR1AI = SPACES OR LOW-VALUES
+                   ...
+               WHEN USRTYPEI OF COUSR1AI = SPACES OR LOW-VALUES
+                   ...
+               WHEN OTHER
+                   MOVE -1       TO FNAMEL OF COUSR1AI
+                   CONTINUE
+           END-EVALUATE
+
+           IF NOT ERR-FLG-ON
+               MOVE USERIDI  OF COUSR1AI TO SEC-USR-ID
+               MOVE FNAMEI   OF COUSR1AI TO SEC-USR-FNAME
+               MOVE LNAMEI   OF COUSR1AI TO SEC-USR-LNAME
+               MOVE PASSWDI  OF COUSR1AI TO SEC-USR-PWD
+               MOVE USRTYPEI OF COUSR1AI TO SEC-USR-TYPE
+               PERFORM WRITE-USER-SEC-FILE
+           END-IF.
+
+       WRITE-USER-SEC-FILE.
+
+           EXEC CICS WRITE
+                DATASET   (WS-USRSEC-FILE)
+                FROM      (SEC-USER-DATA)
+                LENGTH    (LENGTH OF SEC-USER-DATA)
+                RIDFLD    (SEC-USR-ID)
+                KEYLENGTH (LENGTH OF SEC-USR-ID)
+                RESP      (WS-RESP-CD)
+                RESP2     (WS-REAS-CD)
+           END-EXEC.
+
+           EVALUATE WS-RESP-CD
+               WHEN DFHRESP(NORMAL)
+                   PERFORM INITIALIZE-ALL-FIELDS
+                   MOVE DFHGREEN           TO ERRMSGC  OF COUSR1AO
+                   STRING 'User '     DELIMITED BY SIZE
+                          SEC-USR-ID  DELIMITED BY SPACE
+                          ' has been added ...' DELIMITED BY SIZE
+                     INTO WS-MESSAGE
+                   PERFORM SEND-USRADD-SCREEN
+               WHEN DFHRESP(DUPKEY)
+               WHEN DFHRESP(DUPREC)
+                   MOVE 'User ID already exist...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO USERIDL OF COUSR1AI
+                   PERFORM SEND-USRADD-SCREEN
+               WHEN OTHER
+                   MOVE 'Unable to Add User...' TO
+                                   WS-MESSAGE
+                   PERFORM SEND-USRADD-SCREEN
+           END-EVALUATE.
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Successfully add a new user
+
+```gherkin
+GIVEN an admin user is on the User Add screen (COUSR1A)
+WHEN the admin enters First Name "John", Last Name "Doe", User ID "JDOE0001", Password "PASS1234", User Type "U"
+  AND presses Enter
+THEN the system writes a new record to the USRSEC file
+  AND displays "User JDOE0001 has been added ..." in green
+  AND all input fields are cleared for the next entry
+```
+
+### Scenario 2: Empty required field — First Name
+
+```gherkin
+GIVEN an admin user is on the User Add screen (COUSR1A)
+  AND the First Name field is empty
+WHEN the admin presses Enter
+THEN the system displays "First Name can NOT be empty..."
+  AND the cursor is positioned on the First Name field
+  AND no file write is performed
+```
+
+### Scenario 3: Duplicate User ID
+
+```gherkin
+GIVEN an admin user is on the User Add screen (COUSR1A)
+  AND user "USER0001" already exists in the USRSEC file
+WHEN the admin enters User ID "USER0001" with all other fields filled
+  AND presses Enter
+THEN the system displays "User ID already exist..."
+  AND the cursor is positioned on the User ID field
+  AND the existing record is not modified
+```
+
+### Scenario 4: PF3 to return to admin menu
+
+```gherkin
+GIVEN an admin user is on the User Add screen (COUSR1A)
+WHEN the admin presses PF3
+THEN the system transfers control to COADM01C (Admin Menu)
+  AND no user record is created
+```
+
+### Scenario 5: PF4 to clear form
+
+```gherkin
+GIVEN an admin user is on the User Add screen (COUSR1A)
+  AND some fields contain data
+WHEN the admin presses PF4
+THEN all input fields are cleared to spaces
+  AND the cursor is positioned on the First Name field
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 97 | SCA credential provisioning | User creation is restricted to admin users, ensuring controlled credential provisioning |
+| FFFS 2014:5 | Ch. 6 | User access management procedures | Formal user creation process with required fields ensures structured access provisioning |
+| DORA | Art. 9 | ICT access control provisioning | Admin-controlled user creation supports formal access provisioning requirements |
+| GDPR | Art. 5(1)(c) | Data minimisation | Only essential user attributes are collected (name, ID, password, type) |
+| GDPR | Art. 5(1)(d) | Data accuracy | Required field validation ensures complete user records are created |
+
+## Edge Cases
+
+1. **No User Type validation**: The User Type field is required but not validated for specific values. Any single character is accepted, even though only 'A' and 'U' are meaningful. The migrated system should validate against allowed user types.
+
+2. **No password complexity enforcement**: The password is accepted as-is (any 1-8 characters). The migrated system must enforce password complexity policies (length, special characters, etc.).
+
+3. **No User ID format validation**: The User ID is any 1-8 characters. The migrated system should enforce naming conventions if required.
+
+4. **Plaintext password storage**: The password is written directly to the SEC-USR-PWD field in plaintext. The migrated system must hash passwords before storage.
+
+5. **No audit trail**: User creation is not logged to an audit trail. The migrated system must log all user provisioning events per DORA Art. 9 and FFFS 2014:5.
+
+6. **Form cleared on success**: After successful creation, all fields are cleared. The admin must re-enter all fields for the next user. This prevents accidental duplicate creation but requires full re-entry.
+
+## Domain Expert Notes
+
+- **Pending**: No domain expert review yet. Key questions for validation:
+  - What are the valid User Type values beyond 'A' and 'U'?
+  - Is there a naming convention for User IDs (e.g., first initial + last name)?
+  - Should user creation trigger any notifications or approval workflows?
+  - Is there a maximum number of users the system should support?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/user-security/USEC-BR-007.md
+++ b/docs-site/docs/business-rules/user-security/USEC-BR-007.md
@@ -1,0 +1,373 @@
+---
+id: "USEC-BR-007"
+title: "User update with field-level change detection and rewrite"
+domain: "user-security"
+cobol_source: "COUSR02C.cbl:115-274"
+requirement_id: "USEC-BR-007"
+regulations:
+  - "FFFS 2014:5 Ch. 6 — User access management"
+  - "DORA Art. 9 — ICT access control maintenance"
+  - "GDPR Art. 5 — Data accuracy"
+  - "GDPR Art. 16 — Right to rectification"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# USEC-BR-007: User update with field-level change detection and rewrite
+
+## Summary
+
+The User Update program (COUSR02C) allows admin users to modify existing user records in the USRSEC file. The workflow is two-phase: first the admin enters or receives a User ID (from the User List screen), and the program reads and displays the current record. The admin then modifies fields (First Name, Last Name, Password, User Type) and presses PF5 to save. Before writing, the program performs field-level change detection — comparing each screen field against the stored record. If no fields have changed, the program displays an error message ("Please modify to update ...") and does not write. If at least one field changed, it performs a CICS REWRITE to persist the updated record. All five fields (User ID, First Name, Last Name, Password, User Type) must be non-empty for the update to proceed.
+
+## Business Logic
+
+### Pseudocode
+
+```
+// Phase 1: Lookup (Enter key)
+RECEIVE screen input
+
+IF User-ID is empty:
+    ERROR 'User ID can NOT be empty...'
+    Re-display screen
+
+READ USRSEC file with UPDATE intent using User-ID as key
+
+EVALUATE read response:
+  WHEN record found (NORMAL):
+    Display stored values: First Name, Last Name, Password, User Type
+    Display 'Press PF5 key to save your updates ...'
+  WHEN record not found (NOTFND):
+    ERROR 'User ID NOT found...'
+  WHEN other error:
+    ERROR 'Unable to lookup User...'
+
+// Phase 2: Save (PF5 key)
+VALIDATE all fields are non-empty (sequential):
+  IF User-ID empty:    ERROR 'User ID can NOT be empty...'
+  IF First-Name empty: ERROR 'First Name can NOT be empty...'
+  IF Last-Name empty:  ERROR 'Last Name can NOT be empty...'
+  IF Password empty:   ERROR 'Password can NOT be empty...'
+  IF User-Type empty:  ERROR 'User Type can NOT be empty...'
+
+READ USRSEC file with UPDATE intent (re-read for REWRITE)
+
+// Field-level change detection:
+SET modified = false
+IF screen-First-Name != stored-First-Name:  UPDATE stored, SET modified = true
+IF screen-Last-Name  != stored-Last-Name:   UPDATE stored, SET modified = true
+IF screen-Password   != stored-Password:    UPDATE stored, SET modified = true
+IF screen-User-Type  != stored-User-Type:   UPDATE stored, SET modified = true
+
+IF modified:
+    CICS REWRITE USRSEC record
+    EVALUATE response:
+      WHEN success (NORMAL):
+        Display (green) 'User <ID> has been updated ...'
+      WHEN not found (NOTFND):
+        ERROR 'User ID NOT found...'
+      WHEN other:
+        ERROR 'Unable to Update User...'
+ELSE:
+    ERROR (red) 'Please modify to update ...'
+```
+
+### Decision Table
+
+| Phase | User ID | Fields Valid | Record Found | Fields Changed | Outcome |
+|-------|---------|-------------|-------------|----------------|---------|
+| Lookup | Empty | - | - | - | Error: "User ID can NOT be empty..." |
+| Lookup | Provided | - | No | - | Error: "User ID NOT found..." |
+| Lookup | Provided | - | Yes | - | Display current values, prompt PF5 |
+| Save | Empty | - | - | - | Error: "User ID can NOT be empty..." |
+| Save | Provided | No (any empty) | - | - | Error: "<field> can NOT be empty..." |
+| Save | Provided | Yes | Yes | No | Error: "Please modify to update ..." |
+| Save | Provided | Yes | Yes | Yes | Success: "User <ID> has been updated ..." |
+| Save | Provided | Yes | No (deleted between lookup and save) | - | Error: "User ID NOT found..." |
+
+### Key Navigation
+
+| Key | Action |
+|-----|--------|
+| Enter | Look up User ID and display current values |
+| PF3 | Save pending changes (if any), then return to calling program |
+| PF4 | Clear all fields |
+| PF5 | Save/commit updates to USRSEC file |
+| PF12 | Return to Admin Menu (COADM01C) without saving |
+| Other | Error: invalid key message |
+
+## Source COBOL Reference
+
+**Program:** `COUSR02C.cbl`
+**Lines:** 115-274 (PROCESS-ENTER-KEY, UPDATE-USER-INFO, UPDATE-USER-SEC-FILE)
+
+```cobol
+       PROCESS-ENTER-KEY.
+
+           EVALUATE TRUE
+               WHEN USRIDINI OF COUSR2AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'User ID can NOT be empty...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO USRIDINL OF COUSR2AI
+                   PERFORM SEND-USRUPD-SCREEN
+               WHEN OTHER
+                   MOVE -1       TO USRIDINL OF COUSR2AI
+                   CONTINUE
+           END-EVALUATE
+
+           IF NOT ERR-FLG-ON
+               MOVE SPACES      TO FNAMEI   OF COUSR2AI
+                                   LNAMEI   OF COUSR2AI
+                                   PASSWDI  OF COUSR2AI
+                                   USRTYPEI OF COUSR2AI
+               MOVE USRIDINI  OF COUSR2AI TO SEC-USR-ID
+               PERFORM READ-USER-SEC-FILE
+           END-IF.
+
+           IF NOT ERR-FLG-ON
+               MOVE SEC-USR-FNAME      TO FNAMEI    OF COUSR2AI
+               MOVE SEC-USR-LNAME      TO LNAMEI    OF COUSR2AI
+               MOVE SEC-USR-PWD        TO PASSWDI   OF COUSR2AI
+               MOVE SEC-USR-TYPE       TO USRTYPEI  OF COUSR2AI
+               PERFORM SEND-USRUPD-SCREEN
+           END-IF.
+
+       UPDATE-USER-INFO.
+
+           EVALUATE TRUE
+               WHEN USRIDINI OF COUSR2AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'User ID can NOT be empty...' TO WS-MESSAGE
+                   MOVE -1       TO USRIDINL OF COUSR2AI
+                   PERFORM SEND-USRUPD-SCREEN
+               WHEN FNAMEI OF COUSR2AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'First Name can NOT be empty...' TO WS-MESSAGE
+                   MOVE -1       TO FNAMEL OF COUSR2AI
+                   PERFORM SEND-USRUPD-SCREEN
+               WHEN LNAMEI OF COUSR2AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Last Name can NOT be empty...' TO WS-MESSAGE
+                   MOVE -1       TO LNAMEL OF COUSR2AI
+                   PERFORM SEND-USRUPD-SCREEN
+               WHEN PASSWDI OF COUSR2AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Password can NOT be empty...' TO WS-MESSAGE
+                   MOVE -1       TO PASSWDL OF COUSR2AI
+                   PERFORM SEND-USRUPD-SCREEN
+               WHEN USRTYPEI OF COUSR2AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'User Type can NOT be empty...' TO WS-MESSAGE
+                   MOVE -1       TO USRTYPEL OF COUSR2AI
+                   PERFORM SEND-USRUPD-SCREEN
+               WHEN OTHER
+                   MOVE -1       TO FNAMEL OF COUSR2AI
+                   CONTINUE
+           END-EVALUATE
+
+           IF NOT ERR-FLG-ON
+               MOVE USRIDINI  OF COUSR2AI TO SEC-USR-ID
+               PERFORM READ-USER-SEC-FILE
+
+               IF FNAMEI  OF COUSR2AI NOT = SEC-USR-FNAME
+                   MOVE FNAMEI   OF COUSR2AI TO SEC-USR-FNAME
+                   SET USR-MODIFIED-YES TO TRUE
+               END-IF
+               IF LNAMEI  OF COUSR2AI NOT = SEC-USR-LNAME
+                   MOVE LNAMEI   OF COUSR2AI TO SEC-USR-LNAME
+                   SET USR-MODIFIED-YES TO TRUE
+               END-IF
+               IF PASSWDI  OF COUSR2AI NOT = SEC-USR-PWD
+                   MOVE PASSWDI  OF COUSR2AI TO SEC-USR-PWD
+                   SET USR-MODIFIED-YES TO TRUE
+               END-IF
+               IF USRTYPEI  OF COUSR2AI NOT = SEC-USR-TYPE
+                   MOVE USRTYPEI OF COUSR2AI TO SEC-USR-TYPE
+                   SET USR-MODIFIED-YES TO TRUE
+               END-IF
+
+               IF USR-MODIFIED-YES
+                   PERFORM UPDATE-USER-SEC-FILE
+               ELSE
+                   MOVE 'Please modify to update ...' TO WS-MESSAGE
+                   MOVE DFHRED       TO ERRMSGC  OF COUSR2AO
+                   PERFORM SEND-USRUPD-SCREEN
+               END-IF
+           END-IF.
+
+       UPDATE-USER-SEC-FILE.
+
+           EXEC CICS REWRITE
+                DATASET   (WS-USRSEC-FILE)
+                FROM      (SEC-USER-DATA)
+                LENGTH    (LENGTH OF SEC-USER-DATA)
+                RESP      (WS-RESP-CD)
+                RESP2     (WS-REAS-CD)
+           END-EXEC.
+
+           EVALUATE WS-RESP-CD
+               WHEN DFHRESP(NORMAL)
+                   MOVE SPACES             TO WS-MESSAGE
+                   MOVE DFHGREEN           TO ERRMSGC  OF COUSR2AO
+                   STRING 'User '     DELIMITED BY SIZE
+                          SEC-USR-ID  DELIMITED BY SPACE
+                          ' has been updated ...' DELIMITED BY SIZE
+                     INTO WS-MESSAGE
+                   PERFORM SEND-USRUPD-SCREEN
+               WHEN DFHRESP(NOTFND)
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'User ID NOT found...' TO WS-MESSAGE
+                   MOVE -1       TO USRIDINL OF COUSR2AI
+                   PERFORM SEND-USRUPD-SCREEN
+               WHEN OTHER
+                   DISPLAY 'RESP:' WS-RESP-CD 'REAS:' WS-REAS-CD
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Unable to Update User...' TO WS-MESSAGE
+                   MOVE -1       TO FNAMEL OF COUSR2AI
+                   PERFORM SEND-USRUPD-SCREEN
+           END-EVALUATE.
+```
+
+**Copybook:** `CSUSR01Y.cpy` (User security record)
+
+```cobol
+ 01 SEC-USER-DATA.
+   05 SEC-USR-ID                 PIC X(08).
+   05 SEC-USR-FNAME              PIC X(20).
+   05 SEC-USR-LNAME              PIC X(20).
+   05 SEC-USR-PWD                PIC X(08).
+   05 SEC-USR-TYPE               PIC X(01).
+   05 SEC-USR-FILLER             PIC X(23).
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Look up existing user by ID
+
+```gherkin
+GIVEN an admin user is on the User Update screen (COUSR2A)
+WHEN the admin enters User ID "USER0001" and presses Enter
+THEN the system reads the USRSEC file for User ID "USER0001"
+  AND displays the stored First Name, Last Name, Password, and User Type
+  AND displays "Press PF5 key to save your updates ..."
+```
+
+### Scenario 2: User ID not found on lookup
+
+```gherkin
+GIVEN an admin user is on the User Update screen (COUSR2A)
+WHEN the admin enters User ID "NOTEXIST" and presses Enter
+THEN the system displays "User ID NOT found..."
+  AND the cursor is positioned on the User ID field
+```
+
+### Scenario 3: Successful field update
+
+```gherkin
+GIVEN an admin user has looked up User ID "USER0001"
+  AND the current Last Name is "Smith"
+WHEN the admin changes Last Name to "Johnson" and presses PF5
+THEN the system detects the Last Name field has changed
+  AND rewrites the USRSEC record with the new Last Name
+  AND displays "User USER0001 has been updated ..." in green
+```
+
+### Scenario 4: No changes detected
+
+```gherkin
+GIVEN an admin user has looked up User ID "USER0001"
+  AND no fields have been modified
+WHEN the admin presses PF5
+THEN the system displays "Please modify to update ..." in red
+  AND the USRSEC record is NOT rewritten
+```
+
+### Scenario 5: Empty required field on save
+
+```gherkin
+GIVEN an admin user has looked up User ID "USER0001"
+  AND the admin clears the First Name field
+WHEN the admin presses PF5
+THEN the system displays "First Name can NOT be empty..."
+  AND the cursor is positioned on the First Name field
+  AND the USRSEC record is NOT modified
+```
+
+### Scenario 6: Empty User ID on lookup
+
+```gherkin
+GIVEN an admin user is on the User Update screen (COUSR2A)
+  AND the User ID field is empty
+WHEN the admin presses Enter
+THEN the system displays "User ID can NOT be empty..."
+  AND the cursor is positioned on the User ID field
+```
+
+### Scenario 7: PF3 saves pending changes before exiting
+
+```gherkin
+GIVEN an admin user has modified fields for User ID "USER0001"
+WHEN the admin presses PF3
+THEN the system saves any pending updates via UPDATE-USER-INFO
+  AND transfers control to the calling program (or COADM01C)
+```
+
+### Scenario 8: PF4 clears all fields
+
+```gherkin
+GIVEN an admin user is on the User Update screen (COUSR2A)
+  AND some fields contain data
+WHEN the admin presses PF4
+THEN all input fields are cleared to spaces
+  AND the cursor is positioned on the User ID field
+```
+
+### Scenario 9: Pre-populated User ID from User List
+
+```gherkin
+GIVEN an admin user selected User ID "USER0001" for update from the User List (COUSR00C)
+WHEN the User Update screen (COUSR2A) is first displayed
+THEN the User ID field is pre-populated with "USER0001"
+  AND the system automatically looks up and displays the user's current data
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FFFS 2014:5 | Ch. 6 | User access management — maintenance of user accounts | Provides admin capability to maintain user credentials and roles |
+| DORA | Art. 9 | ICT access control — ongoing maintenance of access rights | Supports modification of user types and credentials as part of access lifecycle management |
+| GDPR | Art. 5(1)(d) | Data accuracy — personal data shall be accurate and kept up to date | User update function enables correction of user name and credential data |
+| GDPR | Art. 16 | Right to rectification | The update function provides the mechanism to correct inaccurate personal data |
+
+## Edge Cases
+
+1. **User ID is immutable**: The User ID field is used as the lookup key and cannot be changed through this screen. To "change" a User ID, the admin must delete the old record and create a new one. The migrated system should consider whether User ID renaming is a requirement.
+
+2. **READ with UPDATE intent**: The program issues `CICS READ ... UPDATE` which acquires a record-level lock in the VSAM file. This prevents concurrent modifications but also means the record is locked between the read and the rewrite. If the admin abandons the screen without saving, the lock is released when the task ends (pseudo-conversational return). The migrated system should use optimistic concurrency (e.g., ETags or row versions) rather than pessimistic locking.
+
+3. **PF3 auto-saves**: Pressing PF3 (typically "Exit") first calls UPDATE-USER-INFO, which will save any pending changes before returning to the previous screen. This is non-standard UI behavior — most users expect PF3 to exit without saving. The migrated system should clarify save-on-exit behavior (prompt for unsaved changes).
+
+4. **No password change confirmation**: The password field is displayed and can be changed without requiring the current password or a confirmation entry. The migrated system should require current password verification for password changes and a confirmation field to prevent typos.
+
+5. **No change audit trail**: User modifications are not logged. The migrated system must log all user attribute changes (who changed what, when) per DORA Art. 9 and FFFS 2014:5.
+
+6. **Plaintext password displayed**: The existing password is displayed in the Password field in plaintext when the record is loaded. The migrated system must never display stored passwords.
+
+7. **No User Type validation**: Like user creation, the User Type field accepts any single character. Changing a user from type 'U' to type 'A' (or vice versa) has no confirmation or approval workflow. The migrated system should require authorization for privilege escalation.
+
+## Domain Expert Notes
+
+- **Pending**: No domain expert review yet. Key questions for validation:
+  - Should password changes require re-authentication or a separate workflow?
+  - Is the PF3 auto-save behavior intentional, or should exit discard unsaved changes?
+  - Should privilege escalation (changing User Type from 'U' to 'A') require additional authorization?
+  - Are there any fields that should be read-only after initial creation (e.g., User ID)?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/user-security/USEC-BR-008.md
+++ b/docs-site/docs/business-rules/user-security/USEC-BR-008.md
@@ -1,0 +1,322 @@
+---
+id: "USEC-BR-008"
+title: "User deletion with read-before-delete confirmation pattern"
+domain: "user-security"
+cobol_source: "COUSR03C.cbl:115-250"
+requirement_id: "USEC-BR-008"
+regulations:
+  - "FFFS 2014:5 Ch. 6 — User access deprovisioning"
+  - "DORA Art. 9 — ICT access control revocation"
+  - "GDPR Art. 17 — Right to erasure"
+  - "GDPR Art. 5 — Storage limitation"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# USEC-BR-008: User deletion with read-before-delete confirmation pattern
+
+## Summary
+
+The User Delete program (COUSR03C) allows admin users to delete user records from the USRSEC file. The workflow follows a read-before-delete pattern: the admin first enters (or receives from the User List) a User ID and presses Enter to look up and display the user's details (First Name, Last Name, User Type — but NOT the password). After reviewing the record, the admin confirms deletion by pressing PF5. The program reads the record again with UPDATE intent (acquiring a lock) and then performs a CICS DELETE. On success, the form is cleared and a confirmation message is displayed. The deletion is immediate and permanent — there is no soft-delete, undo capability, or confirmation dialog beyond the two-step review-then-delete pattern.
+
+## Business Logic
+
+### Pseudocode
+
+```
+// Phase 1: Lookup (Enter key)
+RECEIVE screen input
+
+IF User-ID is empty:
+    ERROR 'User ID can NOT be empty...'
+    Re-display screen
+
+READ USRSEC file with UPDATE intent using User-ID as key
+
+EVALUATE read response:
+  WHEN record found (NORMAL):
+    Display stored values: First Name, Last Name, User Type
+    Display 'Press PF5 key to delete this user ...'
+  WHEN record not found (NOTFND):
+    ERROR 'User ID NOT found...'
+  WHEN other error:
+    ERROR 'Unable to lookup User...'
+
+// Phase 2: Delete (PF5 key)
+IF User-ID is empty:
+    ERROR 'User ID can NOT be empty...'
+
+READ USRSEC file with UPDATE intent (re-read to acquire lock)
+
+IF record found:
+    CICS DELETE from USRSEC dataset
+
+    EVALUATE delete response:
+      WHEN success (NORMAL):
+        Clear all fields
+        Display (green) 'User <ID> has been deleted ...'
+      WHEN not found (NOTFND):
+        ERROR 'User ID NOT found...'
+      WHEN other error:
+        ERROR 'Unable to Update User...'    // Note: message says "Update" — bug in original
+```
+
+### Decision Table
+
+| Phase | User ID | Record Found | Outcome |
+|-------|---------|-------------|---------|
+| Lookup | Empty | - | Error: "User ID can NOT be empty..." |
+| Lookup | Provided | No | Error: "User ID NOT found..." |
+| Lookup | Provided | Yes | Display user details, prompt PF5 to confirm |
+| Delete | Empty | - | Error: "User ID can NOT be empty..." |
+| Delete | Provided | No (deleted between lookup and delete) | Error: "User ID NOT found..." |
+| Delete | Provided | Yes | Success: "User <ID> has been deleted ..." |
+
+### Key Navigation
+
+| Key | Action |
+|-----|--------|
+| Enter | Look up User ID and display details for review |
+| PF3 | Return to calling program (COADM01C or previous) |
+| PF4 | Clear all fields |
+| PF5 | Confirm and execute deletion |
+| PF12 | Return to Admin Menu (COADM01C) |
+| Other | Error: invalid key message |
+
+### Fields Displayed (Read-Only Review)
+
+| Field | Source | Displayed |
+|-------|--------|-----------|
+| User ID | Screen input / COMMAREA | Yes (input field) |
+| First Name | SEC-USR-FNAME | Yes (display only) |
+| Last Name | SEC-USR-LNAME | Yes (display only) |
+| Password | SEC-USR-PWD | No — not displayed on delete screen |
+| User Type | SEC-USR-TYPE | Yes (display only) |
+
+## Source COBOL Reference
+
+**Program:** `COUSR03C.cbl`
+**Lines:** 115-250 (PROCESS-ENTER-KEY, DELETE-USER-INFO, DELETE-USER-SEC-FILE)
+
+```cobol
+       PROCESS-ENTER-KEY.
+
+           EVALUATE TRUE
+               WHEN USRIDINI OF COUSR3AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'User ID can NOT be empty...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO USRIDINL OF COUSR3AI
+                   PERFORM SEND-USRDEL-SCREEN
+               WHEN OTHER
+                   MOVE -1       TO USRIDINL OF COUSR3AI
+                   CONTINUE
+           END-EVALUATE
+
+           IF NOT ERR-FLG-ON
+               MOVE SPACES      TO FNAMEI   OF COUSR3AI
+                                   LNAMEI   OF COUSR3AI
+                                   USRTYPEI OF COUSR3AI
+               MOVE USRIDINI  OF COUSR3AI TO SEC-USR-ID
+               PERFORM READ-USER-SEC-FILE
+           END-IF.
+
+           IF NOT ERR-FLG-ON
+               MOVE SEC-USR-FNAME      TO FNAMEI    OF COUSR3AI
+               MOVE SEC-USR-LNAME      TO LNAMEI    OF COUSR3AI
+               MOVE SEC-USR-TYPE       TO USRTYPEI  OF COUSR3AI
+               PERFORM SEND-USRDEL-SCREEN
+           END-IF.
+
+       DELETE-USER-INFO.
+
+           EVALUATE TRUE
+               WHEN USRIDINI OF COUSR3AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'User ID can NOT be empty...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO USRIDINL OF COUSR3AI
+                   PERFORM SEND-USRDEL-SCREEN
+               WHEN OTHER
+                   MOVE -1       TO USRIDINL OF COUSR3AI
+                   CONTINUE
+           END-EVALUATE
+
+           IF NOT ERR-FLG-ON
+               MOVE USRIDINI  OF COUSR3AI TO SEC-USR-ID
+               PERFORM READ-USER-SEC-FILE
+               PERFORM DELETE-USER-SEC-FILE
+           END-IF.
+
+       DELETE-USER-SEC-FILE.
+
+           EXEC CICS DELETE
+                DATASET   (WS-USRSEC-FILE)
+                RESP      (WS-RESP-CD)
+                RESP2     (WS-REAS-CD)
+           END-EXEC.
+
+           EVALUATE WS-RESP-CD
+               WHEN DFHRESP(NORMAL)
+                   PERFORM INITIALIZE-ALL-FIELDS
+                   MOVE SPACES             TO WS-MESSAGE
+                   MOVE DFHGREEN           TO ERRMSGC  OF COUSR3AO
+                   STRING 'User '     DELIMITED BY SIZE
+                          SEC-USR-ID  DELIMITED BY SPACE
+                          ' has been deleted ...' DELIMITED BY SIZE
+                     INTO WS-MESSAGE
+                   PERFORM SEND-USRDEL-SCREEN
+               WHEN DFHRESP(NOTFND)
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'User ID NOT found...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO USRIDINL OF COUSR3AI
+                   PERFORM SEND-USRDEL-SCREEN
+               WHEN OTHER
+                   DISPLAY 'RESP:' WS-RESP-CD 'REAS:' WS-REAS-CD
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Unable to Update User...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO FNAMEL OF COUSR3AI
+                   PERFORM SEND-USRDEL-SCREEN
+           END-EVALUATE.
+```
+
+**Copybook:** `CSUSR01Y.cpy` (User security record)
+
+```cobol
+ 01 SEC-USER-DATA.
+   05 SEC-USR-ID                 PIC X(08).
+   05 SEC-USR-FNAME              PIC X(20).
+   05 SEC-USR-LNAME              PIC X(20).
+   05 SEC-USR-PWD                PIC X(08).
+   05 SEC-USR-TYPE               PIC X(01).
+   05 SEC-USR-FILLER             PIC X(23).
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Look up existing user for deletion
+
+```gherkin
+GIVEN an admin user is on the User Delete screen (COUSR3A)
+WHEN the admin enters User ID "USER0001" and presses Enter
+THEN the system reads the USRSEC file for User ID "USER0001"
+  AND displays the stored First Name, Last Name, and User Type
+  AND does NOT display the password
+  AND displays "Press PF5 key to delete this user ..."
+```
+
+### Scenario 2: Confirm deletion with PF5
+
+```gherkin
+GIVEN an admin user has reviewed User ID "USER0001" on the delete screen
+WHEN the admin presses PF5
+THEN the system reads the USRSEC record with UPDATE intent
+  AND deletes the record from the USRSEC file
+  AND clears all input fields
+  AND displays "User USER0001 has been deleted ..." in green
+```
+
+### Scenario 3: User ID not found on lookup
+
+```gherkin
+GIVEN an admin user is on the User Delete screen (COUSR3A)
+WHEN the admin enters User ID "NOTEXIST" and presses Enter
+THEN the system displays "User ID NOT found..."
+  AND the cursor is positioned on the User ID field
+```
+
+### Scenario 4: Empty User ID on lookup
+
+```gherkin
+GIVEN an admin user is on the User Delete screen (COUSR3A)
+  AND the User ID field is empty
+WHEN the admin presses Enter
+THEN the system displays "User ID can NOT be empty..."
+  AND the cursor is positioned on the User ID field
+```
+
+### Scenario 5: Empty User ID on delete attempt
+
+```gherkin
+GIVEN an admin user is on the User Delete screen (COUSR3A)
+  AND the User ID field is empty
+WHEN the admin presses PF5
+THEN the system displays "User ID can NOT be empty..."
+  AND the cursor is positioned on the User ID field
+  AND no deletion is performed
+```
+
+### Scenario 6: User deleted between lookup and delete
+
+```gherkin
+GIVEN an admin user has looked up User ID "USER0001" on the delete screen
+  AND another admin deletes "USER0001" before this admin presses PF5
+WHEN the admin presses PF5
+THEN the system attempts to read the record
+  AND displays "User ID NOT found..."
+  AND no deletion is performed
+```
+
+### Scenario 7: Pre-populated User ID from User List
+
+```gherkin
+GIVEN an admin user selected User ID "USER0001" for deletion from the User List (COUSR00C)
+WHEN the User Delete screen (COUSR3A) is first displayed
+THEN the User ID field is pre-populated with "USER0001"
+  AND the system automatically looks up and displays the user's details
+```
+
+### Scenario 8: PF4 clears all fields
+
+```gherkin
+GIVEN an admin user is on the User Delete screen (COUSR3A)
+  AND user details are displayed
+WHEN the admin presses PF4
+THEN all input fields are cleared to spaces
+  AND the cursor is positioned on the User ID field
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FFFS 2014:5 | Ch. 6 | User access deprovisioning | Provides formal process for removing user access from the system |
+| DORA | Art. 9 | ICT access control — revocation of access rights | Supports timely removal of user accounts when access is no longer required |
+| GDPR | Art. 17 | Right to erasure | Provides mechanism to delete user data, supporting data subject erasure requests |
+| GDPR | Art. 5(1)(e) | Storage limitation — data kept no longer than necessary | Hard-delete removes the record entirely, ensuring data is not retained beyond its purpose |
+
+## Edge Cases
+
+1. **Hard delete with no soft-delete option**: The deletion is permanent — the VSAM record is physically removed via CICS DELETE. There is no soft-delete, recycle bin, or undo capability. The migrated system should consider implementing soft-delete (status flag) with a configurable retention period before physical deletion, to allow recovery from accidental deletions and to comply with audit trail requirements.
+
+2. **No deletion confirmation dialog**: The two-step pattern (lookup then PF5) serves as the confirmation mechanism. However, there is no explicit "Are you sure?" prompt. The migrated system should implement a confirmation dialog for destructive operations.
+
+3. **Password not displayed on delete screen**: Unlike the update screen, the delete screen does not display the password field. This is a security-conscious design choice — the password is not needed for deletion review. The migrated system should follow this pattern.
+
+4. **Error message bug — "Unable to Update User..."**: The DELETE-USER-SEC-FILE paragraph's WHEN OTHER error handler displays "Unable to Update User..." instead of "Unable to Delete User...". This is a copy-paste bug from COUSR02C. The migrated system should use the correct error message.
+
+5. **No cascade delete**: Deleting a user from the USRSEC file does not cascade to any related records (e.g., transaction history, audit logs). The migrated system must consider referential integrity — should user deletion cascade, or should it be blocked if the user has associated records?
+
+6. **No self-deletion prevention**: An admin user can delete their own account. The migrated system should prevent self-deletion or at minimum require a second admin to approve.
+
+7. **No "last admin" protection**: There is no check to prevent deleting the last remaining admin user, which would lock everyone out of admin functions. The migrated system should enforce that at least one admin account must remain active.
+
+8. **READ with UPDATE for delete**: The program reads with UPDATE intent before DELETE, which is the correct CICS pattern (the DELETE operates on the last READ UPDATE record). This ensures the record is locked during the delete operation.
+
+## Domain Expert Notes
+
+- **Pending**: No domain expert review yet. Key questions for validation:
+  - Should user deletion be a hard delete or soft delete (deactivation)?
+  - Are there regulatory retention requirements that prevent immediate deletion of user records?
+  - Should deletion require approval from a second admin (dual-control)?
+  - What happens to transactions or audit records associated with a deleted user?
+  - Should the system prevent deletion of the last admin account?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/user-security/index.md
+++ b/docs-site/docs/business-rules/user-security/index.md
@@ -1,0 +1,121 @@
+---
+title: "User/Security Domain — Business Rules"
+domain: "user-security"
+status: "extracted"
+cobol_programs:
+  - "COSGN00C.cbl"
+  - "COADM01C.cbl"
+  - "COUSR00C.cbl"
+  - "COUSR01C.cbl"
+  - "COUSR02C.cbl"
+  - "COUSR03C.cbl"
+copybooks:
+  - "CSUSR01Y.cpy"
+  - "COADM02Y.cpy"
+  - "COMEN02Y.cpy"
+---
+
+# User/Security Domain — Business Rules
+
+## Overview
+
+The User/Security domain covers authentication, authorization, admin functions, and user lifecycle management (CRUD) in the CardDemo application. These programs manage access control for the entire system — no other program can be reached without first passing through the sign-on gate (COSGN00C).
+
+**Regulatory scope**: PSD2 Strong Customer Authentication (SCA), GDPR (user data handling), DORA Art. 9 (ICT access control), FFFS 2014:5 Ch. 6 (IT security).
+
+## COBOL Program Inventory
+
+| Program | Transaction ID | Function | Business Rules |
+|---------|---------------|----------|----------------|
+| COSGN00C.cbl | CC00 | Sign-on / Authentication | USEC-BR-001, USEC-BR-002, USEC-BR-003 |
+| COADM01C.cbl | CA00 | Admin Menu | USEC-BR-004 |
+| COUSR00C.cbl | CU00 | User List | USEC-BR-005 |
+| COUSR01C.cbl | CU01 | User Add | USEC-BR-006 |
+| COUSR02C.cbl | CU02 | User Update | USEC-BR-007 |
+| COUSR03C.cbl | CU03 | User Delete | USEC-BR-008 |
+
+## Extracted Business Rules
+
+| Rule ID | Title | Source Program | Priority | Status |
+|---------|-------|---------------|----------|--------|
+| [USEC-BR-001](USEC-BR-001.md) | User authentication via credential validation against USRSEC file | COSGN00C.cbl:108-257 | Critical | Extracted |
+| [USEC-BR-002](USEC-BR-002.md) | User type-based authorization routing after authentication | COSGN00C.cbl:230-240 | Critical | Extracted |
+| [USEC-BR-003](USEC-BR-003.md) | Session validation via COMMAREA presence check | COSGN00C.cbl:80-96 | Critical | Extracted |
+| [USEC-BR-004](USEC-BR-004.md) | Admin menu access control and option routing | COADM01C.cbl:119-158 | High | Extracted |
+| [USEC-BR-005](USEC-BR-005.md) | User list display with pagination from USRSEC file | COUSR00C.cbl:149-332 | High | Extracted |
+| [USEC-BR-006](USEC-BR-006.md) | User creation with required field validation and duplicate detection | COUSR01C.cbl:115-274 | High | Extracted |
+| [USEC-BR-007](USEC-BR-007.md) | User update with field-level change detection and rewrite | COUSR02C.cbl:115-274 | High | Extracted |
+| [USEC-BR-008](USEC-BR-008.md) | User deletion with read-before-delete confirmation pattern | COUSR03C.cbl:115-250 | High | Extracted |
+
+## Key Data Structures
+
+### USRSEC File (CSUSR01Y.cpy)
+
+The USRSEC VSAM KSDS file stores all user credentials and roles. Key structure:
+
+| Field | PIC | Length | Description |
+|-------|-----|--------|-------------|
+| SEC-USR-ID | X(08) | 8 | User ID (primary key) |
+| SEC-USR-FNAME | X(20) | 20 | First name |
+| SEC-USR-LNAME | X(20) | 20 | Last name |
+| SEC-USR-PWD | X(08) | 8 | Password (plaintext) |
+| SEC-USR-TYPE | X(01) | 1 | User type ('A' = Admin, 'U' = User) |
+| SEC-USR-FILLER | X(23) | 23 | Reserved filler |
+
+**Total record length**: 80 bytes
+
+### COMMAREA Session Context (COCOM01Y.cpy)
+
+Session state carried between programs via CICS COMMAREA:
+
+| Field | Description |
+|-------|-------------|
+| CDEMO-USER-ID | Authenticated user ID |
+| CDEMO-USER-TYPE | User type ('A'/'U') with 88-level conditions |
+| CDEMO-FROM-TRANID | Originating transaction ID |
+| CDEMO-FROM-PROGRAM | Originating program name |
+| CDEMO-PGM-CONTEXT | Program context counter |
+| CDEMO-PGM-REENTER | Re-entry flag (first display vs. input processing) |
+
+## Regulatory Traceability Summary
+
+| Regulation | Article | Rules Mapped | Coverage |
+|------------|---------|-------------|----------|
+| PSD2 | Art. 97 — SCA | USEC-BR-001, USEC-BR-002, USEC-BR-003, USEC-BR-006 | Authentication, authorization, session management, credential provisioning |
+| FFFS 2014:5 | Ch. 6 — IT Security | USEC-BR-001 through USEC-BR-008 | All user/security operations |
+| DORA | Art. 9 — ICT Access Control | USEC-BR-001 through USEC-BR-008 | Access control lifecycle (provision, modify, revoke, monitor) |
+| GDPR | Art. 5, 16, 17, 32 | USEC-BR-005, USEC-BR-006, USEC-BR-007, USEC-BR-008 | Data minimisation, accuracy, rectification, erasure |
+
+## Migration Gaps Identified
+
+The following security gaps must be addressed in the .NET 8 migration:
+
+1. **Single-factor authentication**: COBOL system uses password-only auth. PSD2 requires at least two independent factors (SCA). The migrated system must implement MFA.
+2. **Plaintext passwords**: Passwords stored and compared in plaintext (PIC X(08)). Must use bcrypt/Argon2 hashing.
+3. **No account lockout**: Unlimited login attempts allowed. Must implement lockout/rate limiting.
+4. **No session timeout**: CICS pseudo-conversational pattern has no expiry. Must implement configurable session timeouts.
+5. **No audit trail**: User CRUD operations are not logged. Must implement comprehensive audit logging per DORA Art. 9.
+6. **Case-insensitive passwords**: FUNCTION UPPER-CASE applied to passwords. Must enforce case-sensitive passwords.
+7. **No password complexity**: No validation of password strength. Must enforce complexity policies.
+8. **Binary role model**: Only 'A' (Admin) and 'U' (User) roles. Should implement granular RBAC.
+9. **No per-operation authorization**: Admin menu doesn't check granular permissions. Must implement per-endpoint authorization.
+10. **No self-deletion/last-admin protection**: Admin can delete own account or last admin. Must add safeguards.
+11. **PF3 auto-save on update**: Non-standard UX — exit saves changes. Must clarify save-on-exit behavior.
+12. **Error message bug**: Delete screen shows "Unable to Update User..." — copy-paste error from update program.
+
+## Domain Expert Questions (Pending Validation)
+
+1. Is the case-insensitive password behavior intentional or a mainframe limitation?
+2. Are there external authentication systems (RACF, ACF2, Top Secret) supplementing USRSEC auth?
+3. What is the current operational password rotation policy?
+4. Should MFA be required from day one of migration?
+5. Can an admin user also perform regular user operations?
+6. Should user deletion be hard-delete or soft-delete (deactivation)?
+7. Are there regulatory retention requirements preventing immediate user record deletion?
+8. Should privilege escalation (U -> A) require additional authorization?
+
+---
+
+**Extraction date:** 2026-02-15
+**Template version:** 1.0
+**Total COBOL lines analyzed:** ~2,315 (6 programs) + 189 (3 copybooks)


### PR DESCRIPTION
## Summary
- Extracted 8 business rules (USEC-BR-001 through USEC-BR-008) from 6 COBOL programs covering the User/Security domain
- Rules cover authentication (COSGN00C), authorization routing, session management, admin menu, user CRUD operations (COUSR00C-03C)
- Each rule includes COBOL source references, GIVEN/WHEN/THEN acceptance criteria, and regulatory traceability (PSD2, GDPR, DORA, FFFS 2014:5)

## Changes
- `docs-site/docs/business-rules/user-security/USEC-BR-001.md` — Authentication via USRSEC credential validation
- `docs-site/docs/business-rules/user-security/USEC-BR-002.md` — User type-based authorization routing
- `docs-site/docs/business-rules/user-security/USEC-BR-003.md` — Session validation via COMMAREA
- `docs-site/docs/business-rules/user-security/USEC-BR-004.md` — Admin menu access control
- `docs-site/docs/business-rules/user-security/USEC-BR-005.md` — User list with pagination
- `docs-site/docs/business-rules/user-security/USEC-BR-006.md` — User creation with validation
- `docs-site/docs/business-rules/user-security/USEC-BR-007.md` — User update with change detection
- `docs-site/docs/business-rules/user-security/USEC-BR-008.md` — User deletion with confirmation
- `docs-site/docs/business-rules/user-security/index.md` — Domain index with rule inventory, data structures, regulatory traceability, and migration gaps

## Testing
- [x] All COBOL source code snippets verified against actual source at aws-samples/aws-mainframe-modernization-carddemo
- [x] All copybook structures (CSUSR01Y, COADM02Y, COMEN02Y, COCOM01Y) verified
- [x] YAML front matter complete with status: extracted on all documents
- [x] GIVEN/WHEN/THEN acceptance criteria present on all rules
- [x] Regulatory mapping (PSD2, GDPR, DORA, FFFS) complete on all rules

Closes #13

🤖 Generated with Claude Code