### PR TITLE
feat(#70): Scaffold .NET 8 solution and Transaction domain foundation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,70 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{cs,csx}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Namespace
+csharp_style_namespace_declarations = file_scoped:warning
+
+# var preferences
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+
+# Null checking
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+
+# Braces
+csharp_prefer_braces = true:warning
+
+# Naming conventions
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.private_fields_should_be_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_camel_case.style = camel_case_with_underscore
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.camel_case_with_underscore.required_prefix = _
+dotnet_naming_style.camel_case_with_underscore.capitalization = camel_case
+
+# Analyzers
+dotnet_analyzer_diagnostic.severity = warning
+
+# Discard expression results — EF fluent API and async patterns produce this frequently
+dotnet_diagnostic.IDE0058.severity = none
+
+# Primary constructors — optional style preference, not enforced
+dotnet_diagnostic.IDE0290.severity = none
+
+# var usage — align with preference settings above
+csharp_style_var_elsewhere = true:suggestion
+dotnet_diagnostic.IDE0008.severity = suggestion
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{csproj,props,targets}]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,24 @@ on:
     branches: [main]
 
 jobs:
-  validate:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate markdown links
-        run: |
-          echo "CI validation passed"
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build (warnings as errors)
+        run: dotnet build /warnaserror --no-restore
+
+      - name: Run tests
+        run: dotnet test --no-build --verbosity normal
+
+      - name: Check formatting
+        run: dotnet format --verify-no-changes --no-restore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# .NET
+bin/
+obj/
+*.user
+*.suo
+*.cache
+*.vs/
+*.DotSettings.user
+TestResults/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Node (docs-site)
+node_modules/
+
+# Environment
+.env
+*.local

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>CS1591</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/NordKredit.sln
+++ b/NordKredit.sln
@@ -1,0 +1,71 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{36EEE27E-7974-4B3D-9583-C7B453C7DB58}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NordKredit.Domain", "src\NordKredit.Domain\NordKredit.Domain.csproj", "{EA644D24-2EE9-40AA-987F-C524DFEC1DF7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NordKredit.Infrastructure", "src\NordKredit.Infrastructure\NordKredit.Infrastructure.csproj", "{55822975-AEF0-4493-ABB5-068C759CE715}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NordKredit.Api", "src\NordKredit.Api\NordKredit.Api.csproj", "{50406D9B-7475-4A80-A802-BC0961D9AB03}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NordKredit.Functions", "src\NordKredit.Functions\NordKredit.Functions.csproj", "{EF0FA4C2-4F56-4722-99A0-6214FC0277B3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A4C5A011-F864-421B-9D1E-60DE73C605D7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NordKredit.UnitTests", "tests\NordKredit.UnitTests\NordKredit.UnitTests.csproj", "{D32092D5-DF60-4ED4-BE39-366284B98ED2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NordKredit.BDD", "tests\NordKredit.BDD\NordKredit.BDD.csproj", "{5BC8A3C8-981F-4E79-A6A6-7EEB10C8E077}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NordKredit.ComparisonTests", "tests\NordKredit.ComparisonTests\NordKredit.ComparisonTests.csproj", "{F4F1B169-70D1-48F2-B70A-C44B94DE3E0F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EA644D24-2EE9-40AA-987F-C524DFEC1DF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA644D24-2EE9-40AA-987F-C524DFEC1DF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA644D24-2EE9-40AA-987F-C524DFEC1DF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA644D24-2EE9-40AA-987F-C524DFEC1DF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55822975-AEF0-4493-ABB5-068C759CE715}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55822975-AEF0-4493-ABB5-068C759CE715}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55822975-AEF0-4493-ABB5-068C759CE715}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55822975-AEF0-4493-ABB5-068C759CE715}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50406D9B-7475-4A80-A802-BC0961D9AB03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50406D9B-7475-4A80-A802-BC0961D9AB03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50406D9B-7475-4A80-A802-BC0961D9AB03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50406D9B-7475-4A80-A802-BC0961D9AB03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF0FA4C2-4F56-4722-99A0-6214FC0277B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF0FA4C2-4F56-4722-99A0-6214FC0277B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF0FA4C2-4F56-4722-99A0-6214FC0277B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF0FA4C2-4F56-4722-99A0-6214FC0277B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D32092D5-DF60-4ED4-BE39-366284B98ED2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D32092D5-DF60-4ED4-BE39-366284B98ED2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D32092D5-DF60-4ED4-BE39-366284B98ED2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D32092D5-DF60-4ED4-BE39-366284B98ED2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5BC8A3C8-981F-4E79-A6A6-7EEB10C8E077}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5BC8A3C8-981F-4E79-A6A6-7EEB10C8E077}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5BC8A3C8-981F-4E79-A6A6-7EEB10C8E077}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5BC8A3C8-981F-4E79-A6A6-7EEB10C8E077}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4F1B169-70D1-48F2-B70A-C44B94DE3E0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4F1B169-70D1-48F2-B70A-C44B94DE3E0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4F1B169-70D1-48F2-B70A-C44B94DE3E0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4F1B169-70D1-48F2-B70A-C44B94DE3E0F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{EA644D24-2EE9-40AA-987F-C524DFEC1DF7} = {36EEE27E-7974-4B3D-9583-C7B453C7DB58}
+		{55822975-AEF0-4493-ABB5-068C759CE715} = {36EEE27E-7974-4B3D-9583-C7B453C7DB58}
+		{50406D9B-7475-4A80-A802-BC0961D9AB03} = {36EEE27E-7974-4B3D-9583-C7B453C7DB58}
+		{EF0FA4C2-4F56-4722-99A0-6214FC0277B3} = {36EEE27E-7974-4B3D-9583-C7B453C7DB58}
+		{D32092D5-DF60-4ED4-BE39-366284B98ED2} = {A4C5A011-F864-421B-9D1E-60DE73C605D7}
+		{5BC8A3C8-981F-4E79-A6A6-7EEB10C8E077} = {A4C5A011-F864-421B-9D1E-60DE73C605D7}
+		{F4F1B169-70D1-48F2-B70A-C44B94DE3E0F} = {A4C5A011-F864-421B-9D1E-60DE73C605D7}
+	EndGlobalSection
+EndGlobal

--- a/src/NordKredit.Api/NordKredit.Api.csproj
+++ b/src/NordKredit.Api/NordKredit.Api.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\NordKredit.Domain\NordKredit.Domain.csproj" />
+    <ProjectReference Include="..\NordKredit.Infrastructure\NordKredit.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NordKredit.Api/Program.cs
+++ b/src/NordKredit.Api/Program.cs
@@ -1,0 +1,7 @@
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+app.MapGet("/health", () => Results.Ok(new { Status = "Healthy" }));
+
+app.Run();

--- a/src/NordKredit.Api/Properties/launchSettings.json
+++ b/src/NordKredit.Api/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:24382",
+      "sslPort": 44355
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "http://localhost:5048",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "https://localhost:7209;http://localhost:5048",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/NordKredit.Api/appsettings.Development.json
+++ b/src/NordKredit.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/NordKredit.Api/appsettings.json
+++ b/src/NordKredit.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/NordKredit.Domain/NordKredit.Domain.csproj
+++ b/src/NordKredit.Domain/NordKredit.Domain.csproj
@@ -1,0 +1,3 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+</Project>

--- a/src/NordKredit.Domain/Transactions/Account.cs
+++ b/src/NordKredit.Domain/Transactions/Account.cs
@@ -1,0 +1,31 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Account record used by transaction processing.
+/// COBOL source: CVACT01Y.cpy (ACCOUNT-RECORD), 300 bytes.
+/// Contains only the fields needed for transaction domain operations.
+/// Full account management entity will reside in AccountManagement domain.
+/// </summary>
+public class Account
+{
+    /// <summary>Account identifier. COBOL: ACCT-ID PIC 9(11).</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Active status ('A' = active, 'D' = dormant). COBOL: ACCT-ACTIVE-STATUS PIC X(01).</summary>
+    public string ActiveStatus { get; set; } = string.Empty;
+
+    /// <summary>Current balance. COBOL: ACCT-CURR-BAL PIC S9(10)V99. Maps to SQL decimal(12,2).</summary>
+    public decimal CurrentBalance { get; set; }
+
+    /// <summary>Credit limit. COBOL: ACCT-CREDIT-LIMIT PIC S9(10)V99. Maps to SQL decimal(12,2).</summary>
+    public decimal CreditLimit { get; set; }
+
+    /// <summary>Cash credit limit. COBOL: ACCT-CASH-CREDIT-LIMIT PIC S9(10)V99. Maps to SQL decimal(12,2).</summary>
+    public decimal CashCreditLimit { get; set; }
+
+    /// <summary>Current cycle credit total. COBOL: ACCT-CURR-CYC-CREDIT PIC S9(10)V99. Maps to SQL decimal(12,2).</summary>
+    public decimal CurrentCycleCredit { get; set; }
+
+    /// <summary>Current cycle debit total. COBOL: ACCT-CURR-CYC-DEBIT PIC S9(10)V99. Maps to SQL decimal(12,2).</summary>
+    public decimal CurrentCycleDebit { get; set; }
+}

--- a/src/NordKredit.Domain/Transactions/CardCrossReference.cs
+++ b/src/NordKredit.Domain/Transactions/CardCrossReference.cs
@@ -1,0 +1,18 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Card-to-account cross-reference record.
+/// COBOL source: CVACT03Y.cpy (CARD-XREF-RECORD), 50 bytes.
+/// Links card numbers to customer and account identifiers.
+/// </summary>
+public class CardCrossReference
+{
+    /// <summary>Card number. COBOL: XREF-CARD-NUM PIC X(16).</summary>
+    public string CardNumber { get; set; } = string.Empty;
+
+    /// <summary>Customer identifier. COBOL: XREF-CUST-ID PIC 9(09).</summary>
+    public int CustomerId { get; set; }
+
+    /// <summary>Account identifier. COBOL: XREF-ACCT-ID PIC 9(11).</summary>
+    public string AccountId { get; set; } = string.Empty;
+}

--- a/src/NordKredit.Domain/Transactions/DailyTransaction.cs
+++ b/src/NordKredit.Domain/Transactions/DailyTransaction.cs
@@ -1,0 +1,49 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Daily transaction record — represents unposted transactions from daily batch input.
+/// COBOL source: CVTRA06Y.cpy (DALYTRAN-RECORD), 350 bytes.
+/// Same layout as Transaction (TRAN-RECORD) but sourced from sequential daily input file.
+/// Used by CBTRN01C (verification) and CBTRN02C (posting).
+/// </summary>
+public class DailyTransaction
+{
+    /// <summary>Transaction ID. COBOL: DALYTRAN-ID PIC X(16).</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Transaction type code. COBOL: DALYTRAN-TYPE-CD PIC X(02).</summary>
+    public string TypeCode { get; set; } = string.Empty;
+
+    /// <summary>Category code. COBOL: DALYTRAN-CAT-CD PIC 9(04).</summary>
+    public int CategoryCode { get; set; }
+
+    /// <summary>Source system. COBOL: DALYTRAN-SOURCE PIC X(10).</summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>Transaction description. COBOL: DALYTRAN-DESC PIC X(100).</summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Transaction amount. COBOL: DALYTRAN-AMT PIC S9(09)V99. Maps to SQL decimal(11,2).</summary>
+    public decimal Amount { get; set; }
+
+    /// <summary>Merchant identifier. COBOL: DALYTRAN-MERCHANT-ID PIC 9(09).</summary>
+    public int MerchantId { get; set; }
+
+    /// <summary>Merchant name. COBOL: DALYTRAN-MERCHANT-NAME PIC X(50).</summary>
+    public string MerchantName { get; set; } = string.Empty;
+
+    /// <summary>Merchant city. COBOL: DALYTRAN-MERCHANT-CITY PIC X(50).</summary>
+    public string MerchantCity { get; set; } = string.Empty;
+
+    /// <summary>Merchant postal code. COBOL: DALYTRAN-MERCHANT-ZIP PIC X(10).</summary>
+    public string MerchantZip { get; set; } = string.Empty;
+
+    /// <summary>Card number. COBOL: DALYTRAN-CARD-NUM PIC X(16).</summary>
+    public string CardNumber { get; set; } = string.Empty;
+
+    /// <summary>Origination timestamp. COBOL: DALYTRAN-ORIG-TS PIC X(26).</summary>
+    public DateTime OriginationTimestamp { get; set; }
+
+    /// <summary>Processing timestamp. COBOL: DALYTRAN-PROC-TS PIC X(26).</summary>
+    public DateTime ProcessingTimestamp { get; set; }
+}

--- a/src/NordKredit.Domain/Transactions/IAccountRepository.cs
+++ b/src/NordKredit.Domain/Transactions/IAccountRepository.cs
@@ -1,0 +1,13 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Repository for account records used by transaction processing.
+/// COBOL source: CVACT01Y.cpy (ACCOUNT-RECORD), VSAM ACCTFILE.
+/// Used by CBTRN02C to update balances during daily posting.
+/// </summary>
+public interface IAccountRepository
+{
+    Task<Account?> GetByIdAsync(string accountId, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(Account account, CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/Transactions/ICardCrossReferenceRepository.cs
+++ b/src/NordKredit.Domain/Transactions/ICardCrossReferenceRepository.cs
@@ -1,0 +1,11 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Repository for card-to-account cross-reference lookups.
+/// COBOL source: CVACT03Y.cpy (CARD-XREF-RECORD), VSAM CARDXREF file.
+/// Used by CBTRN01C to verify card numbers during daily transaction processing.
+/// </summary>
+public interface ICardCrossReferenceRepository
+{
+    Task<CardCrossReference?> GetByCardNumberAsync(string cardNumber, CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/Transactions/IDailyTransactionRepository.cs
+++ b/src/NordKredit.Domain/Transactions/IDailyTransactionRepository.cs
@@ -1,0 +1,14 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Repository for daily transaction input records.
+/// COBOL source: Sequential DALYTRAN file, read by CBTRN01C (verification) and CBTRN02C (posting).
+/// </summary>
+public interface IDailyTransactionRepository
+{
+    Task<IReadOnlyList<DailyTransaction>> GetUnprocessedAsync(CancellationToken cancellationToken = default);
+
+    Task AddAsync(DailyTransaction dailyTransaction, CancellationToken cancellationToken = default);
+
+    Task MarkAsProcessedAsync(string transactionId, CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/Transactions/ITransactionCategoryBalanceRepository.cs
+++ b/src/NordKredit.Domain/Transactions/ITransactionCategoryBalanceRepository.cs
@@ -1,0 +1,21 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Repository for transaction category balance records.
+/// COBOL source: VSAM TRAN-CAT-BAL file, keyed by AccountId + TypeCode + CategoryCode.
+/// Updated by CBTRN02C during daily posting.
+/// </summary>
+public interface ITransactionCategoryBalanceRepository
+{
+    Task<TransactionCategoryBalance?> GetAsync(
+        string accountId,
+        string typeCode,
+        int categoryCode,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<TransactionCategoryBalance>> GetByAccountIdAsync(
+        string accountId,
+        CancellationToken cancellationToken = default);
+
+    Task UpsertAsync(TransactionCategoryBalance balance, CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/Transactions/ITransactionRepository.cs
+++ b/src/NordKredit.Domain/Transactions/ITransactionRepository.cs
@@ -1,0 +1,18 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Repository for posted transaction records.
+/// COBOL source: VSAM TRANSACT file, accessed by COTRN00C/01C/02C.
+/// </summary>
+public interface ITransactionRepository
+{
+    Task<Transaction?> GetByIdAsync(string transactionId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Transaction>> GetByAccountIdAsync(
+        string accountId,
+        int pageSize,
+        string? startAfterTransactionId = null,
+        CancellationToken cancellationToken = default);
+
+    Task AddAsync(Transaction transaction, CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/Transactions/Transaction.cs
+++ b/src/NordKredit.Domain/Transactions/Transaction.cs
@@ -1,0 +1,48 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Posted transaction record.
+/// COBOL source: CVTRA05Y.cpy (TRAN-RECORD), 350 bytes.
+/// All monetary fields use decimal (never float/double) per COBOL PIC S9(09)V99.
+/// </summary>
+public class Transaction
+{
+    /// <summary>Transaction ID. COBOL: TRAN-ID PIC X(16).</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Transaction type code (e.g., "DB", "CR"). COBOL: TRAN-TYPE-CD PIC X(02).</summary>
+    public string TypeCode { get; set; } = string.Empty;
+
+    /// <summary>Category code (e.g., 1001-9999). COBOL: TRAN-CAT-CD PIC 9(04).</summary>
+    public int CategoryCode { get; set; }
+
+    /// <summary>Source system (e.g., "ONLINE", "BATCH"). COBOL: TRAN-SOURCE PIC X(10).</summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>Transaction description. COBOL: TRAN-DESC PIC X(100).</summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Transaction amount. COBOL: TRAN-AMT PIC S9(09)V99. Maps to SQL decimal(11,2).</summary>
+    public decimal Amount { get; set; }
+
+    /// <summary>Merchant identifier. COBOL: TRAN-MERCHANT-ID PIC 9(09).</summary>
+    public int MerchantId { get; set; }
+
+    /// <summary>Merchant name. COBOL: TRAN-MERCHANT-NAME PIC X(50).</summary>
+    public string MerchantName { get; set; } = string.Empty;
+
+    /// <summary>Merchant city. COBOL: TRAN-MERCHANT-CITY PIC X(50).</summary>
+    public string MerchantCity { get; set; } = string.Empty;
+
+    /// <summary>Merchant postal code. COBOL: TRAN-MERCHANT-ZIP PIC X(10).</summary>
+    public string MerchantZip { get; set; } = string.Empty;
+
+    /// <summary>Card number. COBOL: TRAN-CARD-NUM PIC X(16).</summary>
+    public string CardNumber { get; set; } = string.Empty;
+
+    /// <summary>Origination timestamp. COBOL: TRAN-ORIG-TS PIC X(26).</summary>
+    public DateTime OriginationTimestamp { get; set; }
+
+    /// <summary>Processing timestamp. COBOL: TRAN-PROC-TS PIC X(26).</summary>
+    public DateTime ProcessingTimestamp { get; set; }
+}

--- a/src/NordKredit.Domain/Transactions/TransactionCategoryBalance.cs
+++ b/src/NordKredit.Domain/Transactions/TransactionCategoryBalance.cs
@@ -1,0 +1,21 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Transaction category balance record — tracks balance per account/type/category combination.
+/// COBOL source: CVTRA01Y.cpy (TRAN-CAT-BAL-RECORD), 50 bytes.
+/// Composite key: AccountId + TypeCode + CategoryCode (TRAN-CAT-KEY).
+/// </summary>
+public class TransactionCategoryBalance
+{
+    /// <summary>Account identifier. COBOL: TRANCAT-ACCT-ID PIC 9(11).</summary>
+    public string AccountId { get; set; } = string.Empty;
+
+    /// <summary>Transaction type code. COBOL: TRANCAT-TYPE-CD PIC X(02).</summary>
+    public string TypeCode { get; set; } = string.Empty;
+
+    /// <summary>Category code. COBOL: TRANCAT-CD PIC 9(04).</summary>
+    public int CategoryCode { get; set; }
+
+    /// <summary>Category balance. COBOL: TRAN-CAT-BAL PIC S9(09)V99. Maps to SQL decimal(11,2).</summary>
+    public decimal Balance { get; set; }
+}

--- a/src/NordKredit.Functions/NordKredit.Functions.csproj
+++ b/src/NordKredit.Functions/NordKredit.Functions.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NordKredit.Domain\NordKredit.Domain.csproj" />
+    <ProjectReference Include="..\NordKredit.Infrastructure\NordKredit.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NordKredit.Functions/Program.cs
+++ b/src/NordKredit.Functions/Program.cs
@@ -1,0 +1,7 @@
+using NordKredit.Functions;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<Worker>();
+
+var host = builder.Build();
+host.Run();

--- a/src/NordKredit.Functions/Properties/launchSettings.json
+++ b/src/NordKredit.Functions/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "NordKredit.Functions": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/NordKredit.Functions/Worker.cs
+++ b/src/NordKredit.Functions/Worker.cs
@@ -1,0 +1,27 @@
+namespace NordKredit.Functions;
+
+public partial class Worker : BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+
+    public Worker(ILogger<Worker> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                LogWorkerRunning(_logger, DateTimeOffset.Now);
+            }
+
+            await Task.Delay(1000, stoppingToken);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Worker running at: {Time}")]
+    private static partial void LogWorkerRunning(ILogger logger, DateTimeOffset time);
+}

--- a/src/NordKredit.Functions/appsettings.Development.json
+++ b/src/NordKredit.Functions/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/src/NordKredit.Functions/appsettings.json
+++ b/src/NordKredit.Functions/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/src/NordKredit.Infrastructure/NordKredit.Infrastructure.csproj
+++ b/src/NordKredit.Infrastructure/NordKredit.Infrastructure.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\NordKredit.Domain\NordKredit.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+  </ItemGroup>
+
+</Project>

--- a/src/NordKredit.Infrastructure/NordKreditDbContext.cs
+++ b/src/NordKredit.Infrastructure/NordKreditDbContext.cs
@@ -1,0 +1,132 @@
+using Microsoft.EntityFrameworkCore;
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.Infrastructure;
+
+/// <summary>
+/// Entity Framework Core DbContext for NordKredit Azure SQL Database.
+/// Maps COBOL VSAM/Db2 data structures to Azure SQL tables.
+/// </summary>
+public class NordKreditDbContext : DbContext
+{
+    public NordKreditDbContext(DbContextOptions<NordKreditDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Transaction> Transactions => Set<Transaction>();
+    public DbSet<DailyTransaction> DailyTransactions => Set<DailyTransaction>();
+    public DbSet<TransactionCategoryBalance> TransactionCategoryBalances => Set<TransactionCategoryBalance>();
+    public DbSet<CardCrossReference> CardCrossReferences => Set<CardCrossReference>();
+    public DbSet<Account> Accounts => Set<Account>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        ConfigureTransaction(modelBuilder);
+        ConfigureDailyTransaction(modelBuilder);
+        ConfigureTransactionCategoryBalance(modelBuilder);
+        ConfigureCardCrossReference(modelBuilder);
+        ConfigureAccount(modelBuilder);
+    }
+
+    private static void ConfigureTransaction(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Transaction>(entity =>
+        {
+            entity.ToTable("Transactions");
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Id).HasMaxLength(16).IsRequired();
+            entity.Property(e => e.TypeCode).HasMaxLength(2).IsRequired();
+            entity.Property(e => e.CategoryCode).IsRequired();
+            entity.Property(e => e.Source).HasMaxLength(10).IsRequired();
+            entity.Property(e => e.Description).HasMaxLength(100).IsRequired();
+            // COBOL: PIC S9(09)V99 — 9 integer digits + 2 decimal = decimal(11,2)
+            entity.Property(e => e.Amount).HasColumnType("decimal(11,2)").IsRequired();
+            entity.Property(e => e.MerchantId).IsRequired();
+            entity.Property(e => e.MerchantName).HasMaxLength(50).IsRequired();
+            entity.Property(e => e.MerchantCity).HasMaxLength(50).IsRequired();
+            entity.Property(e => e.MerchantZip).HasMaxLength(10).IsRequired();
+            entity.Property(e => e.CardNumber).HasMaxLength(16).IsRequired();
+            entity.Property(e => e.OriginationTimestamp).IsRequired();
+            entity.Property(e => e.ProcessingTimestamp).IsRequired();
+
+            entity.HasIndex(e => e.CardNumber);
+        });
+    }
+
+    private static void ConfigureDailyTransaction(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<DailyTransaction>(entity =>
+        {
+            entity.ToTable("DailyTransactions");
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Id).HasMaxLength(16).IsRequired();
+            entity.Property(e => e.TypeCode).HasMaxLength(2).IsRequired();
+            entity.Property(e => e.CategoryCode).IsRequired();
+            entity.Property(e => e.Source).HasMaxLength(10).IsRequired();
+            entity.Property(e => e.Description).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.Amount).HasColumnType("decimal(11,2)").IsRequired();
+            entity.Property(e => e.MerchantId).IsRequired();
+            entity.Property(e => e.MerchantName).HasMaxLength(50).IsRequired();
+            entity.Property(e => e.MerchantCity).HasMaxLength(50).IsRequired();
+            entity.Property(e => e.MerchantZip).HasMaxLength(10).IsRequired();
+            entity.Property(e => e.CardNumber).HasMaxLength(16).IsRequired();
+            entity.Property(e => e.OriginationTimestamp).IsRequired();
+            entity.Property(e => e.ProcessingTimestamp).IsRequired();
+
+            entity.HasIndex(e => e.CardNumber);
+        });
+    }
+
+    private static void ConfigureTransactionCategoryBalance(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TransactionCategoryBalance>(entity =>
+        {
+            entity.ToTable("TransactionCategoryBalances");
+            // COBOL: Composite key TRAN-CAT-KEY = ACCT-ID + TYPE-CD + CAT-CD
+            entity.HasKey(e => new { e.AccountId, e.TypeCode, e.CategoryCode });
+
+            entity.Property(e => e.AccountId).HasMaxLength(11).IsRequired();
+            entity.Property(e => e.TypeCode).HasMaxLength(2).IsRequired();
+            entity.Property(e => e.CategoryCode).IsRequired();
+            entity.Property(e => e.Balance).HasColumnType("decimal(11,2)").IsRequired();
+        });
+    }
+
+    private static void ConfigureCardCrossReference(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<CardCrossReference>(entity =>
+        {
+            entity.ToTable("CardCrossReferences");
+            entity.HasKey(e => e.CardNumber);
+
+            entity.Property(e => e.CardNumber).HasMaxLength(16).IsRequired();
+            entity.Property(e => e.CustomerId).IsRequired();
+            entity.Property(e => e.AccountId).HasMaxLength(11).IsRequired();
+
+            entity.HasIndex(e => e.AccountId);
+        });
+    }
+
+    private static void ConfigureAccount(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Account>(entity =>
+        {
+            entity.ToTable("Accounts");
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Id).HasMaxLength(11).IsRequired();
+            entity.Property(e => e.ActiveStatus).HasMaxLength(1).IsRequired();
+            // COBOL: PIC S9(10)V99 — 10 integer digits + 2 decimal = decimal(12,2)
+            entity.Property(e => e.CurrentBalance).HasColumnType("decimal(12,2)").IsRequired();
+            entity.Property(e => e.CreditLimit).HasColumnType("decimal(12,2)").IsRequired();
+            entity.Property(e => e.CashCreditLimit).HasColumnType("decimal(12,2)").IsRequired();
+            entity.Property(e => e.CurrentCycleCredit).HasColumnType("decimal(12,2)").IsRequired();
+            entity.Property(e => e.CurrentCycleDebit).HasColumnType("decimal(12,2)").IsRequired();
+        });
+    }
+}

--- a/src/NordKredit.Infrastructure/Transactions/SqlAccountRepository.cs
+++ b/src/NordKredit.Infrastructure/Transactions/SqlAccountRepository.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.Infrastructure.Transactions;
+
+/// <summary>
+/// Azure SQL implementation of <see cref="IAccountRepository"/>.
+/// Replaces VSAM ACCTFILE keyed file read/write operations for transaction processing.
+/// </summary>
+public class SqlAccountRepository : IAccountRepository
+{
+    private readonly NordKreditDbContext _dbContext;
+
+    public SqlAccountRepository(NordKreditDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Account?> GetByIdAsync(string accountId, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Accounts
+            .FirstOrDefaultAsync(a => a.Id == accountId, cancellationToken);
+    }
+
+    public async Task UpdateAsync(Account account, CancellationToken cancellationToken = default)
+    {
+        _dbContext.Accounts.Update(account);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/NordKredit.Infrastructure/Transactions/SqlCardCrossReferenceRepository.cs
+++ b/src/NordKredit.Infrastructure/Transactions/SqlCardCrossReferenceRepository.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.Infrastructure.Transactions;
+
+/// <summary>
+/// Azure SQL implementation of <see cref="ICardCrossReferenceRepository"/>.
+/// Replaces VSAM CARDXREF keyed file read operations.
+/// </summary>
+public class SqlCardCrossReferenceRepository : ICardCrossReferenceRepository
+{
+    private readonly NordKreditDbContext _dbContext;
+
+    public SqlCardCrossReferenceRepository(NordKreditDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<CardCrossReference?> GetByCardNumberAsync(
+        string cardNumber,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.CardCrossReferences
+            .FirstOrDefaultAsync(x => x.CardNumber == cardNumber, cancellationToken);
+    }
+}

--- a/src/NordKredit.Infrastructure/Transactions/SqlDailyTransactionRepository.cs
+++ b/src/NordKredit.Infrastructure/Transactions/SqlDailyTransactionRepository.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.Infrastructure.Transactions;
+
+/// <summary>
+/// Azure SQL implementation of <see cref="IDailyTransactionRepository"/>.
+/// Replaces sequential DALYTRAN file read operations used by CBTRN01C/CBTRN02C.
+/// </summary>
+public class SqlDailyTransactionRepository : IDailyTransactionRepository
+{
+    private readonly NordKreditDbContext _dbContext;
+
+    public SqlDailyTransactionRepository(NordKreditDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<DailyTransaction>> GetUnprocessedAsync(CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.DailyTransactions
+            .OrderBy(d => d.Id)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(DailyTransaction dailyTransaction, CancellationToken cancellationToken = default)
+    {
+        await _dbContext.DailyTransactions.AddAsync(dailyTransaction, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task MarkAsProcessedAsync(string transactionId, CancellationToken cancellationToken = default)
+    {
+        var entity = await _dbContext.DailyTransactions
+            .FirstOrDefaultAsync(d => d.Id == transactionId, cancellationToken);
+
+        if (entity is not null)
+        {
+            _dbContext.DailyTransactions.Remove(entity);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/src/NordKredit.Infrastructure/Transactions/SqlTransactionCategoryBalanceRepository.cs
+++ b/src/NordKredit.Infrastructure/Transactions/SqlTransactionCategoryBalanceRepository.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.Infrastructure.Transactions;
+
+/// <summary>
+/// Azure SQL implementation of <see cref="ITransactionCategoryBalanceRepository"/>.
+/// Replaces VSAM TRAN-CAT-BAL keyed file operations.
+/// </summary>
+public class SqlTransactionCategoryBalanceRepository : ITransactionCategoryBalanceRepository
+{
+    private readonly NordKreditDbContext _dbContext;
+
+    public SqlTransactionCategoryBalanceRepository(NordKreditDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<TransactionCategoryBalance?> GetAsync(
+        string accountId,
+        string typeCode,
+        int categoryCode,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.TransactionCategoryBalances
+            .FirstOrDefaultAsync(
+                b => b.AccountId == accountId && b.TypeCode == typeCode && b.CategoryCode == categoryCode,
+                cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<TransactionCategoryBalance>> GetByAccountIdAsync(
+        string accountId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.TransactionCategoryBalances
+            .Where(b => b.AccountId == accountId)
+            .OrderBy(b => b.TypeCode)
+            .ThenBy(b => b.CategoryCode)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task UpsertAsync(TransactionCategoryBalance balance, CancellationToken cancellationToken = default)
+    {
+        var existing = await GetAsync(balance.AccountId, balance.TypeCode, balance.CategoryCode, cancellationToken);
+
+        if (existing is null)
+        {
+            await _dbContext.TransactionCategoryBalances.AddAsync(balance, cancellationToken);
+        }
+        else
+        {
+            existing.Balance = balance.Balance;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/NordKredit.Infrastructure/Transactions/SqlTransactionRepository.cs
+++ b/src/NordKredit.Infrastructure/Transactions/SqlTransactionRepository.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.Infrastructure.Transactions;
+
+/// <summary>
+/// Azure SQL implementation of <see cref="ITransactionRepository"/>.
+/// Replaces VSAM TRANSACT file browse/read/write operations.
+/// </summary>
+public class SqlTransactionRepository : ITransactionRepository
+{
+    private readonly NordKreditDbContext _dbContext;
+
+    public SqlTransactionRepository(NordKreditDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Transaction?> GetByIdAsync(string transactionId, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Transactions
+            .FirstOrDefaultAsync(t => t.Id == transactionId, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Transaction>> GetByAccountIdAsync(
+        string accountId,
+        int pageSize,
+        string? startAfterTransactionId = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Keyset pagination matching COBOL VSAM STARTBR/READNEXT pattern
+        IQueryable<Transaction> query = _dbContext.Transactions
+            .Join(
+                _dbContext.CardCrossReferences,
+                t => t.CardNumber,
+                x => x.CardNumber,
+                (t, x) => new { Transaction = t, Xref = x })
+            .Where(j => j.Xref.AccountId == accountId)
+            .Select(j => j.Transaction)
+            .OrderBy(t => t.Id);
+
+        if (!string.IsNullOrEmpty(startAfterTransactionId))
+        {
+            query = query.Where(t => t.Id.CompareTo(startAfterTransactionId) > 0)
+                .OrderBy(t => t.Id);
+        }
+
+        return await query
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(Transaction transaction, CancellationToken cancellationToken = default)
+    {
+        await _dbContext.Transactions.AddAsync(transaction, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- Allow underscores in test method names (standard xUnit convention) -->
+    <NoWarn>$(NoWarn);CA1707</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/tests/NordKredit.BDD/NordKredit.BDD.csproj
+++ b/tests/NordKredit.BDD/NordKredit.BDD.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NordKredit.Domain\NordKredit.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/NordKredit.BDD/SmokeTest.cs
+++ b/tests/NordKredit.BDD/SmokeTest.cs
@@ -1,0 +1,11 @@
+namespace NordKredit.BDD;
+
+/// <summary>
+/// Placeholder test to verify BDD project builds and runs.
+/// SpecFlow scenarios will be added as business rules are implemented.
+/// </summary>
+public class SmokeTest
+{
+    [Fact]
+    public void BddProjectShouldBuild() => Assert.True(true);
+}

--- a/tests/NordKredit.ComparisonTests/NordKredit.ComparisonTests.csproj
+++ b/tests/NordKredit.ComparisonTests/NordKredit.ComparisonTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NordKredit.Domain\NordKredit.Domain.csproj" />
+    <ProjectReference Include="..\..\src\NordKredit.Infrastructure\NordKredit.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/NordKredit.ComparisonTests/SmokeTest.cs
+++ b/tests/NordKredit.ComparisonTests/SmokeTest.cs
@@ -1,0 +1,11 @@
+namespace NordKredit.ComparisonTests;
+
+/// <summary>
+/// Placeholder test to verify ComparisonTests project builds and runs.
+/// Output comparison tests (mainframe vs new system) will be added during parallel-run validation.
+/// </summary>
+public class SmokeTest
+{
+    [Fact]
+    public void ComparisonTestProjectShouldBuild() => Assert.True(true);
+}

--- a/tests/NordKredit.UnitTests/NordKredit.UnitTests.csproj
+++ b/tests/NordKredit.UnitTests/NordKredit.UnitTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NordKredit.Domain\NordKredit.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/NordKredit.UnitTests/Transactions/DailyTransactionTests.cs
+++ b/tests/NordKredit.UnitTests/Transactions/DailyTransactionTests.cs
@@ -1,0 +1,72 @@
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.UnitTests.Transactions;
+
+/// <summary>
+/// Tests for the DailyTransaction entity.
+/// COBOL source: CVTRA06Y.cpy (DALYTRAN-RECORD)
+/// </summary>
+public class DailyTransactionTests
+{
+    [Fact]
+    public void DailyTransaction_ShouldStoreAllFields()
+    {
+        var origTs = new DateTime(2026, 2, 10, 8, 0, 0, DateTimeKind.Utc);
+        var procTs = new DateTime(2026, 2, 10, 23, 30, 0, DateTimeKind.Utc);
+
+        var dailyTran = new DailyTransaction
+        {
+            Id = "0000000000000042",
+            TypeCode = "CR",
+            CategoryCode = 2001,
+            Source = "BATCH",
+            Description = "Salary deposit Nordea",
+            Amount = 35000.00m,
+            MerchantId = 987654321,
+            MerchantName = "Nordea Bank AB",
+            MerchantCity = "Stockholm",
+            MerchantZip = "10571",
+            CardNumber = "5425233430109903",
+            OriginationTimestamp = origTs,
+            ProcessingTimestamp = procTs
+        };
+
+        Assert.Equal("0000000000000042", dailyTran.Id);
+        Assert.Equal("CR", dailyTran.TypeCode);
+        Assert.Equal(2001, dailyTran.CategoryCode);
+        Assert.Equal("BATCH", dailyTran.Source);
+        Assert.Equal("Salary deposit Nordea", dailyTran.Description);
+        Assert.Equal(35000.00m, dailyTran.Amount);
+        Assert.Equal(987654321, dailyTran.MerchantId);
+        Assert.Equal("Nordea Bank AB", dailyTran.MerchantName);
+        Assert.Equal("Stockholm", dailyTran.MerchantCity);
+        Assert.Equal("10571", dailyTran.MerchantZip);
+        Assert.Equal("5425233430109903", dailyTran.CardNumber);
+        Assert.Equal(origTs, dailyTran.OriginationTimestamp);
+        Assert.Equal(procTs, dailyTran.ProcessingTimestamp);
+    }
+
+    [Fact]
+    public void DailyTransaction_Amount_ShouldBeDecimal()
+    {
+        var dailyTran = new DailyTransaction { Amount = 999999999.99m };
+
+        // COBOL: PIC S9(09)V99 — same layout as TRAN-RECORD
+        Assert.Equal(999999999.99m, dailyTran.Amount);
+    }
+
+    [Fact]
+    public void DailyTransaction_ShouldSupportSwedishCharacters()
+    {
+        var dailyTran = new DailyTransaction
+        {
+            MerchantName = "Göteborgs Spårvägar",
+            MerchantCity = "Västerås",
+            Description = "Månadskort Örebro länstrafik"
+        };
+
+        Assert.Contains("ö", dailyTran.MerchantName);
+        Assert.Contains("ä", dailyTran.MerchantCity);
+        Assert.Contains("Ö", dailyTran.Description);
+    }
+}

--- a/tests/NordKredit.UnitTests/Transactions/TransactionCategoryBalanceTests.cs
+++ b/tests/NordKredit.UnitTests/Transactions/TransactionCategoryBalanceTests.cs
@@ -1,0 +1,45 @@
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.UnitTests.Transactions;
+
+/// <summary>
+/// Tests for the TransactionCategoryBalance entity.
+/// COBOL source: CVTRA01Y.cpy (TRAN-CAT-BAL-RECORD)
+/// </summary>
+public class TransactionCategoryBalanceTests
+{
+    [Fact]
+    public void TransactionCategoryBalance_ShouldStoreAllFields()
+    {
+        var balance = new TransactionCategoryBalance
+        {
+            AccountId = "00000000001",
+            TypeCode = "DB",
+            CategoryCode = 5001,
+            Balance = 45678.90m
+        };
+
+        Assert.Equal("00000000001", balance.AccountId);
+        Assert.Equal("DB", balance.TypeCode);
+        Assert.Equal(5001, balance.CategoryCode);
+        Assert.Equal(45678.90m, balance.Balance);
+    }
+
+    [Fact]
+    public void TransactionCategoryBalance_Balance_ShouldBeDecimal()
+    {
+        var balance = new TransactionCategoryBalance { Balance = 999999999.99m };
+
+        // COBOL: PIC S9(09)V99 — same as transaction amount
+        Assert.Equal(999999999.99m, balance.Balance);
+    }
+
+    [Fact]
+    public void TransactionCategoryBalance_Balance_ShouldSupportNegativeValues()
+    {
+        // COBOL: PIC S9(09)V99 — signed field
+        var balance = new TransactionCategoryBalance { Balance = -1234.56m };
+
+        Assert.Equal(-1234.56m, balance.Balance);
+    }
+}

--- a/tests/NordKredit.UnitTests/Transactions/TransactionTests.cs
+++ b/tests/NordKredit.UnitTests/Transactions/TransactionTests.cs
@@ -1,0 +1,82 @@
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.UnitTests.Transactions;
+
+/// <summary>
+/// Tests for the Transaction entity.
+/// COBOL source: CVTRA05Y.cpy (TRAN-RECORD)
+/// </summary>
+public class TransactionTests
+{
+    [Fact]
+    public void Transaction_ShouldStoreAllFields()
+    {
+        var origTs = new DateTime(2026, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+        var procTs = new DateTime(2026, 1, 15, 11, 0, 0, DateTimeKind.Utc);
+
+        var transaction = new Transaction
+        {
+            Id = "0000000000000001",
+            TypeCode = "DB",
+            CategoryCode = 1001,
+            Source = "ONLINE",
+            Description = "Grocery purchase at ICA Maxi",
+            Amount = 1234.56m,
+            MerchantId = 123456789,
+            MerchantName = "ICA Maxi Göteborg",
+            MerchantCity = "Göteborg",
+            MerchantZip = "41101",
+            CardNumber = "4532015112830366",
+            OriginationTimestamp = origTs,
+            ProcessingTimestamp = procTs
+        };
+
+        Assert.Equal("0000000000000001", transaction.Id);
+        Assert.Equal("DB", transaction.TypeCode);
+        Assert.Equal(1001, transaction.CategoryCode);
+        Assert.Equal("ONLINE", transaction.Source);
+        Assert.Equal("Grocery purchase at ICA Maxi", transaction.Description);
+        Assert.Equal(1234.56m, transaction.Amount);
+        Assert.Equal(123456789, transaction.MerchantId);
+        Assert.Equal("ICA Maxi Göteborg", transaction.MerchantName);
+        Assert.Equal("Göteborg", transaction.MerchantCity);
+        Assert.Equal("41101", transaction.MerchantZip);
+        Assert.Equal("4532015112830366", transaction.CardNumber);
+        Assert.Equal(origTs, transaction.OriginationTimestamp);
+        Assert.Equal(procTs, transaction.ProcessingTimestamp);
+    }
+
+    [Fact]
+    public void Transaction_Amount_ShouldBeDecimal()
+    {
+        var transaction = new Transaction { Amount = 999999999.99m };
+
+        // COBOL: PIC S9(09)V99 — max value 999,999,999.99
+        Assert.Equal(999999999.99m, transaction.Amount);
+    }
+
+    [Fact]
+    public void Transaction_Amount_ShouldSupportNegativeValues()
+    {
+        // COBOL: PIC S9(09)V99 — signed field supports negative
+        var transaction = new Transaction { Amount = -500.00m };
+
+        Assert.Equal(-500.00m, transaction.Amount);
+    }
+
+    [Fact]
+    public void Transaction_ShouldSupportSwedishCharacters()
+    {
+        // EBCDIC-to-UTF-8: Swedish characters (Å, Ä, Ö)
+        var transaction = new Transaction
+        {
+            MerchantName = "Systembolaget Ängelholm",
+            MerchantCity = "Malmö",
+            Description = "Köp av dagligvaror på Åhléns"
+        };
+
+        Assert.Contains("Ä", transaction.MerchantName);
+        Assert.Contains("ö", transaction.MerchantCity);
+        Assert.Contains("Å", transaction.Description);
+    }
+}


### PR DESCRIPTION
## Summary
- Scaffolds the complete .NET 8 solution structure with 7 projects per CLAUDE.md project layout
- Implements Transaction domain entities mapped from COBOL copybooks (CVTRA05Y, CVTRA06Y, CVTRA01Y, CVACT01Y, CVACT03Y)
- Defines repository interfaces and Azure SQL implementations with EF Core
- Configures .editorconfig, Directory.Build.props, and Roslyn analyzers for zero-warning builds

## Changes
- **NordKredit.sln** — Solution file tying 4 source + 3 test projects together
- **src/NordKredit.Domain/Transactions/** — 5 entities (Transaction, DailyTransaction, TransactionCategoryBalance, Account, CardCrossReference) and 5 repository interfaces
- **src/NordKredit.Infrastructure/** — NordKreditDbContext with EF Core Fluent API config + 5 SQL repository implementations
- **src/NordKredit.Api/** — Minimal web API with health endpoint
- **src/NordKredit.Functions/** — Worker service placeholder for batch jobs
- **tests/** — 10 domain entity unit tests + 2 smoke tests across 3 test projects
- **.editorconfig + Directory.Build.props** — TreatWarningsAsErrors, Roslyn analyzers at latest-recommended, file-scoped namespaces
- **.github/workflows/ci.yml** — Updated with .NET 8 build, test, and format checks

## COBOL Traceability
| Entity | COBOL Source | SQL Precision |
|--------|-------------|---------------|
| Transaction | CVTRA05Y.cpy (TRAN-RECORD) | decimal(11,2) |
| DailyTransaction | CVTRA06Y.cpy (DALYTRAN-RECORD) | decimal(11,2) |
| TransactionCategoryBalance | CVTRA01Y.cpy (TRAN-CAT-BAL-RECORD) | decimal(11,2) |
| Account | CVACT01Y.cpy (ACCOUNT-RECORD) | decimal(12,2) |
| CardCrossReference | CVACT03Y.cpy (CARD-XREF-RECORD) | N/A |

## Testing
- [x] 10 unit tests for domain entities (field storage, decimal precision, Swedish characters, negative amounts)
- [x] 2 smoke tests (BDD + ComparisonTests projects)
- [x] `dotnet build /warnaserror` — 0 warnings, 0 errors
- [x] `dotnet test` — 12 passed, 0 failed
- [x] `dotnet format --verify-no-changes` — clean

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)