### PR TITLE
feat(#89): Add card shared input validation service (CARD-BR-004, CARD-BR-005)

### DIFF
--- a/src/NordKredit.Domain/CardManagement/CardValidationResult.cs
+++ b/src/NordKredit.Domain/CardManagement/CardValidationResult.cs
@@ -1,0 +1,28 @@
+namespace NordKredit.Domain.CardManagement;
+
+/// <summary>
+/// Result of card input validation (account number or card number).
+/// COBOL source: COCRDLIC.cbl:1003-1034, COCRDSLC.cbl:647-724, COCRDUPC.cbl:721-800.
+/// Consolidates duplicated validation logic from three COBOL programs into a single reusable result type.
+/// Regulations: FFFS 2014:5 Ch. 4 §3 (operational risk), PSD2 Art. 97.
+/// </summary>
+public class CardValidationResult
+{
+    /// <summary>Whether validation passed with no errors.</summary>
+    public bool IsValid { get; }
+
+    /// <summary>Error message if validation failed. Maps to COBOL WS-MESSAGE.</summary>
+    public string? ErrorMessage { get; }
+
+    private CardValidationResult(bool isValid, string? errorMessage)
+    {
+        IsValid = isValid;
+        ErrorMessage = errorMessage;
+    }
+
+    public static CardValidationResult Success()
+        => new(true, null);
+
+    public static CardValidationResult Error(string errorMessage)
+        => new(false, errorMessage);
+}

--- a/src/NordKredit.Domain/CardManagement/CardValidationService.cs
+++ b/src/NordKredit.Domain/CardManagement/CardValidationService.cs
@@ -1,0 +1,87 @@
+namespace NordKredit.Domain.CardManagement;
+
+/// <summary>
+/// Shared input validation for account numbers and card numbers used across card management programs.
+/// COBOL source: COCRDLIC.cbl:1003-1034, COCRDSLC.cbl:647-724, COCRDUPC.cbl:721-800.
+/// Consolidates identical validation logic duplicated in list (COCRDLIC), detail (COCRDSLC),
+/// and update (COCRDUPC) programs into a single reusable service.
+/// Regulations: FFFS 2014:5 Ch. 4 §3 (operational risk), PSD2 Art. 97.
+/// </summary>
+public static class CardValidationService
+{
+    /// <summary>
+    /// Validates an account number input.
+    /// COBOL: EDIT-ACCOUNT paragraph — COCRDLIC.cbl:1003-1034, COCRDSLC.cbl:647-683, COCRDUPC.cbl:721-760.
+    /// Business rule: CARD-BR-004.
+    /// </summary>
+    /// <param name="accountNumber">The account number to validate.</param>
+    /// <param name="required">
+    /// True for detail/update programs (blank = error).
+    /// False for list program (blank = skip filter).
+    /// </param>
+    public static CardValidationResult ValidateAccountNumber(string? accountNumber, bool required)
+    {
+        // Blank check — COBOL: IF account-id = SPACES OR LOW-VALUES
+        if (string.IsNullOrWhiteSpace(accountNumber))
+        {
+            return required
+                ? CardValidationResult.Error("Account number not provided")
+                : CardValidationResult.Success();
+        }
+
+        // Numeric and length check — COBOL: IF account-id IS NOT NUMERIC
+        // Also catches all-zeros — COBOL: IF account-id = ZEROS
+        if (!IsValidNumericField(accountNumber, 11))
+        {
+            return CardValidationResult.Error("ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER");
+        }
+
+        return CardValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates a card number input.
+    /// COBOL: EDIT-CARD paragraph — COCRDSLC.cbl:685-724, COCRDUPC.cbl:762-800.
+    /// Business rule: CARD-BR-005.
+    /// </summary>
+    /// <param name="cardNumber">The card number to validate.</param>
+    /// <param name="required">
+    /// True for detail/update programs (blank = error).
+    /// False for list program (blank = skip filter).
+    /// </param>
+    public static CardValidationResult ValidateCardNumber(string? cardNumber, bool required)
+    {
+        // Blank check — COBOL: IF card-number = SPACES OR LOW-VALUES OR ZEROS
+        // Card number treats all-zeros as blank (unlike account number)
+        if (string.IsNullOrWhiteSpace(cardNumber) || IsAllZeros(cardNumber))
+        {
+            return required
+                ? CardValidationResult.Error("Card number not provided")
+                : CardValidationResult.Success();
+        }
+
+        // Numeric and length check — COBOL: IF card-number IS NOT NUMERIC
+        if (!IsValidNumericField(cardNumber, 16))
+        {
+            return CardValidationResult.Error("CARD ID FILTER,IF SUPPLIED MUST BE A 16 DIGIT NUMBER");
+        }
+
+        return CardValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Checks if a value is exactly the expected length and all ASCII digits, and not all zeros.
+    /// Combines the COBOL IS NUMERIC check with length validation and zeros check.
+    /// </summary>
+    private static bool IsValidNumericField(string value, int expectedLength) =>
+        value.Length == expectedLength
+        && value.All(char.IsAsciiDigit)
+        && !IsAllZeros(value);
+
+    /// <summary>
+    /// Checks if the string consists entirely of '0' characters.
+    /// COBOL: IF field = ZEROS.
+    /// </summary>
+    private static bool IsAllZeros(string value) =>
+        value.All(c => c == '0');
+}

--- a/tests/NordKredit.UnitTests/CardManagement/CardValidationServiceTests.cs
+++ b/tests/NordKredit.UnitTests/CardManagement/CardValidationServiceTests.cs
@@ -1,0 +1,261 @@
+using NordKredit.Domain.CardManagement;
+
+namespace NordKredit.UnitTests.CardManagement;
+
+/// <summary>
+/// Unit tests for CardValidationService.
+/// COBOL source: COCRDLIC.cbl:1003-1034, COCRDSLC.cbl:647-724, COCRDUPC.cbl:721-800.
+/// Covers account number validation (CARD-BR-004) and card number validation (CARD-BR-005).
+/// Regulations: FFFS 2014:5 Ch. 4 §3 (operational risk), PSD2 Art. 97.
+/// </summary>
+public class CardValidationServiceTests
+{
+    // ===================================================================
+    // Account Number Validation — CARD-BR-004
+    // COBOL: COCRDLIC.cbl:1003-1034, COCRDSLC.cbl:647-683, COCRDUPC.cbl:721-760
+    // ===================================================================
+
+    [Fact]
+    public void ValidateAccountNumber_ValidElevenDigits_Passes()
+    {
+        var result = CardValidationService.ValidateAccountNumber("12345678901", required: true);
+
+        Assert.True(result.IsValid);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateAccountNumber_ValidWithLeadingZeros_Passes()
+    {
+        var result = CardValidationService.ValidateAccountNumber("00012345678", required: true);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ValidateAccountNumber_Null_Required_ReturnsNotProvided()
+    {
+        var result = CardValidationService.ValidateAccountNumber(null, required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Account number not provided", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateAccountNumber_Empty_Required_ReturnsNotProvided()
+    {
+        var result = CardValidationService.ValidateAccountNumber("", required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Account number not provided", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateAccountNumber_Whitespace_Required_ReturnsNotProvided()
+    {
+        var result = CardValidationService.ValidateAccountNumber("           ", required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Account number not provided", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateAccountNumber_Null_NotRequired_Passes()
+    {
+        var result = CardValidationService.ValidateAccountNumber(null, required: false);
+
+        Assert.True(result.IsValid);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateAccountNumber_Empty_NotRequired_Passes()
+    {
+        var result = CardValidationService.ValidateAccountNumber("", required: false);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ValidateAccountNumber_Whitespace_NotRequired_Passes()
+    {
+        var result = CardValidationService.ValidateAccountNumber("   ", required: false);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData("ABCDEFGHIJK")]
+    [InlineData("ABC12345678")]
+    [InlineData("1234567890A")]
+    [InlineData("12345 67890")]
+    public void ValidateAccountNumber_NonNumeric_ReturnsFormatError(string input)
+    {
+        var result = CardValidationService.ValidateAccountNumber(input, required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateAccountNumber_AllZeros_ReturnsFormatError()
+    {
+        var result = CardValidationService.ValidateAccountNumber("00000000000", required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateAccountNumber_TooShort_ReturnsFormatError()
+    {
+        // In COBOL, shorter input is padded with spaces, making it non-numeric
+        var result = CardValidationService.ValidateAccountNumber("12345", required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateAccountNumber_TooLong_ReturnsFormatError()
+    {
+        var result = CardValidationService.ValidateAccountNumber("123456789012", required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateAccountNumber_NonNumeric_NotRequired_ReturnsFormatError()
+    {
+        // Even when not required, if provided it must be valid
+        var result = CardValidationService.ValidateAccountNumber("ABCDEFGHIJK", required: false);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER", result.ErrorMessage);
+    }
+
+    // ===================================================================
+    // Card Number Validation — CARD-BR-005
+    // COBOL: COCRDSLC.cbl:685-724, COCRDUPC.cbl:762-800
+    // ===================================================================
+
+    [Fact]
+    public void ValidateCardNumber_ValidSixteenDigits_Passes()
+    {
+        var result = CardValidationService.ValidateCardNumber("4000123456789012", required: true);
+
+        Assert.True(result.IsValid);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateCardNumber_ValidWithLeadingZeros_Passes()
+    {
+        var result = CardValidationService.ValidateCardNumber("0000123456789012", required: true);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ValidateCardNumber_Null_Required_ReturnsNotProvided()
+    {
+        var result = CardValidationService.ValidateCardNumber(null, required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Card number not provided", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateCardNumber_Empty_Required_ReturnsNotProvided()
+    {
+        var result = CardValidationService.ValidateCardNumber("", required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Card number not provided", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateCardNumber_Whitespace_Required_ReturnsNotProvided()
+    {
+        var result = CardValidationService.ValidateCardNumber("                ", required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Card number not provided", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateCardNumber_AllZeros_Required_ReturnsNotProvided()
+    {
+        // COBOL treats all-zeros same as blank for card number
+        var result = CardValidationService.ValidateCardNumber("0000000000000000", required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Card number not provided", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateCardNumber_Null_NotRequired_Passes()
+    {
+        var result = CardValidationService.ValidateCardNumber(null, required: false);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ValidateCardNumber_Empty_NotRequired_Passes()
+    {
+        var result = CardValidationService.ValidateCardNumber("", required: false);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ValidateCardNumber_AllZeros_NotRequired_Passes()
+    {
+        // When not required, all-zeros is treated as blank (skip filter)
+        var result = CardValidationService.ValidateCardNumber("0000000000000000", required: false);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData("ABCD123456789012")]
+    [InlineData("400012345678901A")]
+    [InlineData("40001234 5678901")]
+    public void ValidateCardNumber_NonNumeric_ReturnsFormatError(string input)
+    {
+        var result = CardValidationService.ValidateCardNumber(input, required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("CARD ID FILTER,IF SUPPLIED MUST BE A 16 DIGIT NUMBER", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateCardNumber_TooShort_ReturnsFormatError()
+    {
+        var result = CardValidationService.ValidateCardNumber("1234567890", required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("CARD ID FILTER,IF SUPPLIED MUST BE A 16 DIGIT NUMBER", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateCardNumber_TooLong_ReturnsFormatError()
+    {
+        var result = CardValidationService.ValidateCardNumber("12345678901234567", required: true);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("CARD ID FILTER,IF SUPPLIED MUST BE A 16 DIGIT NUMBER", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateCardNumber_NonNumeric_NotRequired_ReturnsFormatError()
+    {
+        // Even when not required, if provided it must be valid
+        var result = CardValidationService.ValidateCardNumber("ABCD123456789012", required: false);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("CARD ID FILTER,IF SUPPLIED MUST BE A 16 DIGIT NUMBER", result.ErrorMessage);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `CardValidationService` with `ValidateAccountNumber` and `ValidateCardNumber` methods in `src/NordKredit.Domain/CardManagement/`
- Adds `CardValidationResult` value object with `Success()`/`Error()` factory methods following existing `TransactionValidationResult` pattern
- Consolidates identical validation logic duplicated across three COBOL programs (COCRDLIC, COCRDSLC, COCRDUPC) into a single reusable service

## Changes
- `src/NordKredit.Domain/CardManagement/CardValidationResult.cs` — Immutable result type with private constructor and static factory methods
- `src/NordKredit.Domain/CardManagement/CardValidationService.cs` — Static validation service implementing CARD-BR-004 (account number: 11 digits, numeric, not all zeros) and CARD-BR-005 (card number: 16 digits, numeric, all-zeros treated as blank)
- `tests/NordKredit.UnitTests/CardManagement/CardValidationServiceTests.cs` — 31 unit tests covering all acceptance criteria

## Regulatory Traceability
- **CARD-BR-004**: Account number validation — COBOL: `COCRDLIC.cbl:1003-1034`, `COCRDSLC.cbl:647-683`, `COCRDUPC.cbl:721-760` — FFFS 2014:5 Ch. 4 §3
- **CARD-BR-005**: Card number validation — COBOL: `COCRDSLC.cbl:685-724`, `COCRDUPC.cbl:762-800` — FFFS 2014:5 Ch. 4 §3, PSD2 Art. 97

## Testing
- [x] 31 unit tests pass (14 account number + 14 card number + 3 Theory variations)
- [x] All 219 tests in solution pass
- [x] Build passes with zero warnings (`dotnet build /warnaserror`)
- [x] Format check passes (`dotnet format --verify-no-changes`)

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)