### PR TITLE
docs(#36): Add GitHub Actions workflow for docs site deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,53 @@
+name: Deploy docs site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs-site/**'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Install dependencies
+        working-directory: docs-site
+        run: npm ci
+
+      - name: Build site
+        working-directory: docs-site
+        run: npm run build
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs-site/build
+          retention-days: 14
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-docs.yml` to automatically build and deploy the Docusaurus docs site to GitHub Pages
- Triggers only on pushes to `main` that change files under `docs-site/`
- Uses the modern GitHub Pages deployment approach (Actions as source, not `gh-pages` branch)

## Changes

- **New file**: `.github/workflows/deploy-docs.yml`
  - Build job: checkout, Node 20 setup with npm cache, `npm ci`, `npm run build`, configure-pages, upload artifact with 14-day retention
  - Deploy job: deploys to GitHub Pages environment using `actions/deploy-pages@v4`
  - Permissions: `pages: write`, `id-token: write`, `contents: read`
  - Concurrency group to prevent overlapping deployments

## Testing

- [x] YAML syntax validated locally
- [x] All acceptance criteria verified:
  - Path filter `docs-site/**` prevents triggering on non-docs changes
  - `retention-days: 14` set per `.factory/context.md` gotcha
  - Correct action versions: `configure-pages@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`

## Manual step after merge

A repository admin must enable GitHub Pages with source set to **"GitHub Actions"** at:
https://github.com/Agentic-Delivery/nordkredit-core-banking/settings/pages

Closes #36

🤖 Generated with Claude Code