### PR TITLE
chore(#43): Add workflow_dispatch trigger to docs deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'docs-site/**'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the docs deploy workflow
- Enables manual triggering from the GitHub Actions tab for initial deployment and re-deploys without docs changes

## Changes
- `.github/workflows/deploy-docs.yml`: Added `workflow_dispatch:` to the `on:` trigger block

## Testing
- [x] YAML structure validated
- [x] No other files affected

## Post-merge
After merging, trigger the workflow manually from **Actions → Deploy docs site to GitHub Pages → Run workflow** to perform the initial deployment.

**Prerequisite:** GitHub Pages must be enabled with source "GitHub Actions" in repo settings.

Closes #43

🤖 Generated with Claude Code