### PR TITLE
fix(#47): Set correct GitHub Pages url and baseUrl in Docusaurus config

### DIFF
--- a/docs-site/docusaurus.config.js
+++ b/docs-site/docusaurus.config.js
@@ -12,8 +12,11 @@ const config = {
     v4: true,
   },
 
-  url: 'https://nordkredit-docs.example.com',
-  baseUrl: '/',
+  url: 'https://agentic-delivery.github.io',
+  baseUrl: '/nordkredit-core-banking/',
+
+  organizationName: 'Agentic-Delivery',
+  projectName: 'nordkredit-core-banking',
 
   onBrokenLinks: 'throw',
 


### PR DESCRIPTION
## Summary
- Fixed placeholder `url` and `baseUrl` values in `docs-site/docusaurus.config.js` to point to the actual GitHub Pages deployment
- Added `organizationName` and `projectName` fields required for GitHub Pages

## Changes
- `docs-site/docusaurus.config.js`: Updated `url` from `https://nordkredit-docs.example.com` to `https://agentic-delivery.github.io`, `baseUrl` from `/` to `/nordkredit-core-banking/`, and added `organizationName: 'Agentic-Delivery'` and `projectName: 'nordkredit-core-banking'`

## Testing
- [x] Docusaurus build succeeds locally (`npm run build`)
- [x] Config values match acceptance criteria

Closes #47

🤖 Generated with Claude Code