### PR TITLE
docs(#14): Extract Billing domain business rules from COBOL

### DIFF
--- a/cobol-source/batch/CBSTM03A.CBL
+++ b/cobol-source/batch/CBSTM03A.CBL
@@ -1,0 +1,924 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID.    CBSTM03A.
+       AUTHOR.        AWS.
+      ******************************************************************
+      * Program     : CBSTM03A.CBL
+      * Application : CardDemo
+      * Type        : BATCH COBOL Program
+      * Function    : Print Account Statements from Transaction data
+      *               in two formats : 1/plain text and 2/HTML
+      ******************************************************************
+      * Copyright Amazon.com, Inc. or its affiliates.
+      * All Rights Reserved.
+      *
+      * Licensed under the Apache License, Version 2.0 (the "License").
+      * You may not use this file except in compliance with the License.
+      * You may obtain a copy of the License at
+      *
+      *    http://www.apache.org/licenses/LICENSE-2.0
+      *
+      * Unless required by applicable law or agreed to in writing,
+      * software distributed under the License is distributed on an
+      * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+      * either express or implied. See the License for the specific
+      * language governing permissions and limitations under the License
+      ******************************************************************
+      * This program is to create statement based on the data in
+      * transaction file. The following features are excercised
+      * to help create excercise modernization tooling
+      ******************************************************************
+      *  1. Mainframe Control block addressing
+      *  2. Alter and GO TO statements
+      *  3. COMP and COMP-3 variables
+      *  4. 2 dimensional array
+      *  5. Call to Subroutine
+      ******************************************************************
+       ENVIRONMENT DIVISION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT STMT-FILE ASSIGN TO STMTFILE.
+           SELECT HTML-FILE ASSIGN TO HTMLFILE.
+      *
+       DATA DIVISION.
+       FILE SECTION.
+       FD  STMT-FILE.
+       01  FD-STMTFILE-REC         PIC X(80).
+       FD  HTML-FILE.
+       01  FD-HTMLFILE-REC         PIC X(100).
+
+       WORKING-STORAGE SECTION.
+
+       COPY COSTM01.
+
+       COPY CVACT03Y.
+
+       COPY CUSTREC.
+
+       COPY CVACT01Y.
+
+       01  COMP-VARIABLES          COMP.
+           05  CR-CNT              PIC S9(4) VALUE 0.
+           05  TR-CNT              PIC S9(4) VALUE 0.
+           05  CR-JMP              PIC S9(4) VALUE 0.
+           05  TR-JMP              PIC S9(4) VALUE 0.
+       01  COMP3-VARIABLES         COMP-3.
+           05  WS-TOTAL-AMT        PIC S9(9)V99 VALUE 0.
+       01  MISC-VARIABLES.
+           05  WS-FL-DD            PIC X(8) VALUE 'TRNXFILE'.
+           05  WS-TRN-AMT          PIC S9(9)V99 VALUE 0.
+           05  WS-SAVE-CARD VALUE SPACES PIC X(16).
+           05  END-OF-FILE         PIC X(01) VALUE 'N'.
+       01  WS-M03B-AREA.
+           05  WS-M03B-DD          PIC X(08).
+           05  WS-M03B-OPER        PIC X(01).
+             88  M03B-OPEN       VALUE 'O'.
+             88  M03B-CLOSE      VALUE 'C'.
+             88  M03B-READ       VALUE 'R'.
+             88  M03B-READ-K     VALUE 'K'.
+             88  M03B-WRITE      VALUE 'W'.
+             88  M03B-REWRITE    VALUE 'Z'.
+           05  WS-M03B-RC          PIC X(02).
+           05  WS-M03B-KEY         PIC X(25).
+           05  WS-M03B-KEY-LN      PIC S9(4).
+           05  WS-M03B-FLDT        PIC X(1000).
+
+       01  STATEMENT-LINES.
+           05  ST-LINE0.
+               10  FILLER  VALUE ALL '*'                PIC X(31).
+               10  FILLER  VALUE ALL 'START OF STATEMENT' PIC X(18).
+               10  FILLER  VALUE ALL '*'                PIC X(31).
+           05  ST-LINE1.
+               10  ST-NAME                              PIC X(75).
+               10  FILLER  VALUE SPACES                 PIC X(05).
+           05  ST-LINE2.
+               10  ST-ADD1                              PIC X(50).
+               10  FILLER  VALUE SPACES                 PIC X(30).
+           05  ST-LINE3.
+               10  ST-ADD2                              PIC X(50).
+               10  FILLER  VALUE SPACES                 PIC X(30).
+           05  ST-LINE4.
+               10  ST-ADD3                              PIC X(80).
+           05  ST-LINE5.
+               10  FILLER  VALUE ALL '-'                PIC X(80).
+           05  ST-LINE6.
+               10  FILLER  VALUE SPACES                 PIC X(33).
+               10  FILLER  VALUE 'Basic Details'        PIC X(14).
+               10  FILLER  VALUE SPACES                 PIC X(33).
+           05  ST-LINE7.
+               10  FILLER  VALUE 'Account ID         :' PIC X(20).
+               10  ST-ACCT-ID                           PIC X(20).
+               10  FILLER  VALUE SPACES                 PIC X(40).
+           05  ST-LINE8.
+               10  FILLER  VALUE 'Current Balance    :' PIC X(20).
+               10  ST-CURR-BAL                          PIC 9(9).99-.
+               10  FILLER  VALUE SPACES                 PIC X(07).
+               10  FILLER  VALUE SPACES                 PIC X(40).
+           05  ST-LINE9.
+               10  FILLER  VALUE 'FICO Score         :' PIC X(20).
+               10  ST-FICO-SCORE                        PIC X(20).
+               10  FILLER  VALUE SPACES                 PIC X(40).
+           05  ST-LINE10.
+               10  FILLER  VALUE ALL '-'                PIC X(80).
+           05  ST-LINE11.
+               10  FILLER  VALUE SPACES                 PIC X(30).
+               10  FILLER  VALUE 'TRANSACTION SUMMARY ' PIC X(20).
+               10  FILLER  VALUE SPACES                 PIC X(30).
+           05  ST-LINE12.
+               10  FILLER  VALUE ALL '-'                PIC X(80).
+           05  ST-LINE13.
+               10  FILLER  VALUE 'Tran ID         '     PIC X(16).
+               10  FILLER  VALUE 'Tran Details    '     PIC X(51).
+               10  FILLER  VALUE '  Tran Amount'        PIC X(13).
+           05  ST-LINE14.
+               10  ST-TRANID                            PIC X(16).
+               10  FILLER            VALUE ' '          PIC X(01).
+               10  ST-TRANDT                            PIC X(49).
+               10  FILLER            VALUE '$'          PIC X(01).
+               10  ST-TRANAMT                           PIC Z(9).99-.
+           05  ST-LINE14A.
+               10  FILLER            VALUE 'Total EXP:' PIC X(10).
+               10  FILLER            VALUE SPACES       PIC X(56).
+               10  FILLER            VALUE '$'          PIC X(01).
+               10  ST-TOTAL-TRAMT                       PIC Z(9).99-.
+           05  ST-LINE15.
+               10  FILLER  VALUE ALL '*'                PIC X(32).
+               10  FILLER  VALUE ALL 'END OF STATEMENT' PIC X(16).
+               10  FILLER  VALUE ALL '*'                PIC X(32).
+
+       01  HTML-LINES.
+           05  HTML-FIXED-LN        PIC X(100).
+             88  HTML-L01 VALUE '<!DOCTYPE html>'.
+             88  HTML-L02 VALUE '<html lang="en">'.
+             88  HTML-L03 VALUE '<head>'.
+             88  HTML-L04 VALUE '<meta charset="utf-8">'.
+             88  HTML-L05 VALUE '<title>HTML Table Layout</title>'.
+             88  HTML-L06 VALUE '</head>'.
+             88  HTML-L07 VALUE '<body style="margin:0px;">'.
+             88  HTML-L08 VALUE '<table  align="center" frame="box" styl
+      -             'e="width:70%; font:12px Segoe UI,sans-serif;">'.
+             88  HTML-LTRS VALUE '<tr>'.
+             88  HTML-LTRE VALUE '</tr>'.
+             88  HTML-LTDS VALUE '<td>'.
+             88  HTML-LTDE VALUE '</td>'.
+             88  HTML-L10 VALUE '<td colspan="3" style="padding:0px 5px;
+      -             'background-color:#1d1d96b3;">'.
+             88  HTML-L15 VALUE '<td colspan="3" style="padding:0px 5px;
+      -             'background-color:#FFAF33;">'.
+             88  HTML-L16
+               VALUE '<p style="font-size:16px">Bank of XYZ</p>'.
+             88  HTML-L17
+               VALUE '<p>410 Terry Ave N</p>'.
+             88  HTML-L18
+               VALUE '<p>Seattle WA 99999</p>'.
+             88  HTML-L22-35
+                          VALUE '<td colspan="3" style="padding:0px 5px;
+      -              'background-color:#f2f2f2;">'.
+             88  HTML-L30-42
+                          VALUE '<td colspan="3" style="padding:0px 5px;
+      -              'background-color:#33FFD1; text-align:center;">'.
+             88  HTML-L31
+               VALUE '<p style="font-size:16px">Basic Details</p>'.
+             88  HTML-L43
+              VALUE '<p style="font-size:16px">Transaction Summary</p>'.
+             88  HTML-L47
+               VALUE '<td style="width:25%; padding:0px 5px; background-
+      -              'color:#33FF5E; text-align:left;">'.
+             88  HTML-L48
+               VALUE '<p style="font-size:16px">Tran ID</p>'.
+             88  HTML-L50
+               VALUE '<td style="width:55%; padding:0px 5px; background-
+      -              'color:#33FF5E; text-align:left;">'.
+             88  HTML-L51
+               VALUE '<p style="font-size:16px">Tran Details</p>'.
+             88  HTML-L53
+               VALUE '<td style="width:20%; padding:0px 5px; background-
+      -              'color:#33FF5E; text-align:right;">'.
+             88  HTML-L54
+               VALUE '<p style="font-size:16px">Amount</p>'.
+             88  HTML-L58
+               VALUE '<td style="width:25%; padding:0px 5px; background-
+      -              'color:#f2f2f2; text-align:left;">'.
+             88  HTML-L61
+               VALUE '<td style="width:55%; padding:0px 5px; background-
+      -              'color:#f2f2f2; text-align:left;">'.
+             88  HTML-L64
+               VALUE '<td style="width:20%; padding:0px 5px; background-
+      -              'color:#f2f2f2; text-align:right;">'.
+             88  HTML-L75
+               VALUE '<h3>End of Statement</h3>'.
+             88  HTML-L78 VALUE '</table>'.
+             88  HTML-L79 VALUE '</body>'.
+             88  HTML-L80 VALUE '</html>'.
+           05  HTML-L11.
+               10  FILLER   PIC X(34)
+                          VALUE '<h3>Statement for Account Number: '.
+               10  L11-ACCT PIC X(20).
+               10  FILLER   PIC X(05) VALUE '</h3>'.
+           05  HTML-L23.
+               10  FILLER   PIC X(26)
+                          VALUE '<p style="font-size:16px">'.
+               10  L23-NAME PIC X(50).
+           05  HTML-ADDR-LN PIC X(100).
+           05  HTML-BSIC-LN PIC X(100).
+           05  HTML-TRAN-LN PIC X(100).
+
+       01  WS-TRNX-TABLE.
+           05  WS-CARD-TBL OCCURS 51 TIMES.
+               10  WS-CARD-NUM                          PIC X(16).
+               10  WS-TRAN-TBL OCCURS 10 TIMES.
+                   15  WS-TRAN-NUM                      PIC X(16).
+                   15  WS-TRAN-REST                     PIC X(318).
+       01  WS-TRN-TBL-CNTR.
+           05  WS-TRN-TBL-CTR OCCURS 51 TIMES.
+               10  WS-TRCT               PIC S9(4) COMP.
+
+       01  PSAPTR                  POINTER.
+       01  BUMP-TIOT               PIC S9(08) BINARY VALUE ZERO.
+       01  TIOT-INDEX              REDEFINES BUMP-TIOT POINTER.
+
+       LINKAGE SECTION.
+       01  ALIGN-PSA        PIC 9(16) BINARY.
+       01  PSA-BLOCK.
+           05  FILLER       PIC X(536).
+           05  TCB-POINT    POINTER.
+       01  TCB-BLOCK.
+           05  FILLER       PIC X(12).
+           05  TIOT-POINT   POINTER.
+       01  TIOT-BLOCK.
+           05  TIOTNJOB     PIC X(08).
+           05  TIOTJSTP     PIC X(08).
+           05  TIOTPSTP     PIC X(08).
+       01  TIOT-ENTRY.
+           05  TIOT-SEG.
+               10  TIO-LEN  PIC X(01).
+               10  FILLER   PIC X(03).
+               10  TIOCDDNM PIC X(08).
+               10  FILLER   PIC X(05).
+               10  UCB-ADDR PIC X(03).
+                   88 NULL-UCB    VALUES LOW-VALUES.
+           05  FILLER       PIC X(04).
+             88  END-OF-TIOT      VALUE LOW-VALUES.
+      *****************************************************************
+       PROCEDURE DIVISION.
+      *****************************************************************
+      *    Check Unit Control blocks                                  *
+      *****************************************************************
+           SET ADDRESS OF PSA-BLOCK   TO PSAPTR.
+           SET ADDRESS OF TCB-BLOCK   TO TCB-POINT.
+           SET ADDRESS OF TIOT-BLOCK  TO TIOT-POINT.
+           SET TIOT-INDEX             TO TIOT-POINT.
+           DISPLAY 'Running JCL : ' TIOTNJOB ' Step ' TIOTJSTP.
+
+           COMPUTE BUMP-TIOT = BUMP-TIOT + LENGTH OF TIOT-BLOCK.
+           SET ADDRESS OF TIOT-ENTRY  TO TIOT-INDEX.
+
+           DISPLAY 'DD Names from TIOT: '.
+           PERFORM UNTIL END-OF-TIOT
+                      OR TIO-LEN = LOW-VALUES
+               IF NOT NULL-UCB
+                   DISPLAY ': ' TIOCDDNM ' -- valid UCB'
+               ELSE
+                   DISPLAY ': ' TIOCDDNM ' --  null UCB'
+               END-IF
+               COMPUTE BUMP-TIOT = BUMP-TIOT + LENGTH OF TIOT-SEG
+               SET ADDRESS OF TIOT-ENTRY TO TIOT-INDEX
+           END-PERFORM.
+
+           IF NOT NULL-UCB
+               DISPLAY ': ' TIOCDDNM ' -- valid UCB'
+           ELSE
+               DISPLAY ': ' TIOCDDNM ' -- null  UCB'
+           END-IF.
+
+           OPEN OUTPUT STMT-FILE HTML-FILE.
+           INITIALIZE WS-TRNX-TABLE WS-TRN-TBL-CNTR.
+
+       0000-START.
+
+           EVALUATE WS-FL-DD
+             WHEN 'TRNXFILE'
+               ALTER 8100-FILE-OPEN TO PROCEED TO 8100-TRNXFILE-OPEN
+               GO TO 8100-FILE-OPEN
+             WHEN 'XREFFILE'
+               ALTER 8100-FILE-OPEN TO PROCEED TO 8200-XREFFILE-OPEN
+               GO TO 8100-FILE-OPEN
+             WHEN 'CUSTFILE'
+               ALTER 8100-FILE-OPEN TO PROCEED TO 8300-CUSTFILE-OPEN
+               GO TO 8100-FILE-OPEN
+             WHEN 'ACCTFILE'
+               ALTER 8100-FILE-OPEN TO PROCEED TO 8400-ACCTFILE-OPEN
+               GO TO 8100-FILE-OPEN
+             WHEN 'READTRNX'
+               GO TO 8500-READTRNX-READ
+             WHEN OTHER
+               GO TO 9999-GOBACK.
+
+       1000-MAINLINE.
+           PERFORM UNTIL END-OF-FILE = 'Y'
+               IF  END-OF-FILE = 'N'
+                   PERFORM 1000-XREFFILE-GET-NEXT
+                   IF  END-OF-FILE = 'N'
+                       PERFORM 2000-CUSTFILE-GET
+                       PERFORM 3000-ACCTFILE-GET
+                       PERFORM 5000-CREATE-STATEMENT
+                       MOVE 1 TO CR-JMP
+                       MOVE ZERO TO WS-TOTAL-AMT
+                       PERFORM 4000-TRNXFILE-GET
+                   END-IF
+               END-IF
+           END-PERFORM.
+
+           PERFORM 9100-TRNXFILE-CLOSE.
+
+           PERFORM 9200-XREFFILE-CLOSE.
+
+           PERFORM 9300-CUSTFILE-CLOSE.
+
+           PERFORM 9400-ACCTFILE-CLOSE.
+
+           CLOSE STMT-FILE HTML-FILE.
+
+       9999-GOBACK.
+           GOBACK.
+
+      *---------------------------------------------------------------*
+       1000-XREFFILE-GET-NEXT.
+
+           MOVE 'XREFFILE' TO WS-M03B-DD.
+           SET M03B-READ TO TRUE.
+           MOVE ZERO TO WS-M03B-RC.
+           MOVE SPACES TO WS-M03B-FLDT.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           EVALUATE WS-M03B-RC
+             WHEN '00'
+               CONTINUE
+             WHEN '10'
+               MOVE 'Y' TO END-OF-FILE
+             WHEN OTHER
+               DISPLAY 'ERROR READING XREFFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-EVALUATE.
+
+           MOVE WS-M03B-FLDT TO CARD-XREF-RECORD.
+
+           EXIT.
+
+       2000-CUSTFILE-GET.
+
+           MOVE 'CUSTFILE' TO WS-M03B-DD.
+           SET M03B-READ-K TO TRUE.
+           MOVE XREF-CUST-ID TO WS-M03B-KEY.
+           MOVE ZERO TO WS-M03B-KEY-LN.
+           COMPUTE WS-M03B-KEY-LN = LENGTH OF XREF-CUST-ID.
+           MOVE ZERO TO WS-M03B-RC.
+           MOVE SPACES TO WS-M03B-FLDT.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           EVALUATE WS-M03B-RC
+             WHEN '00'
+               CONTINUE
+             WHEN OTHER
+               DISPLAY 'ERROR READING CUSTFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-EVALUATE.
+
+           MOVE WS-M03B-FLDT TO CUSTOMER-RECORD.
+
+           EXIT.
+
+       3000-ACCTFILE-GET.
+
+           MOVE 'ACCTFILE' TO WS-M03B-DD.
+           SET M03B-READ-K TO TRUE.
+           MOVE XREF-ACCT-ID TO WS-M03B-KEY.
+           MOVE ZERO TO WS-M03B-KEY-LN.
+           COMPUTE WS-M03B-KEY-LN = LENGTH OF XREF-ACCT-ID.
+           MOVE ZERO TO WS-M03B-RC.
+           MOVE SPACES TO WS-M03B-FLDT.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           EVALUATE WS-M03B-RC
+             WHEN '00'
+               CONTINUE
+             WHEN OTHER
+               DISPLAY 'ERROR READING ACCTFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-EVALUATE.
+
+           MOVE WS-M03B-FLDT TO ACCOUNT-RECORD.
+
+           EXIT.
+
+       4000-TRNXFILE-GET.
+           PERFORM VARYING CR-JMP FROM 1 BY 1
+             UNTIL CR-JMP > CR-CNT
+             OR (WS-CARD-NUM (CR-JMP) > XREF-CARD-NUM)
+               IF XREF-CARD-NUM = WS-CARD-NUM (CR-JMP)
+                   MOVE WS-CARD-NUM (CR-JMP) TO TRNX-CARD-NUM
+                   PERFORM VARYING TR-JMP FROM 1 BY 1
+                     UNTIL (TR-JMP > WS-TRCT (CR-JMP))
+                       MOVE WS-TRAN-NUM (CR-JMP, TR-JMP)
+                         TO TRNX-ID
+                       MOVE WS-TRAN-REST (CR-JMP, TR-JMP)
+                         TO TRNX-REST
+                       PERFORM 6000-WRITE-TRANS
+                       ADD TRNX-AMT TO WS-TOTAL-AMT
+                   END-PERFORM
+               END-IF
+           END-PERFORM.
+           MOVE WS-TOTAL-AMT TO WS-TRN-AMT.
+           MOVE WS-TRN-AMT TO ST-TOTAL-TRAMT.
+           WRITE FD-STMTFILE-REC FROM ST-LINE12.
+           WRITE FD-STMTFILE-REC FROM ST-LINE14A.
+           WRITE FD-STMTFILE-REC FROM ST-LINE15.
+
+           SET HTML-LTRS TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L10 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L75 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L78 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L79 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L80 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+
+           EXIT.
+      *---------------------------------------------------------------*
+       5000-CREATE-STATEMENT.
+           INITIALIZE STATEMENT-LINES.
+           WRITE FD-STMTFILE-REC FROM ST-LINE0.
+           PERFORM 5100-WRITE-HTML-HEADER THRU 5100-EXIT.
+           STRING CUST-FIRST-NAME DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  CUST-MIDDLE-NAME DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  CUST-LAST-NAME DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  INTO ST-NAME
+           END-STRING.
+           MOVE CUST-ADDR-LINE-1 TO ST-ADD1.
+           MOVE CUST-ADDR-LINE-2 TO ST-ADD2.
+           STRING CUST-ADDR-LINE-3 DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  CUST-ADDR-STATE-CD DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  CUST-ADDR-COUNTRY-CD DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  CUST-ADDR-ZIP DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  INTO ST-ADD3
+           END-STRING.
+
+           MOVE ACCT-ID TO ST-ACCT-ID.
+           MOVE ACCT-CURR-BAL TO ST-CURR-BAL.
+           MOVE CUST-FICO-CREDIT-SCORE TO ST-FICO-SCORE.
+           PERFORM 5200-WRITE-HTML-NMADBS THRU 5200-EXIT.
+
+           WRITE FD-STMTFILE-REC FROM ST-LINE1.
+           WRITE FD-STMTFILE-REC FROM ST-LINE2.
+           WRITE FD-STMTFILE-REC FROM ST-LINE3.
+           WRITE FD-STMTFILE-REC FROM ST-LINE4.
+           WRITE FD-STMTFILE-REC FROM ST-LINE5.
+           WRITE FD-STMTFILE-REC FROM ST-LINE6.
+           WRITE FD-STMTFILE-REC FROM ST-LINE5.
+           WRITE FD-STMTFILE-REC FROM ST-LINE7.
+           WRITE FD-STMTFILE-REC FROM ST-LINE8.
+           WRITE FD-STMTFILE-REC FROM ST-LINE9.
+           WRITE FD-STMTFILE-REC FROM ST-LINE10.
+           WRITE FD-STMTFILE-REC FROM ST-LINE11.
+           WRITE FD-STMTFILE-REC FROM ST-LINE12.
+           WRITE FD-STMTFILE-REC FROM ST-LINE13.
+           WRITE FD-STMTFILE-REC FROM ST-LINE12.
+
+           EXIT.
+
+       5100-WRITE-HTML-HEADER.
+
+           SET HTML-L01 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L02 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L03 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L04 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L05 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L06 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L07 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L08 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRS TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L10 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+
+           MOVE ACCT-ID TO L11-ACCT.
+           WRITE FD-HTMLFILE-REC FROM HTML-L11.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRS TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L15 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L16 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L17 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L18 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRS TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L22-35 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+
+       5100-EXIT.
+           EXIT.
+
+      *---------------------------------------------------------------*
+       5200-WRITE-HTML-NMADBS.
+
+           MOVE ST-NAME TO L23-NAME.
+           MOVE SPACES TO FD-HTMLFILE-REC
+           STRING '<p style="font-size:16px">' DELIMITED BY '*'
+                  L23-NAME DELIMITED BY '  '
+                  '  ' DELIMITED BY SIZE
+                  '</p>' DELIMITED BY '*'
+                  INTO FD-HTMLFILE-REC
+           END-STRING.
+           WRITE FD-HTMLFILE-REC.
+           MOVE SPACES TO HTML-ADDR-LN.
+           STRING '<p>' DELIMITED BY '*'
+                  ST-ADD1 DELIMITED BY '  '
+                  '  ' DELIMITED BY SIZE
+                  '</p>' DELIMITED BY '*'
+                  INTO HTML-ADDR-LN
+           END-STRING.
+           WRITE FD-HTMLFILE-REC FROM HTML-ADDR-LN.
+           MOVE SPACES TO HTML-ADDR-LN.
+           STRING '<p>' DELIMITED BY '*'
+                  ST-ADD2 DELIMITED BY '  '
+                  '  ' DELIMITED BY SIZE
+                  '</p>' DELIMITED BY '*'
+                  INTO HTML-ADDR-LN
+           END-STRING.
+           WRITE FD-HTMLFILE-REC FROM HTML-ADDR-LN.
+           MOVE SPACES TO HTML-ADDR-LN.
+           STRING '<p>' DELIMITED BY '*'
+                  ST-ADD3 DELIMITED BY '  '
+                  '  ' DELIMITED BY SIZE
+                  '</p>' DELIMITED BY '*'
+                  INTO HTML-ADDR-LN
+           END-STRING.
+           WRITE FD-HTMLFILE-REC FROM HTML-ADDR-LN.
+
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRS TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L30-42 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L31 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRS TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L22-35 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+
+           MOVE SPACES TO HTML-BSIC-LN.
+           STRING '<p>Account ID         : ' DELIMITED BY '*'
+                  ST-ACCT-ID DELIMITED BY '*'
+                  '</p>' DELIMITED BY '*'
+                  INTO HTML-BSIC-LN
+           END-STRING.
+           WRITE FD-HTMLFILE-REC FROM HTML-BSIC-LN.
+           MOVE SPACES TO HTML-BSIC-LN.
+           STRING '<p>Current Balance    : ' DELIMITED BY '*'
+                  ST-CURR-BAL DELIMITED BY '*'
+                  '</p>' DELIMITED BY '*'
+                  INTO HTML-BSIC-LN
+           END-STRING.
+           WRITE FD-HTMLFILE-REC FROM HTML-BSIC-LN.
+           MOVE SPACES TO HTML-BSIC-LN.
+           STRING '<p>FICO Score         : ' DELIMITED BY '*'
+                  ST-FICO-SCORE DELIMITED BY '*'
+                  '</p>' DELIMITED BY '*'
+                  INTO HTML-BSIC-LN
+           END-STRING.
+           WRITE FD-HTMLFILE-REC FROM HTML-BSIC-LN.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRS TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L30-42 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L43 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRS TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L47 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L48 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L50 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L51 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L53 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-L54 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           SET HTML-LTRE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+
+       5200-EXIT.
+           EXIT.
+
+      *---------------------------------------------------------------*
+       6000-WRITE-TRANS.
+           MOVE TRNX-ID TO ST-TRANID.
+           MOVE TRNX-DESC TO ST-TRANDT.
+           MOVE TRNX-AMT TO ST-TRANAMT.
+           WRITE FD-STMTFILE-REC FROM ST-LINE14.
+
+           SET HTML-LTRS TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+
+           SET HTML-L58 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           MOVE SPACES TO HTML-TRAN-LN.
+           STRING '<p>' DELIMITED BY '*'
+                  ST-TRANID DELIMITED BY '*'
+                  '</p>' DELIMITED BY '*'
+                  INTO HTML-TRAN-LN
+           END-STRING.
+           WRITE FD-HTMLFILE-REC FROM HTML-TRAN-LN.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+
+           SET HTML-L61 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           MOVE SPACES TO HTML-TRAN-LN.
+           STRING '<p>' DELIMITED BY '*'
+                  ST-TRANDT DELIMITED BY '*'
+                  '</p>' DELIMITED BY '*'
+                  INTO HTML-TRAN-LN
+           END-STRING.
+           WRITE FD-HTMLFILE-REC FROM HTML-TRAN-LN.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+
+           SET HTML-L64 TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+           MOVE SPACES TO HTML-TRAN-LN.
+           STRING '<p>' DELIMITED BY '*'
+                  ST-TRANAMT DELIMITED BY '*'
+                  '</p>' DELIMITED BY '*'
+                  INTO HTML-TRAN-LN
+           END-STRING.
+           WRITE FD-HTMLFILE-REC FROM HTML-TRAN-LN.
+           SET HTML-LTDE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+
+           SET HTML-LTRE TO TRUE.
+           WRITE FD-HTMLFILE-REC FROM HTML-FIXED-LN.
+
+           EXIT.
+
+      *---------------------------------------------------------------*
+       8100-FILE-OPEN.
+           GO TO 8100-TRNXFILE-OPEN
+           .
+
+       8100-TRNXFILE-OPEN.
+           MOVE 'TRNXFILE' TO WS-M03B-DD.
+           SET M03B-OPEN TO TRUE.
+           MOVE ZERO TO WS-M03B-RC.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           IF WS-M03B-RC = '00' OR '04'
+               CONTINUE
+           ELSE
+               DISPLAY 'ERROR OPENING TRNXFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-IF.
+
+           SET M03B-READ TO TRUE.
+           MOVE SPACES TO WS-M03B-FLDT.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           IF WS-M03B-RC = '00' OR '04'
+               CONTINUE
+           ELSE
+               DISPLAY 'ERROR READING TRNXFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-IF.
+
+           MOVE WS-M03B-FLDT TO TRNX-RECORD.
+           MOVE TRNX-CARD-NUM TO WS-SAVE-CARD.
+           MOVE 1 TO CR-CNT.
+           MOVE 0 TO TR-CNT.
+           MOVE 'READTRNX' TO WS-FL-DD.
+           GO TO 0000-START.
+           EXIT.
+
+      *---------------------------------------------------------------*
+       8200-XREFFILE-OPEN.
+           MOVE 'XREFFILE' TO WS-M03B-DD.
+           SET M03B-OPEN TO TRUE.
+           MOVE ZERO TO WS-M03B-RC.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           IF WS-M03B-RC = '00' OR '04'
+               CONTINUE
+           ELSE
+               DISPLAY 'ERROR OPENING XREFFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-IF.
+
+           MOVE 'CUSTFILE' TO WS-FL-DD.
+           GO TO 0000-START.
+           EXIT.
+      *---------------------------------------------------------------*
+       8300-CUSTFILE-OPEN.
+           MOVE 'CUSTFILE' TO WS-M03B-DD.
+           SET M03B-OPEN TO TRUE.
+           MOVE ZERO TO WS-M03B-RC.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           IF WS-M03B-RC = '00' OR '04'
+               CONTINUE
+           ELSE
+               DISPLAY 'ERROR OPENING CUSTFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-IF.
+
+           MOVE 'ACCTFILE' TO WS-FL-DD.
+           GO TO 0000-START.
+           EXIT.
+      *---------------------------------------------------------------*
+       8400-ACCTFILE-OPEN.
+           MOVE 'ACCTFILE' TO WS-M03B-DD.
+           SET M03B-OPEN TO TRUE.
+           MOVE ZERO TO WS-M03B-RC.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           IF WS-M03B-RC = '00' OR '04'
+               CONTINUE
+           ELSE
+               DISPLAY 'ERROR OPENING ACCTFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-IF.
+
+           GO TO 1000-MAINLINE.
+           EXIT.
+      *---------------------------------------------------------------*
+       8500-READTRNX-READ.
+           IF WS-SAVE-CARD = TRNX-CARD-NUM
+               ADD 1 TO TR-CNT
+           ELSE
+               MOVE TR-CNT TO WS-TRCT (CR-CNT)
+               ADD 1 TO CR-CNT
+               MOVE 1 TO TR-CNT
+           END-IF.
+
+           MOVE TRNX-CARD-NUM TO WS-CARD-NUM (CR-CNT).
+           MOVE TRNX-ID TO WS-TRAN-NUM (CR-CNT, TR-CNT).
+           MOVE TRNX-REST TO WS-TRAN-REST (CR-CNT, TR-CNT).
+           MOVE TRNX-CARD-NUM TO WS-SAVE-CARD.
+
+           MOVE 'TRNXFILE' TO WS-M03B-DD.
+           SET M03B-READ TO TRUE.
+           MOVE SPACES TO WS-M03B-FLDT.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           EVALUATE WS-M03B-RC
+             WHEN '00'
+               MOVE WS-M03B-FLDT TO TRNX-RECORD
+               GO TO 8500-READTRNX-READ
+             WHEN '10'
+               GO TO 8599-EXIT
+             WHEN OTHER
+               DISPLAY 'ERROR READING TRNXFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-EVALUATE.
+
+       8599-EXIT.
+           MOVE TR-CNT TO WS-TRCT (CR-CNT).
+           MOVE 'XREFFILE' TO WS-FL-DD.
+           GO TO 0000-START.
+           EXIT.
+
+      *---------------------------------------------------------------*
+       9100-TRNXFILE-CLOSE.
+           MOVE 'TRNXFILE' TO WS-M03B-DD.
+           SET M03B-CLOSE TO TRUE.
+           MOVE ZERO TO WS-M03B-RC.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           IF WS-M03B-RC = '00' OR '04'
+               CONTINUE
+           ELSE
+               DISPLAY 'ERROR CLOSING TRNXFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-IF.
+
+           EXIT.
+
+      *---------------------------------------------------------------*
+       9200-XREFFILE-CLOSE.
+           MOVE 'XREFFILE' TO WS-M03B-DD.
+           SET M03B-CLOSE TO TRUE.
+           MOVE ZERO TO WS-M03B-RC.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           IF WS-M03B-RC = '00' OR '04'
+               CONTINUE
+           ELSE
+               DISPLAY 'ERROR CLOSING XREFFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-IF.
+
+           EXIT.
+      *---------------------------------------------------------------*
+       9300-CUSTFILE-CLOSE.
+           MOVE 'CUSTFILE' TO WS-M03B-DD.
+           SET M03B-CLOSE TO TRUE.
+           MOVE ZERO TO WS-M03B-RC.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           IF WS-M03B-RC = '00' OR '04'
+               CONTINUE
+           ELSE
+               DISPLAY 'ERROR CLOSING CUSTFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-IF.
+
+           EXIT.
+      *---------------------------------------------------------------*
+       9400-ACCTFILE-CLOSE.
+           MOVE 'ACCTFILE' TO WS-M03B-DD.
+           SET M03B-CLOSE TO TRUE.
+           MOVE ZERO TO WS-M03B-RC.
+           CALL 'CBSTM03B' USING WS-M03B-AREA.
+
+           IF WS-M03B-RC = '00' OR '04'
+               CONTINUE
+           ELSE
+               DISPLAY 'ERROR CLOSING ACCTFILE'
+               DISPLAY 'RETURN CODE: ' WS-M03B-RC
+               PERFORM 9999-ABEND-PROGRAM
+           END-IF.
+
+           EXIT.
+
+       9999-ABEND-PROGRAM.
+           DISPLAY 'ABENDING PROGRAM'
+           CALL 'CEE3ABD'.
+

--- a/cobol-source/batch/CBSTM03B.CBL
+++ b/cobol-source/batch/CBSTM03B.CBL
@@ -1,0 +1,230 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID.    CBSTM03B.
+       AUTHOR.        AWS.
+      ******************************************************************
+      * Program     : CBSTM03B.CBL
+      * Application : CardDemo
+      * Type        : BATCH COBOL Subroutine
+      * Function    : Does file processing related to Transact Report
+      ******************************************************************
+      * Copyright Amazon.com, Inc. or its affiliates.
+      * All Rights Reserved.
+      *
+      * Licensed under the Apache License, Version 2.0 (the "License").
+      * You may not use this file except in compliance with the License.
+      * You may obtain a copy of the License at
+      *
+      *    http://www.apache.org/licenses/LICENSE-2.0
+      *
+      * Unless required by applicable law or agreed to in writing,
+      * software distributed under the License is distributed on an
+      * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+      * either express or implied. See the License for the specific
+      * language governing permissions and limitations under the License
+      ******************************************************************
+      * This program is to called by the statement create program
+      * It does file handling
+      ******************************************************************
+       ENVIRONMENT DIVISION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT TRNX-FILE ASSIGN TO TRNXFILE
+                  ORGANIZATION IS INDEXED
+                  ACCESS MODE  IS SEQUENTIAL
+                  RECORD KEY   IS FD-TRNXS-ID
+                  FILE STATUS  IS TRNXFILE-STATUS.
+
+           SELECT XREF-FILE ASSIGN TO   XREFFILE
+                  ORGANIZATION IS INDEXED
+                  ACCESS MODE  IS SEQUENTIAL
+                  RECORD KEY   IS FD-XREF-CARD-NUM
+                  FILE STATUS  IS XREFFILE-STATUS.
+
+           SELECT CUST-FILE ASSIGN TO CUSTFILE
+                  ORGANIZATION IS INDEXED
+                  ACCESS MODE  IS RANDOM
+                  RECORD KEY   IS FD-CUST-ID
+                  FILE STATUS  IS CUSTFILE-STATUS.
+
+           SELECT ACCT-FILE ASSIGN TO ACCTFILE
+                  ORGANIZATION IS INDEXED
+                  ACCESS MODE  IS RANDOM
+                  RECORD KEY   IS FD-ACCT-ID
+                  FILE STATUS  IS ACCTFILE-STATUS.
+
+      *
+       DATA DIVISION.
+       FILE SECTION.
+       FD  TRNX-FILE.
+       01  FD-TRNXFILE-REC.
+           05 FD-TRNXS-ID.
+              10  FD-TRNX-CARD                  PIC X(16).
+              10  FD-TRNX-ID                    PIC X(16).
+           05 FD-ACCT-DATA                      PIC X(318).
+
+       FD  XREF-FILE.
+       01  FD-XREFFILE-REC.
+           05 FD-XREF-CARD-NUM                  PIC X(16).
+           05 FD-XREF-DATA                      PIC X(34).
+
+       FD  CUST-FILE.
+       01  FD-CUSTFILE-REC.
+           05 FD-CUST-ID                        PIC X(09).
+           05 FD-CUST-DATA                      PIC X(491).
+
+       FD  ACCT-FILE.
+       01  FD-ACCTFILE-REC.
+           05 FD-ACCT-ID                        PIC 9(11).
+           05 FD-ACCT-DATA                      PIC X(289).
+
+       WORKING-STORAGE SECTION.
+
+      *****************************************************************
+       01  TRNXFILE-STATUS.
+           05  TRNXFILE-STAT1      PIC X.
+           05  TRNXFILE-STAT2      PIC X.
+
+       01  XREFFILE-STATUS.
+           05  XREFFILE-STAT1      PIC X.
+           05  XREFFILE-STAT2      PIC X.
+
+       01  CUSTFILE-STATUS.
+           05  CUSTFILE-STAT1      PIC X.
+           05  CUSTFILE-STAT2      PIC X.
+
+       01  ACCTFILE-STATUS.
+           05  ACCTFILE-STAT1      PIC X.
+           05  ACCTFILE-STAT2      PIC X.
+
+       LINKAGE SECTION.
+       01  LK-M03B-AREA.
+           05  LK-M03B-DD          PIC X(08).
+           05  LK-M03B-OPER        PIC X(01).
+             88  M03B-OPEN       VALUE 'O'.
+             88  M03B-CLOSE      VALUE 'C'.
+             88  M03B-READ       VALUE 'R'.
+             88  M03B-READ-K     VALUE 'K'.
+             88  M03B-WRITE      VALUE 'W'.
+             88  M03B-REWRITE    VALUE 'Z'.
+           05  LK-M03B-RC          PIC X(02).
+           05  LK-M03B-KEY         PIC X(25).
+           05  LK-M03B-KEY-LN      PIC S9(4).
+           05  LK-M03B-FLDT        PIC X(1000).
+
+       PROCEDURE DIVISION USING LK-M03B-AREA.
+
+       0000-START.
+
+           EVALUATE LK-M03B-DD
+             WHEN 'TRNXFILE'
+               PERFORM 1000-TRNXFILE-PROC THRU 1999-EXIT
+             WHEN 'XREFFILE'
+               PERFORM 2000-XREFFILE-PROC THRU 2999-EXIT
+             WHEN 'CUSTFILE'
+               PERFORM 3000-CUSTFILE-PROC THRU 3999-EXIT
+             WHEN 'ACCTFILE'
+               PERFORM 4000-ACCTFILE-PROC THRU 4999-EXIT
+             WHEN OTHER
+               GO TO 9999-GOBACK.
+
+       9999-GOBACK.
+           GOBACK.
+
+       1000-TRNXFILE-PROC.
+
+           IF M03B-OPEN
+               OPEN INPUT TRNX-FILE
+               GO TO 1900-EXIT
+           END-IF.
+
+           IF M03B-READ
+               READ TRNX-FILE INTO LK-M03B-FLDT
+               END-READ
+               GO TO 1900-EXIT
+           END-IF.
+
+           IF M03B-CLOSE
+               CLOSE TRNX-FILE
+               GO TO 1900-EXIT
+           END-IF.
+
+       1900-EXIT.
+           MOVE TRNXFILE-STATUS TO LK-M03B-RC.
+
+       1999-EXIT.
+           EXIT.
+
+       2000-XREFFILE-PROC.
+
+           IF M03B-OPEN
+               OPEN INPUT XREF-FILE
+               GO TO 2900-EXIT
+           END-IF.
+
+           IF M03B-READ
+               READ XREF-FILE INTO LK-M03B-FLDT
+               END-READ
+               GO TO 2900-EXIT
+           END-IF.
+
+           IF M03B-CLOSE
+               CLOSE XREF-FILE
+               GO TO 2900-EXIT
+           END-IF.
+
+       2900-EXIT.
+           MOVE XREFFILE-STATUS TO LK-M03B-RC.
+
+       2999-EXIT.
+           EXIT.
+
+       3000-CUSTFILE-PROC.
+
+           IF M03B-OPEN
+               OPEN INPUT CUST-FILE
+               GO TO 3900-EXIT
+           END-IF.
+
+           IF M03B-READ-K
+               MOVE LK-M03B-KEY (1:LK-M03B-KEY-LN) TO FD-CUST-ID
+               READ CUST-FILE INTO LK-M03B-FLDT
+               END-READ
+               GO TO 3900-EXIT
+           END-IF.
+
+           IF M03B-CLOSE
+               CLOSE CUST-FILE
+               GO TO 3900-EXIT
+           END-IF.
+
+       3900-EXIT.
+           MOVE CUSTFILE-STATUS TO LK-M03B-RC.
+
+       3999-EXIT.
+           EXIT.
+
+       4000-ACCTFILE-PROC.
+
+           IF M03B-OPEN
+               OPEN INPUT ACCT-FILE
+               GO TO 4900-EXIT
+           END-IF.
+
+           IF M03B-READ-K
+               MOVE LK-M03B-KEY (1:LK-M03B-KEY-LN) TO FD-ACCT-ID
+               READ ACCT-FILE INTO LK-M03B-FLDT
+               END-READ
+               GO TO 4900-EXIT
+           END-IF.
+
+           IF M03B-CLOSE
+               CLOSE ACCT-FILE
+               GO TO 4900-EXIT
+           END-IF.
+
+       4900-EXIT.
+           MOVE ACCTFILE-STATUS TO LK-M03B-RC.
+
+       4999-EXIT.
+           EXIT.
+

--- a/cobol-source/cics/COBIL00C.cbl
+++ b/cobol-source/cics/COBIL00C.cbl
@@ -1,0 +1,572 @@
+      ******************************************************************        
+      * Program     : COBIL00C.CBL
+      * Application : CardDemo
+      * Type        : CICS COBOL Program
+      * Function    : Bill Payment - Pay account balance in full and a
+      *               tractionsaction for the online bill payment.
+      ******************************************************************
+      * Copyright Amazon.com, Inc. or its affiliates.                   
+      * All Rights Reserved.                                            
+      *                                                                 
+      * Licensed under the Apache License, Version 2.0 (the "License"). 
+      * You may not use this file except in compliance with the License.
+      * You may obtain a copy of the License at                         
+      *                                                                 
+      *    http://www.apache.org/licenses/LICENSE-2.0                   
+      *                                                                 
+      * Unless required by applicable law or agreed to in writing,      
+      * software distributed under the License is distributed on an     
+      * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    
+      * either express or implied. See the License for the specific     
+      * language governing permissions and limitations under the License
+      ****************************************************************** 
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. COBIL00C.
+       AUTHOR.     AWS.
+
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+
+       DATA DIVISION.
+      *----------------------------------------------------------------*
+      *                     WORKING STORAGE SECTION
+      *----------------------------------------------------------------*
+       WORKING-STORAGE SECTION.
+
+       01 WS-VARIABLES.
+         05 WS-PGMNAME                 PIC X(08) VALUE 'COBIL00C'.
+         05 WS-TRANID                  PIC X(04) VALUE 'CB00'.
+         05 WS-MESSAGE                 PIC X(80) VALUE SPACES.
+         05 WS-TRANSACT-FILE           PIC X(08) VALUE 'TRANSACT'.
+         05 WS-ACCTDAT-FILE            PIC X(08) VALUE 'ACCTDAT '.
+         05 WS-CXACAIX-FILE            PIC X(08) VALUE 'CXACAIX '.
+         05 WS-ERR-FLG                 PIC X(01) VALUE 'N'.
+           88 ERR-FLG-ON                         VALUE 'Y'.
+           88 ERR-FLG-OFF                        VALUE 'N'.
+         05 WS-RESP-CD                 PIC S9(09) COMP VALUE ZEROS.
+         05 WS-REAS-CD                 PIC S9(09) COMP VALUE ZEROS.
+         05 WS-USR-MODIFIED            PIC X(01) VALUE 'N'.
+           88 USR-MODIFIED-YES                   VALUE 'Y'.
+           88 USR-MODIFIED-NO                    VALUE 'N'.
+         05 WS-CONF-PAY-FLG            PIC X(01) VALUE 'N'.
+           88 CONF-PAY-YES                       VALUE 'Y'.
+           88 CONF-PAY-NO                        VALUE 'N'.
+
+         05 WS-TRAN-AMT                PIC +99999999.99.
+         05 WS-CURR-BAL                PIC +9999999999.99.
+         05 WS-TRAN-ID-NUM             PIC 9(16) VALUE ZEROS.
+         05 WS-TRAN-DATE               PIC X(08) VALUE '00/00/00'.
+         05 WS-ABS-TIME                PIC S9(15) COMP-3 VALUE 0.
+         05 WS-CUR-DATE-X10            PIC X(10) VALUE SPACES.
+         05 WS-CUR-TIME-X08            PIC X(08) VALUE SPACES.
+
+       COPY COCOM01Y.
+          05 CDEMO-CB00-INFO.
+             10 CDEMO-CB00-TRNID-FIRST     PIC X(16).
+             10 CDEMO-CB00-TRNID-LAST      PIC X(16).
+             10 CDEMO-CB00-PAGE-NUM        PIC 9(08).
+             10 CDEMO-CB00-NEXT-PAGE-FLG   PIC X(01) VALUE 'N'.
+                88 NEXT-PAGE-YES                     VALUE 'Y'.
+                88 NEXT-PAGE-NO                      VALUE 'N'.
+             10 CDEMO-CB00-TRN-SEL-FLG     PIC X(01).
+             10 CDEMO-CB00-TRN-SELECTED    PIC X(16).
+
+       COPY COBIL00.
+
+       COPY COTTL01Y.
+       COPY CSDAT01Y.
+       COPY CSMSG01Y.
+
+       COPY CVACT01Y.
+       COPY CVACT03Y.
+       COPY CVTRA05Y.
+
+       COPY DFHAID.
+       COPY DFHBMSCA.
+
+      *----------------------------------------------------------------*
+      *                        LINKAGE SECTION
+      *----------------------------------------------------------------*
+       LINKAGE SECTION.
+       01  DFHCOMMAREA.
+         05  LK-COMMAREA                           PIC X(01)
+             OCCURS 1 TO 32767 TIMES DEPENDING ON EIBCALEN.
+
+      *----------------------------------------------------------------*
+      *                       PROCEDURE DIVISION
+      *----------------------------------------------------------------*
+       PROCEDURE DIVISION.
+       MAIN-PARA.
+
+           SET ERR-FLG-OFF     TO TRUE
+           SET USR-MODIFIED-NO TO TRUE
+
+           MOVE SPACES TO WS-MESSAGE
+                          ERRMSGO OF COBIL0AO
+
+           IF EIBCALEN = 0
+               MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+               PERFORM RETURN-TO-PREV-SCREEN
+           ELSE
+               MOVE DFHCOMMAREA(1:EIBCALEN) TO CARDDEMO-COMMAREA
+               IF NOT CDEMO-PGM-REENTER
+                   SET CDEMO-PGM-REENTER    TO TRUE
+                   MOVE LOW-VALUES          TO COBIL0AO
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   IF CDEMO-CB00-TRN-SELECTED NOT =
+                                              SPACES AND LOW-VALUES
+                       MOVE CDEMO-CB00-TRN-SELECTED TO
+                            ACTIDINI OF COBIL0AI
+                       PERFORM PROCESS-ENTER-KEY
+                   END-IF
+                   PERFORM SEND-BILLPAY-SCREEN
+               ELSE
+                   PERFORM RECEIVE-BILLPAY-SCREEN
+                   EVALUATE EIBAID
+                       WHEN DFHENTER
+                           PERFORM PROCESS-ENTER-KEY
+                       WHEN DFHPF3
+                           IF CDEMO-FROM-PROGRAM = SPACES OR LOW-VALUES
+                               MOVE 'COMEN01C' TO CDEMO-TO-PROGRAM
+                           ELSE
+                               MOVE CDEMO-FROM-PROGRAM TO
+                               CDEMO-TO-PROGRAM
+                           END-IF
+                           PERFORM RETURN-TO-PREV-SCREEN
+                       WHEN DFHPF4
+                           PERFORM CLEAR-CURRENT-SCREEN
+                       WHEN OTHER
+                           MOVE 'Y'                       TO WS-ERR-FLG
+                           MOVE CCDA-MSG-INVALID-KEY      TO WS-MESSAGE
+                           PERFORM SEND-BILLPAY-SCREEN
+                   END-EVALUATE
+               END-IF
+           END-IF
+
+           EXEC CICS RETURN
+                     TRANSID (WS-TRANID)
+                     COMMAREA (CARDDEMO-COMMAREA)
+           END-EXEC.
+
+      *----------------------------------------------------------------*
+      *                      PROCESS-ENTER-KEY
+      *----------------------------------------------------------------*
+       PROCESS-ENTER-KEY.
+
+           SET CONF-PAY-NO TO TRUE
+
+           EVALUATE TRUE
+               WHEN ACTIDINI OF COBIL0AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Acct ID can NOT be empty...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+               WHEN OTHER
+                   CONTINUE
+           END-EVALUATE
+
+           IF NOT ERR-FLG-ON
+               MOVE ACTIDINI  OF COBIL0AI TO ACCT-ID
+                                             XREF-ACCT-ID
+
+               EVALUATE CONFIRMI OF COBIL0AI
+                   WHEN 'Y'
+                   WHEN 'y'
+                       SET CONF-PAY-YES TO TRUE
+                       PERFORM READ-ACCTDAT-FILE
+                   WHEN 'N'
+                   WHEN 'n'
+                       PERFORM CLEAR-CURRENT-SCREEN
+                       MOVE 'Y'     TO WS-ERR-FLG
+                   WHEN SPACES
+                   WHEN LOW-VALUES
+                       PERFORM READ-ACCTDAT-FILE
+                   WHEN OTHER
+                       MOVE 'Y'     TO WS-ERR-FLG
+                       MOVE 'Invalid value. Valid values are (Y/N)...'
+                                    TO WS-MESSAGE
+                       MOVE -1      TO CONFIRML OF COBIL0AI
+                       PERFORM SEND-BILLPAY-SCREEN
+               END-EVALUATE
+
+               MOVE ACCT-CURR-BAL TO WS-CURR-BAL
+               MOVE WS-CURR-BAL   TO CURBALI    OF COBIL0AI
+           END-IF
+
+           IF NOT ERR-FLG-ON
+               IF ACCT-CURR-BAL <= ZEROS AND
+                  ACTIDINI OF COBIL0AI NOT = SPACES AND LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'You have nothing to pay...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+               END-IF
+           END-IF
+
+           IF NOT ERR-FLG-ON
+
+               IF CONF-PAY-YES
+                   PERFORM READ-CXACAIX-FILE
+                   MOVE HIGH-VALUES TO TRAN-ID
+                   PERFORM STARTBR-TRANSACT-FILE
+                   PERFORM READPREV-TRANSACT-FILE
+                   PERFORM ENDBR-TRANSACT-FILE
+                   MOVE TRAN-ID     TO WS-TRAN-ID-NUM
+                   ADD 1 TO WS-TRAN-ID-NUM
+                   INITIALIZE TRAN-RECORD
+                   MOVE WS-TRAN-ID-NUM       TO TRAN-ID
+                   MOVE '02'                 TO TRAN-TYPE-CD
+                   MOVE 2                    TO TRAN-CAT-CD
+                   MOVE 'POS TERM'           TO TRAN-SOURCE
+                   MOVE 'BILL PAYMENT - ONLINE' TO TRAN-DESC
+                   MOVE ACCT-CURR-BAL        TO TRAN-AMT
+                   MOVE XREF-CARD-NUM        TO TRAN-CARD-NUM
+                   MOVE 999999999            TO TRAN-MERCHANT-ID
+                   MOVE 'BILL PAYMENT'       TO TRAN-MERCHANT-NAME
+                   MOVE 'N/A'                TO TRAN-MERCHANT-CITY
+                   MOVE 'N/A'                TO TRAN-MERCHANT-ZIP
+                   PERFORM GET-CURRENT-TIMESTAMP
+                   MOVE WS-TIMESTAMP         TO TRAN-ORIG-TS
+                                                TRAN-PROC-TS
+                   PERFORM WRITE-TRANSACT-FILE
+                   COMPUTE ACCT-CURR-BAL = ACCT-CURR-BAL - TRAN-AMT
+                   PERFORM UPDATE-ACCTDAT-FILE
+               ELSE
+                   MOVE 'Confirm to make a bill payment...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO CONFIRML OF COBIL0AI
+               END-IF
+
+               PERFORM SEND-BILLPAY-SCREEN
+
+           END-IF.
+
+      *----------------------------------------------------------------*
+      *                      GET-CURRENT-TIMESTAMP
+      *----------------------------------------------------------------*
+       GET-CURRENT-TIMESTAMP.
+
+           EXEC CICS ASKTIME
+             ABSTIME(WS-ABS-TIME)
+           END-EXEC
+
+           EXEC CICS FORMATTIME
+             ABSTIME(WS-ABS-TIME)
+             YYYYMMDD(WS-CUR-DATE-X10)
+             DATESEP('-')
+             TIME(WS-CUR-TIME-X08)
+             TIMESEP(':')
+           END-EXEC
+
+           INITIALIZE WS-TIMESTAMP
+           MOVE WS-CUR-DATE-X10 TO WS-TIMESTAMP(01:10)
+           MOVE WS-CUR-TIME-X08 TO WS-TIMESTAMP(12:08)
+           MOVE ZEROS           TO WS-TIMESTAMP-TM-MS6
+           .
+
+
+      *----------------------------------------------------------------*
+      *                      RETURN-TO-PREV-SCREEN
+      *----------------------------------------------------------------*
+       RETURN-TO-PREV-SCREEN.
+
+           IF CDEMO-TO-PROGRAM = LOW-VALUES OR SPACES
+               MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+           END-IF
+           MOVE WS-TRANID    TO CDEMO-FROM-TRANID
+           MOVE WS-PGMNAME   TO CDEMO-FROM-PROGRAM
+           MOVE ZEROS        TO CDEMO-PGM-CONTEXT
+           EXEC CICS
+               XCTL PROGRAM(CDEMO-TO-PROGRAM)
+               COMMAREA(CARDDEMO-COMMAREA)
+           END-EXEC.
+
+      *----------------------------------------------------------------*
+      *                      SEND-BILLPAY-SCREEN
+      *----------------------------------------------------------------*
+       SEND-BILLPAY-SCREEN.
+
+           PERFORM POPULATE-HEADER-INFO
+
+           MOVE WS-MESSAGE TO ERRMSGO OF COBIL0AO
+
+           EXEC CICS SEND
+                     MAP('COBIL0A')
+                     MAPSET('COBIL00')
+                     FROM(COBIL0AO)
+                     ERASE
+                     CURSOR
+           END-EXEC.
+
+      *----------------------------------------------------------------*
+      *                      RECEIVE-BILLPAY-SCREEN
+      *----------------------------------------------------------------*
+       RECEIVE-BILLPAY-SCREEN.
+
+           EXEC CICS RECEIVE
+                     MAP('COBIL0A')
+                     MAPSET('COBIL00')
+                     INTO(COBIL0AI)
+                     RESP(WS-RESP-CD)
+                     RESP2(WS-REAS-CD)
+           END-EXEC.
+
+      *----------------------------------------------------------------*
+      *                      POPULATE-HEADER-INFO
+      *----------------------------------------------------------------*
+       POPULATE-HEADER-INFO.
+
+           MOVE FUNCTION CURRENT-DATE  TO WS-CURDATE-DATA
+
+           MOVE CCDA-TITLE01           TO TITLE01O OF COBIL0AO
+           MOVE CCDA-TITLE02           TO TITLE02O OF COBIL0AO
+           MOVE WS-TRANID              TO TRNNAMEO OF COBIL0AO
+           MOVE WS-PGMNAME             TO PGMNAMEO OF COBIL0AO
+
+           MOVE WS-CURDATE-MONTH       TO WS-CURDATE-MM
+           MOVE WS-CURDATE-DAY         TO WS-CURDATE-DD
+           MOVE WS-CURDATE-YEAR(3:2)   TO WS-CURDATE-YY
+
+           MOVE WS-CURDATE-MM-DD-YY    TO CURDATEO OF COBIL0AO
+
+           MOVE WS-CURTIME-HOURS       TO WS-CURTIME-HH
+           MOVE WS-CURTIME-MINUTE      TO WS-CURTIME-MM
+           MOVE WS-CURTIME-SECOND      TO WS-CURTIME-SS
+
+           MOVE WS-CURTIME-HH-MM-SS    TO CURTIMEO OF COBIL0AO.
+
+      *----------------------------------------------------------------*
+      *                      READ-ACCTDAT-FILE
+      *----------------------------------------------------------------*
+       READ-ACCTDAT-FILE.
+
+           EXEC CICS READ
+                DATASET   (WS-ACCTDAT-FILE)
+                INTO      (ACCOUNT-RECORD)
+                LENGTH    (LENGTH OF ACCOUNT-RECORD)
+                RIDFLD    (ACCT-ID)
+                KEYLENGTH (LENGTH OF ACCT-ID)
+                UPDATE
+                RESP      (WS-RESP-CD)
+                RESP2     (WS-REAS-CD)
+           END-EXEC
+
+           EVALUATE WS-RESP-CD
+               WHEN DFHRESP(NORMAL)
+                   CONTINUE
+               WHEN DFHRESP(NOTFND)
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Account ID NOT found...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+               WHEN OTHER
+                   DISPLAY 'RESP:' WS-RESP-CD 'REAS:' WS-REAS-CD
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Unable to lookup Account...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+           END-EVALUATE.
+
+      *----------------------------------------------------------------*
+      *                      UPDATE-ACCTDAT-FILE
+      *----------------------------------------------------------------*
+       UPDATE-ACCTDAT-FILE.
+
+           EXEC CICS REWRITE
+                DATASET   (WS-ACCTDAT-FILE)
+                FROM      (ACCOUNT-RECORD)
+                LENGTH    (LENGTH OF ACCOUNT-RECORD)
+                RESP      (WS-RESP-CD)
+                RESP2     (WS-REAS-CD)
+           END-EXEC
+
+           EVALUATE WS-RESP-CD
+               WHEN DFHRESP(NORMAL)
+                   CONTINUE
+               WHEN DFHRESP(NOTFND)
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Account ID NOT found...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+               WHEN OTHER
+                   DISPLAY 'RESP:' WS-RESP-CD 'REAS:' WS-REAS-CD
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Unable to Update Account...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+           END-EVALUATE.
+
+      *----------------------------------------------------------------*
+      *                      READ-CXACAIX-FILE
+      *----------------------------------------------------------------*
+       READ-CXACAIX-FILE.
+
+           EXEC CICS READ
+                DATASET   (WS-CXACAIX-FILE)
+                INTO      (CARD-XREF-RECORD)
+                LENGTH    (LENGTH OF CARD-XREF-RECORD)
+                RIDFLD    (XREF-ACCT-ID)
+                KEYLENGTH (LENGTH OF XREF-ACCT-ID)
+                RESP      (WS-RESP-CD)
+                RESP2     (WS-REAS-CD)
+           END-EXEC
+
+           EVALUATE WS-RESP-CD
+               WHEN DFHRESP(NORMAL)
+                   CONTINUE
+               WHEN DFHRESP(NOTFND)
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Account ID NOT found...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+               WHEN OTHER
+                   DISPLAY 'RESP:' WS-RESP-CD 'REAS:' WS-REAS-CD
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Unable to lookup XREF AIX file...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+           END-EVALUATE.
+
+      *----------------------------------------------------------------*
+      *                      STARTBR-TRANSACT-FILE
+      *----------------------------------------------------------------*
+       STARTBR-TRANSACT-FILE.
+
+           EXEC CICS STARTBR
+                DATASET   (WS-TRANSACT-FILE)
+                RIDFLD    (TRAN-ID)
+                KEYLENGTH (LENGTH OF TRAN-ID)
+                RESP      (WS-RESP-CD)
+                RESP2     (WS-REAS-CD)
+           END-EXEC
+
+           EVALUATE WS-RESP-CD
+               WHEN DFHRESP(NORMAL)
+                   CONTINUE
+               WHEN DFHRESP(NOTFND)
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Transaction ID NOT found...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+               WHEN OTHER
+                   DISPLAY 'RESP:' WS-RESP-CD 'REAS:' WS-REAS-CD
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Unable to lookup Transaction...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+           END-EVALUATE.
+
+      *----------------------------------------------------------------*
+      *                      READPREV-TRANSACT-FILE
+      *----------------------------------------------------------------*
+       READPREV-TRANSACT-FILE.
+
+           EXEC CICS READPREV
+                DATASET   (WS-TRANSACT-FILE)
+                INTO      (TRAN-RECORD)
+                LENGTH    (LENGTH OF TRAN-RECORD)
+                RIDFLD    (TRAN-ID)
+                KEYLENGTH (LENGTH OF TRAN-ID)
+                RESP      (WS-RESP-CD)
+                RESP2     (WS-REAS-CD)
+           END-EXEC
+
+           EVALUATE WS-RESP-CD
+               WHEN DFHRESP(NORMAL)
+                   CONTINUE
+               WHEN DFHRESP(ENDFILE)
+                   MOVE ZEROS TO TRAN-ID
+               WHEN OTHER
+                   DISPLAY 'RESP:' WS-RESP-CD 'REAS:' WS-REAS-CD
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Unable to lookup Transaction...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+           END-EVALUATE.
+
+      *----------------------------------------------------------------*
+      *                      ENDBR-TRANSACT-FILE
+      *----------------------------------------------------------------*
+       ENDBR-TRANSACT-FILE.
+
+           EXEC CICS ENDBR
+                DATASET   (WS-TRANSACT-FILE)
+           END-EXEC.
+
+      *----------------------------------------------------------------*
+      *                      WRITE-TRANSACT-FILE
+      *----------------------------------------------------------------*
+       WRITE-TRANSACT-FILE.
+
+           EXEC CICS WRITE
+                DATASET   (WS-TRANSACT-FILE)
+                FROM      (TRAN-RECORD)
+                LENGTH    (LENGTH OF TRAN-RECORD)
+                RIDFLD    (TRAN-ID)
+                KEYLENGTH (LENGTH OF TRAN-ID)
+                RESP      (WS-RESP-CD)
+                RESP2     (WS-REAS-CD)
+           END-EXEC
+
+           EVALUATE WS-RESP-CD
+               WHEN DFHRESP(NORMAL)
+                   PERFORM INITIALIZE-ALL-FIELDS
+                   MOVE SPACES             TO WS-MESSAGE
+                   MOVE DFHGREEN           TO ERRMSGC  OF COBIL0AO
+                   STRING 'Payment successful. '     DELIMITED BY SIZE
+                     ' Your Transaction ID is ' DELIMITED BY SIZE
+                          TRAN-ID  DELIMITED BY SPACE
+                          '.' DELIMITED BY SIZE
+                     INTO WS-MESSAGE
+                   PERFORM SEND-BILLPAY-SCREEN
+               WHEN DFHRESP(DUPKEY)
+               WHEN DFHRESP(DUPREC)
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Tran ID already exist...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+               WHEN OTHER
+                   DISPLAY 'RESP:' WS-RESP-CD 'REAS:' WS-REAS-CD
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Unable to Add Bill pay Transaction...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+           END-EVALUATE.
+
+      *----------------------------------------------------------------*
+      *                      CLEAR-CURRENT-SCREEN
+      *----------------------------------------------------------------*
+       CLEAR-CURRENT-SCREEN.
+
+           PERFORM INITIALIZE-ALL-FIELDS
+           PERFORM SEND-BILLPAY-SCREEN.
+
+      *----------------------------------------------------------------*
+      *                      INITIALIZE-ALL-FIELDS
+      *----------------------------------------------------------------*
+       INITIALIZE-ALL-FIELDS.
+
+           MOVE -1              TO ACTIDINL OF COBIL0AI
+           MOVE SPACES          TO ACTIDINI OF COBIL0AI
+                                   CURBALI  OF COBIL0AI
+                                   CONFIRMI OF COBIL0AI
+                                   WS-MESSAGE.
+
+
+
+      *
+      * Ver: CardDemo_v1.0-15-g27d6c6f-68 Date: 2022-07-19 23:12:32 CDT
+      *

--- a/cobol-source/copybooks/COSTM01.CPY
+++ b/cobol-source/copybooks/COSTM01.CPY
@@ -1,0 +1,38 @@
+      ******************************************************************
+      * CardDemo - Transaction altered Layout for use in reporting
+      ******************************************************************
+      * Copyright Amazon.com, Inc. or its affiliates.
+      * All Rights Reserved.
+      *
+      * Licensed under the Apache License, Version 2.0 (the "License").
+      * You may not use this file except in compliance with the License.
+      * You may obtain a copy of the License at
+      *
+      *    http://www.apache.org/licenses/LICENSE-2.0
+      *
+      * Unless required by applicable law or agreed to in writing,
+      * software distributed under the License is distributed on an
+      * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+      * either express or implied. See the License for the specific
+      * language governing permissions and limitations under the License
+      ******************************************************************
+      *
+       01  TRNX-RECORD.
+           05  TRNX-KEY.
+               10  TRNX-CARD-NUM                       PIC X(16).
+               10  TRNX-ID                             PIC X(16).
+           05  TRNX-REST.
+               10  TRNX-TYPE-CD                        PIC X(02).
+               10  TRNX-CAT-CD                         PIC 9(04).
+               10  TRNX-SOURCE                         PIC X(10).
+               10  TRNX-DESC                           PIC X(100).
+               10  TRNX-AMT                            PIC S9(09)V99.
+               10  TRNX-MERCHANT-ID                    PIC 9(09).
+               10  TRNX-MERCHANT-NAME                  PIC X(50).
+               10  TRNX-MERCHANT-CITY                  PIC X(50).
+               10  TRNX-MERCHANT-ZIP                   PIC X(10).
+               10  TRNX-ORIG-TS                        PIC X(26).
+               10  TRNX-PROC-TS                        PIC X(26).
+               10  FILLER                              PIC X(20).
+
+

--- a/cobol-source/jcl/CREASTMT.JCL
+++ b/cobol-source/jcl/CREASTMT.JCL
@@ -1,0 +1,97 @@
+//CREASTMT JOB 'Create Statement',CLASS=A,MSGCLASS=H,MSGLEVEL=(1,1),
+//         NOTIFY=&SYSUID,TIME=1440
+//******************************************************************
+//* Copyright Amazon.com, Inc. or its affiliates.
+//* All Rights Reserved.
+//*
+//* Licensed under the Apache License, Version 2.0 (the "License").
+//* You may not use this file except in compliance with the License.
+//* You may obtain a copy of the License at
+//*
+//*    http://www.apache.org/licenses/LICENSE-2.0
+//*
+//* Unless required by applicable law or agreed to in writing,
+//* software distributed under the License is distributed on an
+//* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//* either express or implied. See the License for the specific
+//* language governing permissions and limitations under the License
+//******************************************************************
+//* This JCL will create statement for each CARD present in the XREF
+//* file
+//******************************************************************
+//DELDEF01 EXEC PGM=IDCAMS
+//SYSPRINT DD  SYSOUT=*
+//SYSIN    DD  *
+  DELETE    AWS.M2.CARDDEMO.TRXFL.SEQ
+  DELETE    AWS.M2.CARDDEMO.TRXFL.VSAM.KSDS                     -
+            CLUSTER
+  SET       MAXCC = 0
+  DEFINE    CLUSTER  (NAME(AWS.M2.CARDDEMO.TRXFL.VSAM.KSDS)     -
+                      KEYS(32 0)                                -
+                      VOLUMES(TSU023)                           -
+                      RECORDSIZE(350 350)                       -
+                      SHAREOPTIONS(2 3)                         -
+                      ERASE                                     -
+                      INDEXED                                   -
+                      CYL(1 5))                                 -
+            DATA      (NAME(AWS.M2.CARDDEMO.TRXFL.DATA)         -
+                      CISZ(4096))                               -
+            INDEX     (NAME(AWS.M2.CARDDEMO.TRXFL.INDEX))
+/*
+//*********************************************************************
+//* CREATE COPY OF TRANSACT FILE WITH CARD NUMBER AND TRAN ID AS KEY
+//*********************************************************************
+//STEP010  EXEC PGM=SORT
+//SORTIN   DD  DISP=SHR,DSN=AWS.M2.CARDDEMO.TRANSACT.VSAM.KSDS
+//SYSPRINT DD  SYSOUT=*
+//SYSOUT   DD  SYSOUT=*
+//SORTOUT  DD  DSN=AWS.M2.CARDDEMO.TRXFL.SEQ,
+//             DISP=(NEW,CATLG,DELETE),UNIT=SYSDA,
+//             DCB=(LRECL=350,BLKSIZE=3500,RECFM=FB),
+//             SPACE=(CYL,(1,1),RLSE)
+//SYSIN    DD *
+  SORT FIELDS=(263,16,CH,A,1,16,CH,A)
+  OUTREC FIELDS=(1:263,16,17:1,262,279:279,50)
+/*
+//STEP020  EXEC PGM=IDCAMS,COND=(0,NE)
+//SYSPRINT DD  SYSOUT=*
+//INFILE   DD  DISP=SHR,DSN=AWS.M2.CARDDEMO.TRXFL.SEQ
+//OUTFILE  DD  DISP=SHR,DSN=AWS.M2.CARDDEMO.TRXFL.VSAM.KSDS
+//SYSIN    DD  *
+  REPRO INFILE(INFILE) OUTFILE(OUTFILE)
+/*
+//*********************************************************************
+//* DELETE TRANSACTION REPORTS FROM PREVIOUS RUN
+//*********************************************************************
+//STEP030  EXEC PGM=IEFBR14,COND=(0,NE)
+//HTMLFILE DD DISP=(MOD,DELETE,DELETE),
+//         UNIT=SYSDA,
+//         DCB=(LRECL=80,BLKSIZE=3200,RECFM=FB),
+//         SPACE=(CYL,(1,1),RLSE),
+//         DSN=AWS.M2.CARDDEMO.STATEMNT.HTML
+//STMTFILE DD DISP=(MOD,DELETE,DELETE),
+//         DCB=(LRECL=80,BLKSIZE=8000,RECFM=FB),
+//         SPACE=(CYL,(1,1),RLSE),
+//         DSN=AWS.M2.CARDDEMO.STATEMNT.PS
+//*********************************************************************
+//* PRODUCING REPORT IN TEXT AND HTML - DEMONSTRATES CALLED SUBROUTINE
+//*********************************************************************
+//STEP040  EXEC PGM=CBSTM03A,COND=(0,NE)
+//STEPLIB  DD  DISP=SHR,DSN=AWS.M2.CARDDEMO.LOADLIB
+//SYSPRINT DD  SYSOUT=*
+//SYSOUT   DD  SYSOUT=*
+//TRNXFILE DD  DISP=SHR,DSN=AWS.M2.CARDDEMO.TRXFL.VSAM.KSDS
+//XREFFILE DD  DISP=SHR,DSN=AWS.M2.CARDDEMO.CARDXREF.VSAM.KSDS
+//ACCTFILE DD  DISP=SHR,DSN=AWS.M2.CARDDEMO.ACCTDATA.VSAM.KSDS
+//CUSTFILE DD  DISP=SHR,DSN=AWS.M2.CARDDEMO.CUSTDATA.VSAM.KSDS
+//STMTFILE DD DISP=(NEW,CATLG,DELETE),
+//         UNIT=SYSDA,
+//         DCB=(LRECL=80,BLKSIZE=8000,RECFM=FB),
+//         SPACE=(CYL,(1,1),RLSE), 00,RECFM=FB), ATA.VSAM.KSDS
+//         DSN=AWS.M2.CARDDEMO.STATEMNT.PS
+//HTMLFILE DD  DISP=(NEW,CATLG,DELETE),
+//         UNIT=SYSDA,
+//         DCB=(LRECL=100,BLKSIZE=800,RECFM=FB),
+//         SPACE=(CYL,(1,1),RLSE),
+//         DSN=AWS.M2.CARDDEMO.STATEMNT.HTML
+//*

--- a/cobol-source/jcl/INTCALC.jcl
+++ b/cobol-source/jcl/INTCALC.jcl
@@ -1,0 +1,44 @@
+//INTCALC JOB 'INTEREST CALCULATOR',CLASS=A,MSGCLASS=0,
+//   NOTIFY=&SYSUID           
+//******************************************************************
+//* Copyright Amazon.com, Inc. or its affiliates.                   
+//* All Rights Reserved.                                            
+//*                                                                 
+//* Licensed under the Apache License, Version 2.0 (the "License"). 
+//* You may not use this file except in compliance with the License.
+//* You may obtain a copy of the License at                         
+//*                                                                 
+//*    http://www.apache.org/licenses/LICENSE-2.0                   
+//*                                                                 
+//* Unless required by applicable law or agreed to in writing,      
+//* software distributed under the License is distributed on an     
+//* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    
+//* either express or implied. See the License for the specific     
+//* language governing permissions and limitations under the License
+//******************************************************************
+//* *******************************************************************         
+//* Process transaction balance file and compute interest and fees.
+//* *******************************************************************         
+//STEP15 EXEC PGM=CBACT04C,PARM='2022071800'                                    
+//STEPLIB  DD DISP=SHR,                                                         
+//            DSN=AWS.M2.CARDDEMO.LOADLIB                                       
+//SYSPRINT DD SYSOUT=*                                                          
+//SYSOUT   DD SYSOUT=*       
+//TCATBALF DD DISP=SHR,                                                         
+//         DSN=AWS.M2.CARDDEMO.TCATBALF.VSAM.KSDS      
+//XREFFILE DD DISP=SHR,                                                         
+//         DSN=AWS.M2.CARDDEMO.CARDXREF.VSAM.KSDS    
+//XREFFIL1 DD DISP=SHR,                                                         
+//         DSN=AWS.M2.CARDDEMO.CARDXREF.VSAM.AIX.PATH    
+//ACCTFILE DD DISP=SHR,                                                         
+//         DSN=AWS.M2.CARDDEMO.ACCTDATA.VSAM.KSDS                               
+//DISCGRP  DD DISP=SHR,                                                         
+//         DSN=AWS.M2.CARDDEMO.DISCGRP.VSAM.KSDS                                
+//TRANSACT DD DISP=(NEW,CATLG,DELETE),                                          
+//         UNIT=SYSDA,                                                          
+//         DCB=(RECFM=F,LRECL=350,BLKSIZE=0),                                   
+//         SPACE=(CYL,(1,1),RLSE),                                              
+//         DSN=AWS.M2.CARDDEMO.SYSTRAN(+1)           
+//*
+//* Ver: CardDemo_v1.0-15-g27d6c6f-68 Date: 2022-07-19 23:23:06 CDT
+//*

--- a/docs-site/docs/business-rules/billing/BILL-BR-001.md
+++ b/docs-site/docs/business-rules/billing/BILL-BR-001.md
@@ -1,0 +1,291 @@
+---
+id: "BILL-BR-001"
+title: "Online bill payment pays full current balance and creates transaction record"
+domain: "billing"
+cobol_source: "COBIL00C.cbl:98-244"
+requirement_id: "BILL-BR-001"
+regulations:
+  - "PSD2 Art. 64 — Receipt of Payment Orders"
+  - "PSD2 Art. 78 — Amounts Transferred and Received"
+  - "FFFS 2014:5 Ch. 6 — Payment Services"
+  - "GDPR Art. 5(1)(e) — Storage Limitation"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# BILL-BR-001: Online bill payment pays full current balance and creates transaction record
+
+## Summary
+
+The online bill payment function (COBIL00C) allows a user to pay the full current balance of a credit card account. The user enters an account ID, the system looks up the current balance, and upon confirmation creates a payment transaction record for the full balance amount. The account balance is then reduced by the payment amount (set to zero). Partial payments are not supported — the system always pays the entire current balance.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PROCESS-ENTER-KEY:
+    IF account-id IS EMPTY OR SPACES THEN
+        SET error = 'Acct ID can NOT be empty...'
+        EXIT with error
+    END-IF
+
+    EVALUATE confirmation-field:
+        WHEN 'Y' or 'y':
+            SET confirmed = TRUE
+            PERFORM READ-ACCTDAT-FILE
+        WHEN 'N' or 'n':
+            CLEAR screen
+            SET error flag
+        WHEN SPACES or LOW-VALUES:
+            PERFORM READ-ACCTDAT-FILE (initial lookup, no confirmation yet)
+        WHEN OTHER:
+            SET error = 'Invalid value. Valid values are (Y/N)...'
+            EXIT with error
+    END-EVALUATE
+
+    DISPLAY current-balance on screen
+
+    IF account-current-balance <= ZERO THEN
+        SET error = 'You have nothing to pay...'
+        EXIT with error
+    END-IF
+
+    IF confirmed = TRUE THEN
+        READ cross-reference file (CXACAIX) to get card number
+        BROWSE transaction file from HIGH-VALUES (end)
+        READ PREVIOUS to get last transaction ID
+        NEW-TRAN-ID = last-transaction-id + 1
+
+        INITIALIZE transaction-record:
+            TRAN-ID       = new sequential ID
+            TRAN-TYPE-CD  = '02'
+            TRAN-CAT-CD   = 2
+            TRAN-SOURCE   = 'POS TERM'
+            TRAN-DESC     = 'BILL PAYMENT - ONLINE'
+            TRAN-AMT      = account-current-balance (full amount)
+            TRAN-CARD-NUM = card number from xref
+            TRAN-MERCHANT-ID   = 999999999
+            TRAN-MERCHANT-NAME = 'BILL PAYMENT'
+            TRAN-MERCHANT-CITY = 'N/A'
+            TRAN-MERCHANT-ZIP  = 'N/A'
+            TRAN-ORIG-TS  = current timestamp
+            TRAN-PROC-TS  = current timestamp
+
+        WRITE transaction-record to TRANSACT file
+        COMPUTE account-current-balance = account-current-balance - payment-amount
+        REWRITE account record (balance now zero)
+        DISPLAY 'Payment successful. Your Transaction ID is <id>.'
+    ELSE
+        DISPLAY 'Confirm to make a bill payment...'
+    END-IF
+```
+
+### Decision Table
+
+| Acct ID Provided | Confirmation | Balance > 0 | Account Found | Xref Found | Outcome |
+|------------------|-------------|-------------|---------------|------------|---------|
+| No (empty) | — | — | — | — | Error: 'Acct ID can NOT be empty...' |
+| Yes | Invalid value | — | — | — | Error: 'Invalid value. Valid values are (Y/N)...' |
+| Yes | N/n | — | — | — | Screen cleared, error flag set |
+| Yes | Blank (initial) | — | No | — | Error: 'Account ID NOT found...' |
+| Yes | Blank (initial) | <= 0 | Yes | — | Error: 'You have nothing to pay...' |
+| Yes | Blank (initial) | > 0 | Yes | — | Display balance, prompt for confirmation |
+| Yes | Y/y | > 0 | Yes | No | Error: 'Account ID NOT found...' (xref lookup) |
+| Yes | Y/y | > 0 | Yes | Yes | Payment processed, balance set to zero |
+
+## Source COBOL Reference
+
+**Program:** `COBIL00C.cbl`
+**Lines:** 98-244 (MAIN-PARA through PROCESS-ENTER-KEY)
+
+```cobol
+       PROCESS-ENTER-KEY.
+
+           SET CONF-PAY-NO TO TRUE
+
+           EVALUATE TRUE
+               WHEN ACTIDINI OF COBIL0AI = SPACES OR LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'Acct ID can NOT be empty...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+               WHEN OTHER
+                   CONTINUE
+           END-EVALUATE
+```
+
+```cobol
+           IF NOT ERR-FLG-ON
+               IF ACCT-CURR-BAL <= ZEROS AND
+                  ACTIDINI OF COBIL0AI NOT = SPACES AND LOW-VALUES
+                   MOVE 'Y'     TO WS-ERR-FLG
+                   MOVE 'You have nothing to pay...' TO
+                                   WS-MESSAGE
+                   MOVE -1       TO ACTIDINL OF COBIL0AI
+                   PERFORM SEND-BILLPAY-SCREEN
+               END-IF
+           END-IF
+```
+
+```cobol
+               IF CONF-PAY-YES
+                   PERFORM READ-CXACAIX-FILE
+                   MOVE HIGH-VALUES TO TRAN-ID
+                   PERFORM STARTBR-TRANSACT-FILE
+                   PERFORM READPREV-TRANSACT-FILE
+                   PERFORM ENDBR-TRANSACT-FILE
+                   MOVE TRAN-ID     TO WS-TRAN-ID-NUM
+                   ADD 1 TO WS-TRAN-ID-NUM
+                   INITIALIZE TRAN-RECORD
+                   MOVE WS-TRAN-ID-NUM       TO TRAN-ID
+                   MOVE '02'                 TO TRAN-TYPE-CD
+                   MOVE 2                    TO TRAN-CAT-CD
+                   MOVE 'POS TERM'           TO TRAN-SOURCE
+                   MOVE 'BILL PAYMENT - ONLINE' TO TRAN-DESC
+                   MOVE ACCT-CURR-BAL        TO TRAN-AMT
+                   MOVE XREF-CARD-NUM        TO TRAN-CARD-NUM
+                   MOVE 999999999            TO TRAN-MERCHANT-ID
+                   MOVE 'BILL PAYMENT'       TO TRAN-MERCHANT-NAME
+                   MOVE 'N/A'                TO TRAN-MERCHANT-CITY
+                   MOVE 'N/A'                TO TRAN-MERCHANT-ZIP
+                   PERFORM GET-CURRENT-TIMESTAMP
+                   MOVE WS-TIMESTAMP         TO TRAN-ORIG-TS
+                                                TRAN-PROC-TS
+                   PERFORM WRITE-TRANSACT-FILE
+                   COMPUTE ACCT-CURR-BAL = ACCT-CURR-BAL - TRAN-AMT
+                   PERFORM UPDATE-ACCTDAT-FILE
+```
+
+**Copybooks:** `CVACT01Y.cpy` (Account Record), `CVACT03Y.cpy` (Card Cross-Reference), `CVTRA05Y.cpy` (Transaction Record)
+
+## Acceptance Criteria
+
+### Scenario 1: Successful bill payment with confirmed full balance
+
+```gherkin
+GIVEN account "00000012345" has a current balance of $1,500.00
+  AND the cross-reference file links this account to card "1234567890123456"
+  AND the last transaction ID in the TRANSACT file is "0000000000000042"
+WHEN the user enters account ID "00000012345" and confirms with "Y"
+THEN a new transaction record is created with:
+  | Field | Value |
+  | TRAN-ID | 0000000000000043 |
+  | TRAN-TYPE-CD | 02 |
+  | TRAN-CAT-CD | 0002 |
+  | TRAN-SOURCE | POS TERM |
+  | TRAN-DESC | BILL PAYMENT - ONLINE |
+  | TRAN-AMT | 1500.00 |
+  | TRAN-CARD-NUM | 1234567890123456 |
+  | TRAN-MERCHANT-ID | 999999999 |
+  | TRAN-MERCHANT-NAME | BILL PAYMENT |
+  AND the account balance is updated to $0.00
+  AND the message "Payment successful. Your Transaction ID is 43." is displayed
+```
+
+### Scenario 2: Bill payment rejected — empty account ID
+
+```gherkin
+GIVEN the bill payment screen is displayed
+WHEN the user presses Enter with an empty account ID field
+THEN the error message "Acct ID can NOT be empty..." is displayed
+  AND the cursor is positioned on the account ID field
+  AND no file lookups are performed
+```
+
+### Scenario 3: Bill payment rejected — zero balance
+
+```gherkin
+GIVEN account "00000012345" has a current balance of $0.00
+WHEN the user enters account ID "00000012345"
+THEN the error message "You have nothing to pay..." is displayed
+  AND no transaction record is created
+```
+
+### Scenario 4: Bill payment rejected — negative balance (credit)
+
+```gherkin
+GIVEN account "00000012345" has a current balance of -$50.00 (credit)
+WHEN the user enters account ID "00000012345"
+THEN the error message "You have nothing to pay..." is displayed
+  AND no transaction record is created
+```
+
+### Scenario 5: Bill payment rejected — invalid confirmation value
+
+```gherkin
+GIVEN account "00000012345" has a current balance of $500.00
+  AND the user has entered the account ID and the balance is displayed
+WHEN the user enters "X" in the confirmation field
+THEN the error message "Invalid value. Valid values are (Y/N)..." is displayed
+  AND no transaction is processed
+```
+
+### Scenario 6: Bill payment cancelled by user
+
+```gherkin
+GIVEN account "00000012345" has a current balance of $500.00
+  AND the user has entered the account ID and the balance is displayed
+WHEN the user enters "N" in the confirmation field
+THEN the screen is cleared
+  AND no transaction is processed
+  AND no balance change occurs
+```
+
+### Scenario 7: Account not found
+
+```gherkin
+GIVEN no account record exists for account ID "99999999999"
+WHEN the user enters account ID "99999999999"
+THEN the error message "Account ID NOT found..." is displayed
+  AND no transaction is processed
+```
+
+### Scenario 8: Duplicate transaction ID
+
+```gherkin
+GIVEN a valid payment is being processed
+  AND the generated transaction ID already exists in the TRANSACT file
+WHEN the system attempts to write the transaction record
+THEN the error message "Tran ID already exist..." is displayed
+  AND the account balance is NOT updated
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 64 | Payment orders must be received and acknowledged | The system requires explicit confirmation (Y/N) before processing the payment, and returns a transaction ID as acknowledgment. |
+| PSD2 | Art. 78 | The full amount of the payment transaction shall be transferred | The system pays the full current balance — no partial deductions or fees are applied to the payment amount. |
+| FFFS 2014:5 | Ch. 6 §1-3 | Payment services must follow orderly procedures | The two-step process (display balance, confirm, then process) ensures the user sees the amount before committing. |
+| GDPR | Art. 5(1)(e) | Personal data stored only as long as necessary | Transaction records include timestamps but no unnecessary PII. Merchant fields use generic values ('BILL PAYMENT', 'N/A'). |
+
+## Edge Cases
+
+1. **Full balance payment only**: The system does not support partial payments. The `TRAN-AMT` is always set to `ACCT-CURR-BAL` (line 224). The migration must decide whether to add partial payment support or preserve the full-balance-only behavior.
+
+2. **Transaction ID generation**: New transaction IDs are generated by reading the last (highest) ID via `READPREV` from `HIGH-VALUES` and adding 1 (lines 212-217). This is sequential and not thread-safe in a concurrent environment. The migration should use a database sequence or GUID.
+
+3. **UPDATE lock on READ**: The account record is read with `UPDATE` option (line 351 of READ-ACCTDAT-FILE), which locks the record for exclusive access during the CICS transaction. This prevents concurrent modifications but could cause contention. The migration needs equivalent optimistic or pessimistic concurrency control.
+
+4. **Balance can go negative from other transactions**: While bill payment checks `ACCT-CURR-BAL <= ZEROS`, other transactions could modify the balance between the read and the payment. The CICS UPDATE lock mitigates this in the mainframe. The migration must handle race conditions.
+
+5. **Confirmation is case-insensitive**: Both 'Y'/'y' and 'N'/'n' are accepted (lines 174-180). The migration should preserve this behavior.
+
+6. **Hardcoded merchant values**: The merchant ID is `999999999`, name is `'BILL PAYMENT'`, city and zip are `'N/A'` (lines 226-229). These are sentinel values indicating a system-generated transaction rather than a merchant purchase.
+
+7. **PF3 navigation**: PF3 returns to the calling program or defaults to `COMEN01C` (main menu). PF4 clears the screen. Only Enter processes the payment.
+
+## Domain Expert Notes
+
+- **Pending validation**: This rule requires review by a domain expert familiar with the bill payment flow and transaction recording.
+- The transaction type code `'02'` with category `2` indicates an online bill payment. The migration must maintain this classification scheme for downstream reporting and interest calculation.
+- The `TRAN-ORIG-TS` and `TRAN-PROC-TS` are both set to the current timestamp (lines 231-232), meaning processing is immediate with no deferred settlement. The migration should preserve this behavior unless a new settlement model is designed.
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/billing/BILL-BR-002.md
+++ b/docs-site/docs/business-rules/billing/BILL-BR-002.md
@@ -1,0 +1,321 @@
+---
+id: "BILL-BR-002"
+title: "Monthly interest calculated per transaction category using disclosure group rates"
+domain: "billing"
+cobol_source: "CBACT04C.cbl:180-520"
+requirement_id: "BILL-BR-002"
+regulations:
+  - "FFFS 2014:5 Ch. 4 — Interest Rate Disclosure"
+  - "PSD2 Art. 45 — Information on Charges and Interest"
+  - "EBA GL 2020/06 — Interest Rate Risk"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# BILL-BR-002: Monthly interest calculated per transaction category using disclosure group rates
+
+## Summary
+
+The interest calculation batch job (CBACT04C, invoked by INTCALC.jcl) processes transaction category balance records, looks up applicable interest rates from a disclosure group file, computes monthly interest per category, accumulates the total interest per account, and updates the account balance. Interest is calculated using the formula: `monthly_interest = (category_balance * annual_interest_rate) / 1200`. A fee computation step exists but is not yet implemented in the source.
+
+## Business Logic
+
+### Interest Calculation Formula
+
+```
+monthly_interest = (transaction_category_balance * annual_interest_rate) / 1200
+```
+
+Where:
+- `transaction_category_balance` (`TRAN-CAT-BAL`): The balance for a specific transaction category (e.g., purchases, cash advances)
+- `annual_interest_rate` (`DIS-INT-RATE`): The annual percentage rate from the disclosure group file
+- `1200`: Divisor to convert annual rate to monthly (annual_rate / 12, with the rate expressed as a percentage, so effectively annual_rate_percent / 12 / 100 = annual_rate / 1200)
+
+### Precision and Data Types
+
+| Variable | COBOL Picture | Type | Precision |
+|----------|--------------|------|-----------|
+| `TRAN-CAT-BAL` | (from CVTRA01Y copybook) | Signed decimal | Depends on copybook definition |
+| `DIS-INT-RATE` | (from CVTRA02Y copybook) | Decimal | Depends on copybook definition |
+| `WS-MONTHLY-INT` | `PIC S9(09)V99` | Signed, 2 decimal places | 9 digits + 2 decimal |
+| `WS-TOTAL-INT` | `PIC S9(09)V99` | Signed, 2 decimal places | 9 digits + 2 decimal |
+| `ACCT-CURR-BAL` | (from CVACT01Y copybook) | Signed decimal | Depends on copybook definition |
+
+**Critical**: COBOL `COMPUTE` with `PIC S9(09)V99` truncates to 2 decimal places without explicit rounding. The migration must replicate this truncation behavior exactly to match mainframe output during parallel run.
+
+### Pseudocode
+
+```
+PROCEDURE DIVISION USING EXTERNAL-PARMS:
+    OPEN files: TCATBALF (input), XREFFILE (input), DISCGRP (input),
+                ACCTFILE (I-O), TRANSACT (output)
+
+    SET first-time = 'Y'
+    SET total-interest = 0
+
+    READ EACH record FROM transaction-category-balance-file:
+        IF account-id <> last-account-id THEN
+            IF NOT first-time THEN
+                PERFORM UPDATE-ACCOUNT:
+                    ADD total-interest TO account-current-balance
+                    RESET cycle-credit = 0
+                    RESET cycle-debit = 0
+                    REWRITE account record
+            ELSE
+                SET first-time = 'N'
+            END-IF
+
+            RESET total-interest = 0
+            SAVE current account-id as last-account-id
+            READ account master record (ACCTFILE) by account-id
+            READ cross-reference record (XREFFILE) by account-id
+        END-IF
+
+        LOOK UP interest rate:
+            SET disclosure-group-key = (account-group-id, tran-type-cd, tran-cat-cd)
+            READ disclosure-group-file (DISCGRP) by key
+            IF NOT FOUND (status '23') THEN
+                SET disclosure-group-key = ('DEFAULT', tran-type-cd, tran-cat-cd)
+                READ disclosure-group-file with DEFAULT group
+            END-IF
+
+        IF interest-rate <> 0 THEN
+            COMPUTE monthly-interest = (category-balance * interest-rate) / 1200
+            ADD monthly-interest TO total-interest
+            WRITE interest transaction record to TRANSACT file:
+                TRAN-TYPE-CD  = '01'
+                TRAN-CAT-CD   = '05'
+                TRAN-SOURCE   = 'System'
+                TRAN-DESC     = 'Int. for a/c <account-id>'
+                TRAN-AMT      = monthly-interest
+                TRAN-CARD-NUM = card number from xref
+                TRAN-ORIG-TS  = current timestamp
+                TRAN-PROC-TS  = current timestamp
+        END-IF
+
+    END-READ
+
+    PERFORM UPDATE-ACCOUNT for final account
+    CLOSE all files
+```
+
+### Decision Table
+
+| Category Balance Found | Group Rate Found | Default Rate Found | Rate = 0 | Outcome |
+|-----------------------|-----------------|-------------------|----------|---------|
+| Yes | Yes | — | No | Calculate interest, write transaction, accumulate |
+| Yes | Yes | — | Yes | Skip interest (no charge for this category) |
+| Yes | No (status '23') | Yes | No | Calculate using DEFAULT rate |
+| Yes | No (status '23') | Yes | Yes | Skip interest |
+| Yes | No (status '23') | No | — | ABEND: error reading default disclosure group |
+| Yes | Error (other) | — | — | ABEND: error reading disclosure group file |
+| No (EOF) | — | — | — | Update final account, close files, end |
+| Error reading | — | — | — | ABEND: error reading transaction category file |
+
+## Source COBOL Reference
+
+**Program:** `CBACT04C.cbl`
+**Lines:** 462-470 (Core interest calculation)
+
+```cobol
+       1300-COMPUTE-INTEREST.
+
+           COMPUTE WS-MONTHLY-INT
+            = ( TRAN-CAT-BAL * DIS-INT-RATE) / 1200
+
+           ADD WS-MONTHLY-INT  TO WS-TOTAL-INT
+           PERFORM 1300-B-WRITE-TX.
+
+           EXIT.
+```
+
+**Lines:** 350-370 (Account balance update)
+
+```cobol
+       1050-UPDATE-ACCOUNT.
+      * Update the balances in account record to reflect posted trans.
+           ADD WS-TOTAL-INT  TO ACCT-CURR-BAL
+           MOVE 0 TO ACCT-CURR-CYC-CREDIT
+           MOVE 0 TO ACCT-CURR-CYC-DEBIT
+
+           REWRITE FD-ACCTFILE-REC FROM  ACCOUNT-RECORD
+```
+
+**Lines:** 415-460 (Disclosure group lookup with DEFAULT fallback)
+
+```cobol
+       1200-GET-INTEREST-RATE.
+           READ DISCGRP-FILE INTO DIS-GROUP-RECORD
+                INVALID KEY
+                   DISPLAY 'DISCLOSURE GROUP RECORD MISSING'
+                   DISPLAY 'TRY WITH DEFAULT GROUP CODE'
+           END-READ.
+
+           IF  DISCGRP-STATUS  = '00'  OR '23'
+               MOVE 0 TO APPL-RESULT
+           ELSE
+               MOVE 12 TO APPL-RESULT
+           END-IF
+
+           IF  DISCGRP-STATUS  = '23'
+               MOVE 'DEFAULT' TO FD-DIS-ACCT-GROUP-ID
+               PERFORM 1200-A-GET-DEFAULT-INT-RATE
+           END-IF
+           EXIT.
+```
+
+**Lines:** 473-515 (Interest transaction record creation)
+
+```cobol
+       1300-B-WRITE-TX.
+           ADD 1 TO WS-TRANID-SUFFIX
+
+           STRING PARM-DATE,
+                  WS-TRANID-SUFFIX
+             DELIMITED BY SIZE
+             INTO TRAN-ID
+           END-STRING.
+
+           MOVE '01'                 TO TRAN-TYPE-CD
+           MOVE '05'                 TO TRAN-CAT-CD
+           MOVE 'System'             TO TRAN-SOURCE
+           STRING 'Int. for a/c ' ,
+                  ACCT-ID
+                  DELIMITED BY SIZE
+            INTO TRAN-DESC
+           END-STRING
+           MOVE WS-MONTHLY-INT       TO TRAN-AMT
+```
+
+**JCL:** `INTCALC.jcl`
+**Input Files:** TCATBALF (transaction category balances), XREFFILE (card cross-reference), ACCTFILE (account master), DISCGRP (disclosure group rates)
+**Output Files:** TRANSACT (interest transaction records), ACCTFILE (updated balances)
+
+**Copybooks:** `CVTRA01Y.cpy` (Transaction Category Balance), `CVACT03Y.cpy` (Card Cross-Reference), `CVTRA02Y.cpy` (Disclosure Group), `CVACT01Y.cpy` (Account Record), `CVTRA05Y.cpy` (Transaction Record)
+
+## Acceptance Criteria
+
+### Scenario 1: Standard monthly interest calculation
+
+```gherkin
+GIVEN a transaction category balance record for account "00000012345":
+  | Field | Value |
+  | TRANCAT-ACCT-ID | 00000012345 |
+  | TRANCAT-TYPE-CD | 01 |
+  | TRANCAT-CD | 0001 |
+  | TRAN-CAT-BAL | 5000.00 |
+  AND the disclosure group for account group "GRP001", type "01", category "0001" has:
+  | DIS-INT-RATE | 18.00 |
+WHEN the interest calculation batch runs
+THEN the monthly interest = (5000.00 * 18.00) / 1200 = 75.00
+  AND a transaction record is written with TRAN-AMT = 75.00
+  AND the account balance is increased by 75.00
+```
+
+### Scenario 2: Multiple categories for same account
+
+```gherkin
+GIVEN account "00000012345" has two transaction category balances:
+  | Category | Balance | Rate |
+  | Purchases (type 01, cat 0001) | 3000.00 | 18.00 |
+  | Cash Advances (type 02, cat 0002) | 1000.00 | 24.00 |
+WHEN the interest calculation batch runs
+THEN two interest transactions are created:
+  | Category | Monthly Interest |
+  | Purchases | (3000.00 * 18.00) / 1200 = 45.00 |
+  | Cash Advances | (1000.00 * 24.00) / 1200 = 20.00 |
+  AND the total interest added to account balance = 65.00
+```
+
+### Scenario 3: DEFAULT rate fallback
+
+```gherkin
+GIVEN a transaction category balance for account "00000012345" with group "NEWGRP"
+  AND no disclosure group record exists for group "NEWGRP", type "01", cat "0001"
+  AND a DEFAULT disclosure group record exists for type "01", cat "0001" with rate 15.00
+WHEN the interest calculation batch runs
+THEN the DEFAULT rate of 15.00 is used for the calculation
+  AND interest is computed normally using the default rate
+```
+
+### Scenario 4: Zero interest rate — no charge
+
+```gherkin
+GIVEN a transaction category balance with a balance of 2000.00
+  AND the applicable disclosure group has DIS-INT-RATE = 0
+WHEN the interest calculation batch runs
+THEN no interest transaction is created for that category
+  AND the account balance is not affected by that category
+```
+
+### Scenario 5: Account cycle counters reset
+
+```gherkin
+GIVEN account "00000012345" has:
+  | ACCT-CURR-BAL | 10000.00 |
+  | ACCT-CURR-CYC-CREDIT | 500.00 |
+  | ACCT-CURR-CYC-DEBIT | 300.00 |
+  AND the total accumulated interest for the account is 125.00
+WHEN the account balance is updated by the interest batch
+THEN ACCT-CURR-BAL = 10125.00
+  AND ACCT-CURR-CYC-CREDIT = 0
+  AND ACCT-CURR-CYC-DEBIT = 0
+```
+
+### Scenario 6: Fractional interest truncation
+
+```gherkin
+GIVEN a transaction category balance of 1234.56 with rate 17.50
+WHEN monthly interest is calculated
+THEN interest = (1234.56 * 17.50) / 1200 = 18.00 (truncated from 18.0040...)
+  AND the stored value in WS-MONTHLY-INT (PIC S9(09)V99) is 18.00
+```
+
+### Scenario 7: Batch parameter provides processing date
+
+```gherkin
+GIVEN the JCL passes parameter '2022071800' (date 2022-07-18)
+WHEN interest transactions are created
+THEN each transaction ID is formed as: '<parm-date><sequential-suffix>'
+  AND the suffix increments from 000001 for each transaction in the batch run
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FFFS 2014:5 | Ch. 4 §1-4 | Credit interest rates must be disclosed and calculated transparently | Interest rates are stored in a disclosure group file keyed by account group and transaction category, enabling auditable rate application. |
+| PSD2 | Art. 45(1) | Charges and interest applied must be disclosed | Each interest charge creates an individual transaction record with description 'Int. for a/c <id>', providing a clear audit trail. |
+| EBA GL 2020/06 | §4.3 | Interest rate risk in the banking book must be managed | The separation of rates by disclosure group and transaction category allows differential rate management. |
+
+## Edge Cases
+
+1. **COBOL truncation vs. rounding**: The COMPUTE statement with `PIC S9(09)V99` truncates to 2 decimal places. The migration must use truncation (not rounding) to match mainframe output exactly during parallel run. Example: `(1234.56 * 17.50) / 1200 = 18.004...` truncates to `18.00`, not rounds to `18.00`.
+
+2. **Fees not implemented**: The `1400-COMPUTE-FEES` paragraph (line 518) is a stub with only `EXIT`. The migration should note this as a gap — fee computation may need to be implemented as a new business requirement.
+
+3. **Transaction ID format**: Transaction IDs are composed by STRING concatenation of `PARM-DATE` (10 chars from JCL) + `WS-TRANID-SUFFIX` (6 digits). The suffix increments per transaction within a single batch run, starting from 000001. The ID format is `<date><suffix>`, giving a 16-character key.
+
+4. **Account processing order**: Records are read sequentially from TCATBALF, which is an indexed VSAM KSDS file. Records are ordered by the composite key (account-id, type-cd, cat-cd). When the account ID changes, the previous account is updated. This means the final account requires an extra update after the read loop ends (line 220-221).
+
+5. **DEFAULT rate fallback**: If the specific disclosure group record is not found (file status '23'), the system falls back to a group ID of 'DEFAULT'. If the DEFAULT record is also missing, the program ABENDs. The migration must implement this fallback chain.
+
+6. **Single-threaded batch**: The batch reads sequentially and updates accounts one at a time. In the migration, parallel processing could be considered but must ensure the same deterministic results (especially for the final account balance).
+
+7. **Cycle counter reset**: When updating the account, `ACCT-CURR-CYC-CREDIT` and `ACCT-CURR-CYC-DEBIT` are both set to 0 (lines 353-354). This implies the interest calculation is also a billing cycle boundary. The migration must preserve this cycle-close behavior.
+
+8. **Negative balances**: The formula makes no check for negative category balances. If a category has a negative balance (credit), the computed interest would also be negative (a credit to the customer). The migration should verify this is the intended behavior.
+
+## Domain Expert Notes
+
+- **Pending validation**: This rule is HIGH RISK and requires review by a domain expert, particularly for: (1) the truncation vs. rounding behavior, (2) the exact data types in the copybooks CVTRA01Y and CVTRA02Y, and (3) the fee computation gap.
+- The division by 1200 (not 12 * 100) is the standard COBOL pattern for converting annual percentage rate to monthly decimal. For a rate of 18%, the monthly rate is 18/1200 = 0.015 = 1.5%.
+- Interest is added to the account balance (debit), which is correct for a credit card account where balance represents amount owed by the customer.
+- The `TRAN-TYPE-CD = '01'` and `TRAN-CAT-CD = '05'` classify these as system-generated interest transactions, distinct from `'02'`/`2` used for bill payments.
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/billing/BILL-BR-003.md
+++ b/docs-site/docs/business-rules/billing/BILL-BR-003.md
@@ -1,0 +1,326 @@
+---
+id: "BILL-BR-003"
+title: "Batch statement generation produces text and HTML statements per card"
+domain: "billing"
+cobol_source: "CBSTM03A.CBL:262-924"
+requirement_id: "BILL-BR-003"
+regulations:
+  - "FFFS 2014:5 Ch. 4 §5 — Statement Requirements"
+  - "GDPR Art. 15 — Right of Access (statement contains personal data)"
+  - "GDPR Art. 5(1)(f) — Integrity and Confidentiality"
+  - "PSD2 Art. 57 — Information on Individual Payment Transactions"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# BILL-BR-003: Batch statement generation produces text and HTML statements per card
+
+## Summary
+
+The statement generation batch job (CBSTM03A with subroutine CBSTM03B, invoked by CREASTMT.JCL) produces account statements in two formats: plain text and HTML. For each card in the cross-reference file, it retrieves customer information, account details, and all associated transactions, then generates a formatted statement showing customer name and address, account ID, current balance, FICO score, a transaction listing with individual amounts, and a total expenditure amount.
+
+## Business Logic
+
+### Processing Pipeline (CREASTMT.JCL)
+
+```
+Step 1 (DELDEF01): Delete and redefine TRXFL VSAM KSDS cluster
+    - Keys: 32 bytes at offset 0 (card number + tran ID)
+    - Record size: 350 bytes
+
+Step 2 (STEP010): SORT transaction file
+    - Input: TRANSACT.VSAM.KSDS
+    - Sort by: card number (pos 263, 16 bytes, ascending)
+              then tran ID (pos 1, 16 bytes, ascending)
+    - Output record layout rearranged:
+        Pos 1-16:    Card number (from pos 263)
+        Pos 17-278:  Tran ID + rest of record (from pos 1-262)
+        Pos 279-328: Remaining fields (from pos 279, 50 bytes)
+
+Step 3 (STEP020): REPRO sorted sequential file into VSAM KSDS
+
+Step 4 (STEP030): Delete previous statement reports (HTML and text)
+
+Step 5 (STEP040): Execute CBSTM03A to produce statements
+    - Input: TRNXFILE, XREFFILE, ACCTFILE, CUSTFILE
+    - Output: STMTFILE (plain text, LRECL=80), HTMLFILE (HTML, LRECL=100)
+```
+
+### Pseudocode (CBSTM03A)
+
+```
+INITIALIZATION:
+    Display JCL job name, step, and DD name information from TIOT
+    OPEN OUTPUT: STMT-FILE, HTML-FILE
+    INITIALIZE transaction table (51 cards x 10 transactions each)
+
+FILE OPENING SEQUENCE (via ALTER/GO TO):
+    OPEN TRNXFILE -> Read all transactions into memory table
+    OPEN XREFFILE
+    OPEN CUSTFILE
+    OPEN ACCTFILE
+
+LOAD TRANSACTIONS INTO MEMORY:
+    8500-READTRNX-READ:
+        FOR EACH transaction record from TRNXFILE:
+            IF same card number as previous:
+                INCREMENT transaction counter for this card
+            ELSE:
+                SAVE counter for previous card
+                INCREMENT card counter
+                RESET transaction counter to 1
+            END-IF
+            STORE card number, tran ID, and tran data in table
+        END-FOR
+
+MAIN PROCESSING:
+    1000-MAINLINE:
+        FOR EACH cross-reference record (XREFFILE, sequential):
+            READ customer record (CUSTFILE, by XREF-CUST-ID)
+            READ account record (ACCTFILE, by XREF-ACCT-ID)
+
+            5000-CREATE-STATEMENT:
+                Format customer name: first + middle + last
+                Format address lines: addr1, addr2, addr3+state+country+zip
+                Format account details: account ID, current balance, FICO score
+                WRITE statement header (text and HTML)
+
+            4000-TRNXFILE-GET (from in-memory table):
+                RESET total-amount = 0
+                FOR EACH card matching XREF-CARD-NUM:
+                    FOR EACH transaction for this card:
+                        6000-WRITE-TRANS:
+                            Format: tran ID, description, amount
+                            WRITE to text file and HTML file
+                        ADD tran-amount TO total-amount
+                    END-FOR
+                END-FOR
+                WRITE total expenditure line (text and HTML)
+                WRITE end-of-statement markers
+
+        END-FOR
+
+    CLOSE all files
+```
+
+### Statement Layout (Plain Text, 80 columns)
+
+```
+*******************************START OF STATEMENT*******************************
+<Customer Full Name>
+<Address Line 1>
+<Address Line 2>
+<Address Line 3> <State> <Country> <ZIP>
+--------------------------------------------------------------------------------
+                                 Basic Details
+--------------------------------------------------------------------------------
+Account ID         :<Account ID>
+Current Balance    :<Balance (9(9).99-)>
+FICO Score         :<FICO Score>
+--------------------------------------------------------------------------------
+                              TRANSACTION SUMMARY
+--------------------------------------------------------------------------------
+Tran ID         Tran Details                                       Tran Amount
+--------------------------------------------------------------------------------
+<16-char ID>    <49-char description>                             $<amount>
+...
+--------------------------------------------------------------------------------
+Total EXP:                                                        $<total>
+********************************END OF STATEMENT********************************
+```
+
+### Decision Table
+
+| Xref Record | Customer Found | Account Found | Transactions Found | Outcome |
+|------------|---------------|--------------|-------------------|---------|
+| Available | Yes | Yes | Yes | Full statement with transactions |
+| Available | Yes | Yes | No (card not in table) | Statement with header only, zero total |
+| Available | No (error) | — | — | ABEND: error reading CUSTFILE |
+| Available | — | No (error) | — | ABEND: error reading ACCTFILE |
+| EOF | — | — | — | End processing, close files |
+| Error | — | — | — | ABEND: error reading XREFFILE |
+
+## Source COBOL Reference
+
+**Program:** `CBSTM03A.CBL`
+**Lines:** 458-504 (Statement creation)
+
+```cobol
+       5000-CREATE-STATEMENT.
+           INITIALIZE STATEMENT-LINES.
+           WRITE FD-STMTFILE-REC FROM ST-LINE0.
+           PERFORM 5100-WRITE-HTML-HEADER THRU 5100-EXIT.
+           STRING CUST-FIRST-NAME DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  CUST-MIDDLE-NAME DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  CUST-LAST-NAME DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  INTO ST-NAME
+           END-STRING.
+           MOVE CUST-ADDR-LINE-1 TO ST-ADD1.
+           MOVE CUST-ADDR-LINE-2 TO ST-ADD2.
+           STRING CUST-ADDR-LINE-3 DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  CUST-ADDR-STATE-CD DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  CUST-ADDR-COUNTRY-CD DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  CUST-ADDR-ZIP DELIMITED BY ' '
+                  ' ' DELIMITED BY SIZE
+                  INTO ST-ADD3
+           END-STRING.
+           MOVE ACCT-ID TO ST-ACCT-ID.
+           MOVE ACCT-CURR-BAL TO ST-CURR-BAL.
+           MOVE CUST-FICO-CREDIT-SCORE TO ST-FICO-SCORE.
+```
+
+**Lines:** 416-456 (Transaction retrieval and total calculation)
+
+```cobol
+       4000-TRNXFILE-GET.
+           PERFORM VARYING CR-JMP FROM 1 BY 1
+             UNTIL CR-JMP > CR-CNT
+             OR (WS-CARD-NUM (CR-JMP) > XREF-CARD-NUM)
+               IF XREF-CARD-NUM = WS-CARD-NUM (CR-JMP)
+                   MOVE WS-CARD-NUM (CR-JMP) TO TRNX-CARD-NUM
+                   PERFORM VARYING TR-JMP FROM 1 BY 1
+                     UNTIL (TR-JMP > WS-TRCT (CR-JMP))
+                       MOVE WS-TRAN-NUM (CR-JMP, TR-JMP)
+                         TO TRNX-ID
+                       MOVE WS-TRAN-REST (CR-JMP, TR-JMP)
+                         TO TRNX-REST
+                       PERFORM 6000-WRITE-TRANS
+                       ADD TRNX-AMT TO WS-TOTAL-AMT
+                   END-PERFORM
+               END-IF
+           END-PERFORM.
+           MOVE WS-TOTAL-AMT TO WS-TRN-AMT.
+           MOVE WS-TRN-AMT TO ST-TOTAL-TRAMT.
+```
+
+**Lines:** 675-723 (Individual transaction line output)
+
+```cobol
+       6000-WRITE-TRANS.
+           MOVE TRNX-ID TO ST-TRANID.
+           MOVE TRNX-DESC TO ST-TRANDT.
+           MOVE TRNX-AMT TO ST-TRANAMT.
+           WRITE FD-STMTFILE-REC FROM ST-LINE14.
+```
+
+**Subroutine:** `CBSTM03B.CBL` — File I/O handler for TRNXFILE, XREFFILE, CUSTFILE, ACCTFILE
+
+**JCL:** `CREASTMT.JCL`
+**Input Files:** TRANSACT (sorted into TRNXFILE), XREFFILE (card cross-reference), ACCTFILE (account master), CUSTFILE (customer master)
+**Output Files:** STMTFILE (plain text, 80-col), HTMLFILE (HTML format, 100-col)
+
+**Copybooks:** `COSTM01.CPY` (Transaction layout for reporting), `CVACT03Y.cpy` (Card Cross-Reference), `CVACT01Y.cpy` (Account Record), `CUSTREC.cpy` (Customer Record)
+
+## Acceptance Criteria
+
+### Scenario 1: Standard statement with multiple transactions
+
+```gherkin
+GIVEN card "1234567890123456" is linked to customer "John A Smith" and account "00000012345"
+  AND customer address is "123 Main St", "Apt 4B", "Seattle WA US 98101"
+  AND account has current balance of $2,500.00 and FICO score "750"
+  AND the following transactions exist for this card:
+    | Tran ID | Description | Amount |
+    | 0000000000000001 | Purchase at Store A | 100.00 |
+    | 0000000000000002 | Purchase at Store B | 250.50 |
+WHEN the statement generation batch runs
+THEN a text statement is generated containing:
+  - Header: "START OF STATEMENT"
+  - Customer name: "John A Smith"
+  - Address lines
+  - Account ID: "00000012345"
+  - Current Balance: "2500.00"
+  - FICO Score: "750"
+  - Transaction lines for each transaction with amounts
+  - Total EXP: $350.50
+  - Footer: "END OF STATEMENT"
+  AND an equivalent HTML statement is generated
+```
+
+### Scenario 2: Statement with no transactions for a card
+
+```gherkin
+GIVEN card "9999888877776666" is linked to a valid customer and account
+  AND no transactions exist in the transaction file for this card
+WHEN the statement generation batch runs
+THEN a statement is generated with customer and account details
+  AND the transaction summary section shows no transaction lines
+  AND Total EXP: $0.00
+```
+
+### Scenario 3: Multiple cards generate separate statements
+
+```gherkin
+GIVEN the cross-reference file contains cards for 3 different customers
+WHEN the statement generation batch runs
+THEN 3 separate statements are generated in both text and HTML format
+  AND each statement contains only the transactions for that specific card
+```
+
+### Scenario 4: Transaction amount formatting
+
+```gherkin
+GIVEN a transaction with amount -150.75 (credit/refund)
+WHEN the statement is generated
+THEN the amount is displayed as "$   150.75-" (trailing minus, zero-suppressed with leading spaces)
+```
+
+### Scenario 5: Customer name formatting with STRING
+
+```gherkin
+GIVEN a customer with:
+  | CUST-FIRST-NAME | "Jane" (padded with spaces to field width) |
+  | CUST-MIDDLE-NAME | "M" (padded with spaces) |
+  | CUST-LAST-NAME | "Johnson" (padded with spaces) |
+WHEN the statement name line is formatted
+THEN the name appears as "Jane M Johnson" (trimmed at first space, joined with single spaces)
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FFFS 2014:5 | Ch. 4 §5 | Credit card statements must be provided regularly with transaction details | The batch job generates statements with full transaction listing, amounts, and totals for each billing period. |
+| GDPR | Art. 15 | Right of access to personal data | Statements include customer PII (name, address, FICO score). Access to statement output must be controlled. |
+| GDPR | Art. 5(1)(f) | Personal data processed with appropriate security | Statement files (STMTFILE, HTMLFILE) contain PII and must be protected. The migration must ensure encrypted storage and access controls. |
+| PSD2 | Art. 57 | Payment service providers must provide transaction details | Each statement lists individual transactions with ID, description, and amount, satisfying the itemized transaction requirement. |
+
+## Edge Cases
+
+1. **In-memory table limits**: The transaction table is dimensioned for 51 cards (`OCCURS 51 TIMES`) with 10 transactions each (`OCCURS 10 TIMES`). If more than 51 distinct cards or more than 10 transactions per card exist, the table will overflow. The migration should remove these fixed limits and use dynamic collections.
+
+2. **ALTER and GO TO flow control**: CBSTM03A uses `ALTER` statements (lines 300-313) to modify `GO TO` targets at runtime, an obsolete COBOL pattern that creates complex control flow. The file opening sequence proceeds: TRNXFILE -> read all transactions -> XREFFILE -> CUSTFILE -> ACCTFILE -> main processing. The migration should use straightforward sequential logic.
+
+3. **Mainframe control block addressing**: CBSTM03A accesses PSA, TCB, and TIOT control blocks (lines 235-291) to display the JCL job name and DD names. This is z/OS-specific and has no equivalent in the target environment. The migration should replace this with standard logging.
+
+4. **Subroutine call pattern**: CBSTM03A calls CBSTM03B via `CALL 'CBSTM03B' USING WS-M03B-AREA` for all file I/O operations. The subroutine handles OPEN, CLOSE, READ (sequential), and READ-KEY (random) operations via an operation code. The migration should use direct repository/data access patterns.
+
+5. **JCL SORT preprocessing**: Before CBSTM03A runs, the JCL sorts the transaction file by card number + transaction ID and rearranges the record layout (OUTREC FIELDS). The sort key becomes the first 32 bytes (card 16 + tran ID 16). The migration must replicate this ordering via SQL ORDER BY or equivalent.
+
+6. **VSAM cluster management**: The JCL deletes and redefines the TRXFL VSAM cluster each run (DELDEF01 step). This ensures a clean working file. The migration should use temporary tables or equivalent transient storage.
+
+7. **Dual output format**: Statements are produced simultaneously in text and HTML. The HTML includes inline CSS styles with specific colors and layout. The migration should consider whether HTML generation is still needed or if a modern template engine/PDF generator would be preferred.
+
+8. **COMP and COMP-3 variables**: Counter variables (`CR-CNT`, `TR-CNT`, etc.) use `COMP` (binary) storage, and `WS-TOTAL-AMT` uses `COMP-3` (packed decimal, `PIC S9(9)V99`). The migration must account for the precision characteristics of these types.
+
+9. **Transaction amount sign**: `ST-TRANAMT` is `PIC Z(9).99-` (trailing minus for negative) and `ST-TOTAL-TRAMT` is also `PIC Z(9).99-`. Negative amounts (refunds/credits) display with a trailing minus sign. The migration must preserve this display convention or adopt a modern equivalent.
+
+## Domain Expert Notes
+
+- **Pending validation**: This rule requires review by a domain expert to confirm: (1) whether the 51-card and 10-transaction limits are sufficient for production data or if they represent test constraints, (2) whether HTML statement output is still needed, and (3) the complete list of customer and account fields displayed.
+- The FICO score is included on the statement, which may raise GDPR data minimization concerns. The migration should evaluate whether FICO score should be removed from customer-facing statements.
+- The `ALTER`/`GO TO` pattern in CBSTM03A is considered poor practice in COBOL and makes the program difficult to maintain. The migration provides an opportunity to implement clean sequential logic.
+- Statement generation is triggered by the CREASTMT JCL job, which currently runs as a batch job. The migration target is an Azure Function with a timer trigger (per CLAUDE.md), which must meet the "complete by day 3" SLA for monthly statements.
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/billing/BILL-BR-004.md
+++ b/docs-site/docs/business-rules/billing/BILL-BR-004.md
@@ -1,0 +1,198 @@
+---
+id: "BILL-BR-004"
+title: "Transaction record layout for statement reporting uses card-first key structure"
+domain: "billing"
+cobol_source: "COSTM01.CPY:1-38"
+requirement_id: "BILL-BR-004"
+regulations:
+  - "PSD2 Art. 57 — Itemized Transaction Information"
+  - "FFFS 2014:5 Ch. 4 §5 — Statement Content Requirements"
+  - "GDPR Art. 5(1)(e) — Storage Limitation"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "medium"
+---
+
+# BILL-BR-004: Transaction record layout for statement reporting uses card-first key structure
+
+## Summary
+
+The COSTM01 copybook defines the transaction record layout used by the statement generation process. The key difference from the standard transaction record (CVTRA05Y) is that the composite key is ordered as card number + transaction ID (rather than transaction ID first). This layout is used after the CREASTMT JCL SORT step rearranges transaction records for efficient per-card statement processing.
+
+## Business Logic
+
+### Data Structure
+
+```
+TRNX-RECORD (total: 350 bytes)
+├── TRNX-KEY (32 bytes)
+│   ├── TRNX-CARD-NUM       PIC X(16)    Card number (primary sort key)
+│   └── TRNX-ID             PIC X(16)    Transaction ID (secondary sort key)
+├── TRNX-REST (318 bytes)
+│   ├── TRNX-TYPE-CD        PIC X(02)    Transaction type code
+│   ├── TRNX-CAT-CD         PIC 9(04)    Transaction category code
+│   ├── TRNX-SOURCE         PIC X(10)    Transaction source
+│   ├── TRNX-DESC           PIC X(100)   Transaction description
+│   ├── TRNX-AMT            PIC S9(09)V99  Transaction amount (signed, 2 dec)
+│   ├── TRNX-MERCHANT-ID    PIC 9(09)    Merchant identifier
+│   ├── TRNX-MERCHANT-NAME  PIC X(50)    Merchant name
+│   ├── TRNX-MERCHANT-CITY  PIC X(50)    Merchant city
+│   ├── TRNX-MERCHANT-ZIP   PIC X(10)    Merchant ZIP code
+│   ├── TRNX-ORIG-TS        PIC X(26)    Original timestamp
+│   ├── TRNX-PROC-TS        PIC X(26)    Processing timestamp
+│   └── FILLER              PIC X(20)    Reserved/unused
+```
+
+### Key Differences from Standard Transaction Layout
+
+| Aspect | Standard (CVTRA05Y) | Statement (COSTM01) |
+|--------|--------------------|--------------------|
+| Primary key | Transaction ID (16 bytes) | Card Number (16 bytes) |
+| Secondary key | Card Number (after ID) | Transaction ID (after card) |
+| Sort order | By transaction ID | By card number, then transaction ID |
+| Usage | Online CICS transaction processing | Batch statement generation |
+
+### Field Details
+
+| Field | Type | Size | Description | Constraints |
+|-------|------|------|-------------|-------------|
+| TRNX-CARD-NUM | Alphanumeric | 16 | Card number | Primary key component |
+| TRNX-ID | Alphanumeric | 16 | Transaction ID | Secondary key component |
+| TRNX-TYPE-CD | Alphanumeric | 2 | Type code: '01' = system/interest, '02' = payment | Known values: '01', '02' |
+| TRNX-CAT-CD | Numeric | 4 | Category code | Known values: 2 (payment), 5 (interest) |
+| TRNX-SOURCE | Alphanumeric | 10 | Origin: 'POS TERM', 'System' | Free text |
+| TRNX-DESC | Alphanumeric | 100 | Description text | Free text |
+| TRNX-AMT | Signed decimal | 11 (9+2) | Amount with 2 decimal places | Can be negative (credits) |
+| TRNX-MERCHANT-ID | Numeric | 9 | Merchant ID | 999999999 = system payment |
+| TRNX-MERCHANT-NAME | Alphanumeric | 50 | Merchant name | 'BILL PAYMENT' for system |
+| TRNX-MERCHANT-CITY | Alphanumeric | 50 | Merchant city | 'N/A' for system |
+| TRNX-MERCHANT-ZIP | Alphanumeric | 10 | Merchant ZIP | 'N/A' for system |
+| TRNX-ORIG-TS | Alphanumeric | 26 | Original timestamp (DB2 format) | YYYY-MM-DD-HH.MM.SS.NNNNNN |
+| TRNX-PROC-TS | Alphanumeric | 26 | Processing timestamp (DB2 format) | YYYY-MM-DD-HH.MM.SS.NNNNNN |
+| FILLER | Alphanumeric | 20 | Reserved | Unused |
+
+### Transaction Type Codes (from COBIL00C and CBACT04C)
+
+| Type Code | Category Code | Source | Description |
+|-----------|--------------|--------|-------------|
+| '01' | 05 | System | Interest charges (from CBACT04C) |
+| '02' | 0002 | POS TERM | Bill payment - online (from COBIL00C) |
+
+## Source COBOL Reference
+
+**Copybook:** `COSTM01.CPY`
+**Lines:** 1-38
+
+```cobol
+      ******************************************************************
+      * CardDemo - Transaction altered Layout for use in reporting
+      ******************************************************************
+       01  TRNX-RECORD.
+           05  TRNX-KEY.
+               10  TRNX-CARD-NUM                       PIC X(16).
+               10  TRNX-ID                             PIC X(16).
+           05  TRNX-REST.
+               10  TRNX-TYPE-CD                        PIC X(02).
+               10  TRNX-CAT-CD                         PIC 9(04).
+               10  TRNX-SOURCE                         PIC X(10).
+               10  TRNX-DESC                           PIC X(100).
+               10  TRNX-AMT                            PIC S9(09)V99.
+               10  TRNX-MERCHANT-ID                    PIC 9(09).
+               10  TRNX-MERCHANT-NAME                  PIC X(50).
+               10  TRNX-MERCHANT-CITY                  PIC X(50).
+               10  TRNX-MERCHANT-ZIP                   PIC X(10).
+               10  TRNX-ORIG-TS                        PIC X(26).
+               10  TRNX-PROC-TS                        PIC X(26).
+               10  FILLER                              PIC X(20).
+```
+
+**JCL SORT reference (CREASTMT.JCL lines 44-55):**
+
+```jcl
+//STEP010  EXEC PGM=SORT
+//SORTIN   DD  DISP=SHR,DSN=AWS.M2.CARDDEMO.TRANSACT.VSAM.KSDS
+//SYSIN    DD *
+  SORT FIELDS=(263,16,CH,A,1,16,CH,A)
+  OUTREC FIELDS=(1:263,16,17:1,262,279:279,50)
+```
+
+The SORT rearranges the standard transaction record:
+- Bytes 263-278 (card number) move to position 1-16
+- Bytes 1-262 (tran ID + data) move to position 17-278
+- Bytes 279-328 (remaining) move to position 279-328
+
+This places card number first in the record, matching the COSTM01 layout.
+
+## Acceptance Criteria
+
+### Scenario 1: Transaction record correctly maps all fields
+
+```gherkin
+GIVEN a transaction record written by COBIL00C (bill payment):
+  | Original Position | Field | Value |
+  | 1-16 | TRAN-ID | 0000000000000043 |
+  | 263-278 | TRAN-CARD-NUM | 1234567890123456 |
+  | 17-18 | TRAN-TYPE-CD | 02 |
+  | 19-22 | TRAN-CAT-CD | 0002 |
+  | 23-32 | TRAN-SOURCE | POS TERM |
+  | 33-132 | TRAN-DESC | BILL PAYMENT - ONLINE |
+  | 133-143 | TRAN-AMT | 00001500.00 |
+WHEN the SORT step rearranges the record into COSTM01 layout
+THEN the resulting record has:
+  | Position | Field | Value |
+  | 1-16 | TRNX-CARD-NUM | 1234567890123456 |
+  | 17-32 | TRNX-ID | 0000000000000043 |
+  | 33-34 | TRNX-TYPE-CD | 02 |
+  | 35-38 | TRNX-CAT-CD | 0002 |
+  | 39-48 | TRNX-SOURCE | POS TERM |
+  | 49-148 | TRNX-DESC | BILL PAYMENT - ONLINE |
+  | 149-159 | TRNX-AMT | +00001500.00 |
+```
+
+### Scenario 2: Signed amount encoding preserved through SORT
+
+```gherkin
+GIVEN a transaction with a negative amount (credit/refund) of -250.75
+WHEN the SORT rearranges the record
+THEN the TRNX-AMT field preserves the sign: S9(09)V99 = -000000250.75
+  AND the sign is stored in the COBOL standard zoned decimal format
+```
+
+### Scenario 3: FILLER field preserved
+
+```gherkin
+GIVEN a 350-byte transaction record
+WHEN mapped to the COSTM01 layout
+THEN bytes 331-350 map to the 20-byte FILLER field
+  AND these bytes are preserved but not used in statement generation
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 57(1) | Statements must include reference, amount, charges, date, and description for each transaction | The record layout includes transaction ID (reference), amount, description, timestamps, and merchant details. |
+| FFFS 2014:5 | Ch. 4 §5 | Statement content must enable customer to identify transactions | Merchant name, city, and description fields provide identifying information for each transaction. |
+| GDPR | Art. 5(1)(e) | Data stored only as long as necessary | The FILLER field (20 bytes) contains no PII. The migration should not persist unused fields. |
+
+## Edge Cases
+
+1. **EBCDIC signed decimal**: `TRNX-AMT` with `PIC S9(09)V99` stores the sign in the rightmost byte's zone nibble (EBCDIC convention). The SORT preserves the raw bytes. The migration must handle EBCDIC-to-Unicode conversion for this field, converting the sign representation properly.
+
+2. **Timestamp format**: `TRNX-ORIG-TS` and `TRNX-PROC-TS` use DB2 timestamp format: `YYYY-MM-DD-HH.MM.SS.NNNNNN` (26 characters). The migration should convert to ISO 8601 format (`YYYY-MM-DDTHH:MM:SS.ffffff`).
+
+3. **FILLER bytes**: The 20-byte FILLER at the end of the record is carried through the SORT but never used. The migration should not include this field in the target data model.
+
+4. **Record size**: The record is fixed at 350 bytes (matching the VSAM KSDS definition: `RECORDSIZE(350 350)`). The migration to Azure SQL uses variable-length columns, so the fixed-size constraint no longer applies.
+
+## Domain Expert Notes
+
+- **Pending validation**: This rule documents a data structure, not a business rule per se, but the layout is critical for understanding how statement generation works and how the migration must handle the SORT-based record rearrangement.
+- In the target system, the SORT step and record rearrangement would be replaced by a SQL query with `ORDER BY card_number, transaction_id`, eliminating the need for a separate intermediate file.
+- The separation of the reporting layout (COSTM01) from the transaction processing layout (CVTRA05Y) is a common mainframe pattern. The migration should use a single transaction table with appropriate indexes.
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-15

--- a/docs-site/docs/business-rules/billing/index.md
+++ b/docs-site/docs/business-rules/billing/index.md
@@ -1,0 +1,58 @@
+---
+id: "billing-index"
+title: "Billing Domain — Extracted Business Rules"
+domain: "billing"
+status: "in-progress"
+---
+
+# Billing Domain — Extracted Business Rules
+
+## Overview
+
+The Billing domain covers bill payment processing, interest calculation, statement generation, and related data structures. These rules were extracted from COBOL programs in the CardDemo application running on IBM z/OS.
+
+## Source Programs
+
+| Program | Type | Function | Rules Extracted |
+|---------|------|----------|----------------|
+| `COBIL00C.cbl` | CICS | Online bill payment | BILL-BR-001 |
+| `CBACT04C.cbl` | Batch | Interest calculation | BILL-BR-002 |
+| `CBSTM03A.CBL` | Batch | Statement generation (main) | BILL-BR-003 |
+| `CBSTM03B.CBL` | Batch | Statement generation (file I/O subroutine) | BILL-BR-003 |
+| `COSTM01.CPY` | Copybook | Transaction layout for reporting | BILL-BR-004 |
+
+### Related JCL Jobs
+
+| Job | Function | Programs Called |
+|-----|----------|---------------|
+| `INTCALC.jcl` | Interest calculation batch | CBACT04C |
+| `CREASTMT.JCL` | Create statements batch | SORT, IDCAMS, CBSTM03A/CBSTM03B |
+
+## Extracted Rules
+
+| Rule ID | Title | Priority | Status |
+|---------|-------|----------|--------|
+| [BILL-BR-001](BILL-BR-001.md) | Online bill payment pays full current balance and creates transaction record | High | Extracted |
+| [BILL-BR-002](BILL-BR-002.md) | Monthly interest calculated per transaction category using disclosure group rates | Critical | Extracted |
+| [BILL-BR-003](BILL-BR-003.md) | Batch statement generation produces text and HTML statements per card | High | Extracted |
+| [BILL-BR-004](BILL-BR-004.md) | Transaction record layout for statement reporting uses card-first key structure | Medium | Extracted |
+
+## Regulatory Coverage
+
+| Regulation | Rules |
+|------------|-------|
+| FFFS 2014:5 (FSA) | BILL-BR-001, BILL-BR-002, BILL-BR-003, BILL-BR-004 |
+| PSD2 | BILL-BR-001, BILL-BR-002, BILL-BR-003, BILL-BR-004 |
+| GDPR | BILL-BR-001, BILL-BR-003, BILL-BR-004 |
+| EBA GL 2020/06 | BILL-BR-002 |
+
+## Key Risks
+
+1. **Interest calculation precision** (BILL-BR-002): COBOL truncation behavior must be exactly replicated during parallel run. Rounding differences will cause output comparison failures and potential regulatory issues.
+2. **Fee computation gap** (BILL-BR-002): The `1400-COMPUTE-FEES` paragraph is a stub. Fee logic may need to be designed as a new requirement.
+3. **Statement memory limits** (BILL-BR-003): In-memory table limited to 51 cards x 10 transactions. Production data volumes must be verified.
+4. **Full balance payment only** (BILL-BR-001): No partial payment support exists. This may be a business requirement for the new system.
+
+## Validation Status
+
+All rules are in `extracted` status and require domain expert validation before implementation.


### PR DESCRIPTION
## Summary
- Extracted 4 business rules from billing-related COBOL programs (COBIL00C, CBACT04C, CBSTM03A/B) and supporting JCL/copybooks
- Documented each rule with COBOL source references, pseudocode, decision tables, GIVEN/WHEN/THEN acceptance criteria, and regulatory mapping
- Created domain index page listing all extracted rules with risk notes

## Changes
- `docs-site/docs/business-rules/billing/BILL-BR-001.md` — Online bill payment (full balance, confirmation flow, transaction creation)
- `docs-site/docs/business-rules/billing/BILL-BR-002.md` — Interest calculation (monthly per category, disclosure group rates, DEFAULT fallback, truncation behavior)
- `docs-site/docs/business-rules/billing/BILL-BR-003.md` — Statement generation (batch text+HTML, JCL SORT pipeline, subroutine I/O)
- `docs-site/docs/business-rules/billing/BILL-BR-004.md` — Transaction record layout (card-first key structure for reporting)
- `docs-site/docs/business-rules/billing/index.md` — Domain index with rule listing, regulatory coverage, and key risks
- `cobol-source/` — Added COBOL source files for billing domain (COBIL00C, CBSTM03A/B, COSTM01, INTCALC/CREASTMT JCL)

## Key Risks Documented
- **BILL-BR-002** (CRITICAL): Interest calculation uses COBOL truncation (not rounding) to 2 decimal places. Must replicate exactly during parallel run.
- **BILL-BR-002**: Fee computation (`1400-COMPUTE-FEES`) is a stub — gap needs domain expert decision.
- **BILL-BR-003**: In-memory table limited to 51 cards x 10 transactions — production capacity must be verified.

## Testing
- [x] All documents follow the established business rule template (YAML front matter, pseudocode, decision tables, Gherkin scenarios, regulatory mapping)
- [x] Each rule links to specific COBOL source lines
- [x] Regulatory mapping covers FFFS 2014:5, PSD2, GDPR, EBA GL 2020/06

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)