### PR TITLE
feat(#74): Add transaction detail view API endpoint

### DIFF
--- a/src/NordKredit.Api/Program.cs
+++ b/src/NordKredit.Api/Program.cs
@@ -6,9 +6,10 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 
-// Transaction domain services (COTRN02C.cbl — online transaction processing)
+// Transaction domain services (COTRN00C/01C/02C — online transaction processing)
 builder.Services.AddScoped<TransactionValidationService>();
 builder.Services.AddScoped<TransactionAddService>();
+builder.Services.AddScoped<TransactionDetailService>();
 builder.Services.AddScoped<TransactionListService>();
 
 // Infrastructure bindings — Azure SQL repositories replace VSAM file I/O

--- a/src/NordKredit.Domain/Transactions/TransactionDetailResponse.cs
+++ b/src/NordKredit.Domain/Transactions/TransactionDetailResponse.cs
@@ -1,0 +1,25 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Read-only detail view of a single transaction.
+/// COBOL source: COTRN01C.cbl:85-296 (CICS transaction CT01 — transaction detail screen).
+/// Card number is masked per PCI-DSS compliance (show only last 4 digits).
+/// Regulations: FFFS 2014:5 Ch.8 (accurate records), PSD2 Art.94 (transaction retention),
+/// GDPR Art.15 (right of access to personal data).
+/// </summary>
+public sealed class TransactionDetailResponse
+{
+    public required string TransactionId { get; init; }
+    public required string CardNumber { get; init; }
+    public required string TypeCode { get; init; }
+    public required int CategoryCode { get; init; }
+    public required string Source { get; init; }
+    public required decimal Amount { get; init; }
+    public required string Description { get; init; }
+    public required DateTime OriginationTimestamp { get; init; }
+    public required DateTime ProcessingTimestamp { get; init; }
+    public required int MerchantId { get; init; }
+    public required string MerchantName { get; init; }
+    public required string MerchantCity { get; init; }
+    public required string MerchantZip { get; init; }
+}

--- a/src/NordKredit.Domain/Transactions/TransactionDetailService.cs
+++ b/src/NordKredit.Domain/Transactions/TransactionDetailService.cs
@@ -1,0 +1,61 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Retrieves and formats a single transaction for read-only detail view.
+/// COBOL source: COTRN01C.cbl:85-296 (CICS transaction CT01).
+/// Replaces READ TRANSACT-FILE INTO WS-TRAN-RECORD (line 275).
+/// Note: COBOL used READ with UPDATE lock — this is a legacy pattern; read-only is correct.
+/// Regulations: FFFS 2014:5 Ch.8, PSD2 Art.94, GDPR Art.15.
+/// </summary>
+public class TransactionDetailService
+{
+    private readonly ITransactionRepository _transactionRepository;
+
+    public TransactionDetailService(ITransactionRepository transactionRepository)
+    {
+        _transactionRepository = transactionRepository;
+    }
+
+    public async Task<TransactionDetailResponse?> GetByIdAsync(
+        string transactionId,
+        CancellationToken cancellationToken = default)
+    {
+        var transaction = await _transactionRepository.GetByIdAsync(transactionId, cancellationToken);
+
+        if (transaction is null)
+        {
+            return null;
+        }
+
+        return new TransactionDetailResponse
+        {
+            TransactionId = transaction.Id,
+            CardNumber = MaskCardNumber(transaction.CardNumber),
+            TypeCode = transaction.TypeCode,
+            CategoryCode = transaction.CategoryCode,
+            Source = transaction.Source,
+            Amount = transaction.Amount,
+            Description = transaction.Description,
+            OriginationTimestamp = transaction.OriginationTimestamp,
+            ProcessingTimestamp = transaction.ProcessingTimestamp,
+            MerchantId = transaction.MerchantId,
+            MerchantName = transaction.MerchantName,
+            MerchantCity = transaction.MerchantCity,
+            MerchantZip = transaction.MerchantZip
+        };
+    }
+
+    /// <summary>
+    /// Masks card number for PCI-DSS compliance — show only last 4 digits.
+    /// Cards shorter than 5 characters are returned as-is (not enough digits to mask).
+    /// </summary>
+    internal static string MaskCardNumber(string cardNumber)
+    {
+        if (string.IsNullOrEmpty(cardNumber) || cardNumber.Length <= 4)
+        {
+            return cardNumber;
+        }
+
+        return new string('*', cardNumber.Length - 4) + cardNumber[^4..];
+    }
+}

--- a/tests/NordKredit.UnitTests/Transactions/TransactionDetailServiceTests.cs
+++ b/tests/NordKredit.UnitTests/Transactions/TransactionDetailServiceTests.cs
@@ -1,0 +1,171 @@
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.UnitTests.Transactions;
+
+/// <summary>
+/// Unit tests for TransactionDetailService.
+/// COBOL source: COTRN01C.cbl:85-296 (CICS transaction CT01 — transaction detail view).
+/// Regulations: FFFS 2014:5 Ch.8, PSD2 Art.94, GDPR Art.15 (right of access).
+/// </summary>
+public class TransactionDetailServiceTests
+{
+    private readonly StubDetailRepository _repo = new();
+    private readonly TransactionDetailService _service;
+
+    public TransactionDetailServiceTests()
+    {
+        _service = new TransactionDetailService(_repo);
+    }
+
+    private static Transaction CreateTestTransaction(string id = "0000000000000042") => new()
+    {
+        Id = id,
+        TypeCode = "SA",
+        CategoryCode = 5010,
+        Source = "ONLINE",
+        Description = "Monthly rent payment",
+        Amount = 12500.00m,
+        MerchantId = 123456789,
+        MerchantName = "Stockholm Housing AB",
+        MerchantCity = "Stockholm",
+        MerchantZip = "11122",
+        CardNumber = "4000123456780042",
+        OriginationTimestamp = new DateTime(2026, 1, 15, 10, 30, 0),
+        ProcessingTimestamp = new DateTime(2026, 1, 15, 14, 45, 0)
+    };
+
+    // ===================================================================
+    // Happy path — transaction found (COTRN01C.cbl:261-280)
+    // ===================================================================
+
+    [Fact]
+    public async Task GetByIdAsync_ExistingTransaction_ReturnsDetail()
+    {
+        // GIVEN transaction "0000000000000042" exists
+        _repo.Add(CreateTestTransaction());
+
+        // WHEN the detail is requested
+        var result = await _service.GetByIdAsync("0000000000000042", CancellationToken.None);
+
+        // THEN a detail response is returned
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ExistingTransaction_ReturnsAllFields()
+    {
+        // GIVEN transaction "0000000000000042" exists
+        _repo.Add(CreateTestTransaction());
+
+        // WHEN the detail is requested
+        var result = await _service.GetByIdAsync("0000000000000042", CancellationToken.None);
+
+        // THEN all 14 fields are populated
+        Assert.NotNull(result);
+        Assert.Equal("0000000000000042", result.TransactionId);
+        Assert.Equal("SA", result.TypeCode);
+        Assert.Equal(5010, result.CategoryCode);
+        Assert.Equal("ONLINE", result.Source);
+        Assert.Equal("Monthly rent payment", result.Description);
+        Assert.Equal(12500.00m, result.Amount);
+        Assert.Equal(123456789, result.MerchantId);
+        Assert.Equal("Stockholm Housing AB", result.MerchantName);
+        Assert.Equal("Stockholm", result.MerchantCity);
+        Assert.Equal("11122", result.MerchantZip);
+        Assert.Equal(new DateTime(2026, 1, 15, 10, 30, 0), result.OriginationTimestamp);
+        Assert.Equal(new DateTime(2026, 1, 15, 14, 45, 0), result.ProcessingTimestamp);
+    }
+
+    // ===================================================================
+    // Card number masking — PCI-DSS compliance
+    // ===================================================================
+
+    [Fact]
+    public async Task GetByIdAsync_ExistingTransaction_MasksCardNumber()
+    {
+        // GIVEN transaction with card number "4000123456780042"
+        _repo.Add(CreateTestTransaction());
+
+        // WHEN the detail is requested
+        var result = await _service.GetByIdAsync("0000000000000042", CancellationToken.None);
+
+        // THEN card number shows only last 4 digits
+        Assert.NotNull(result);
+        Assert.Equal("************0042", result.CardNumber);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShortCardNumber_MasksAvailableDigits()
+    {
+        // GIVEN transaction with a short card number (edge case)
+        var transaction = CreateTestTransaction();
+        transaction.CardNumber = "1234";
+        _repo.Add(transaction);
+
+        var result = await _service.GetByIdAsync("0000000000000042", CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("1234", result.CardNumber);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_EmptyCardNumber_ReturnsEmpty()
+    {
+        // GIVEN transaction with empty card number
+        var transaction = CreateTestTransaction();
+        transaction.CardNumber = "";
+        _repo.Add(transaction);
+
+        var result = await _service.GetByIdAsync("0000000000000042", CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("", result.CardNumber);
+    }
+
+    // ===================================================================
+    // Not found — COTRN01C.cbl:286-292 "Transaction ID NOT found"
+    // ===================================================================
+
+    [Fact]
+    public async Task GetByIdAsync_NonExistentTransaction_ReturnsNull()
+    {
+        // GIVEN no transaction with ID "9999999999999999"
+        // WHEN the detail is requested
+        var result = await _service.GetByIdAsync("9999999999999999", CancellationToken.None);
+
+        // THEN null is returned
+        Assert.Null(result);
+    }
+}
+
+/// <summary>
+/// In-memory test double for ITransactionRepository — detail view tests.
+/// </summary>
+internal sealed class StubDetailRepository : ITransactionRepository
+{
+    private readonly List<Transaction> _transactions = [];
+
+    public void Add(Transaction transaction) => _transactions.Add(transaction);
+
+    public Task<Transaction?> GetByIdAsync(string transactionId, CancellationToken cancellationToken = default)
+        => Task.FromResult(_transactions.FirstOrDefault(t => t.Id == transactionId));
+
+    public Task<IReadOnlyList<Transaction>> GetByAccountIdAsync(
+        string accountId, int pageSize, string? startAfterTransactionId = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<Transaction>>([]);
+
+    public Task AddAsync(Transaction transaction, CancellationToken cancellationToken = default)
+    {
+        _transactions.Add(transaction);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<Transaction>> GetPageAsync(
+        int pageSize, string? startAfterTransactionId = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<Transaction>>([]);
+
+    public Task<Transaction?> GetLastTransactionAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<Transaction?>(null);
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/transactions/{id}` endpoint replacing COBOL CICS transaction CT01 (COTRN01C.cbl:85-296)
- Return all 14 transaction fields with card number masked per PCI-DSS (show only last 4 digits)
- Handle 400 (empty ID), 404 (not found), and 200 (detail view) responses matching COBOL error messages

## Changes
- `src/NordKredit.Domain/Transactions/TransactionDetailService.cs` — read-only lookup with card masking logic
- `src/NordKredit.Domain/Transactions/TransactionDetailResponse.cs` — response DTO with all 14 fields
- `src/NordKredit.Api/Controllers/TransactionsController.cs` — new `[HttpGet("{transactionId}")]` endpoint
- `src/NordKredit.Api/Program.cs` — register `TransactionDetailService` in DI
- `tests/NordKredit.UnitTests/Transactions/TransactionDetailServiceTests.cs` — service tests (masking, not found, all fields)
- `tests/NordKredit.UnitTests/Transactions/TransactionsControllerTests.cs` — controller HTTP mapping tests

## Regulatory Traceability
- **Source**: COTRN01C.cbl:85-296 (CICS transaction CT01)
- **Requirement**: TRN-BR-002
- **Regulations**: FFFS 2014:5 Ch.8 (accurate records), PSD2 Art.94 (transaction retention), GDPR Art.15 (right of access)

## Testing
- [x] Unit tests pass (123/123)
- [x] Build succeeds with zero warnings (`dotnet build /warnaserror`)
- [x] Formatting clean (`dotnet format --verify-no-changes`)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)