### PR TITLE
feat(#90): Add card update field validation rules (CARD-BR-006)

### DIFF
--- a/src/NordKredit.Domain/CardManagement/CardChangeDetectionResult.cs
+++ b/src/NordKredit.Domain/CardManagement/CardChangeDetectionResult.cs
@@ -1,0 +1,30 @@
+namespace NordKredit.Domain.CardManagement;
+
+/// <summary>
+/// Result of comparing new card data with existing card data.
+/// COBOL source: COCRDUPC.cbl 1200-EDIT-MAP-INPUTS — case-insensitive comparison via UPPER-CASE.
+/// Regulations: GDPR Art. 5(1)(d) — prevents unnecessary data modifications.
+/// </summary>
+public class CardChangeDetectionResult
+{
+    /// <summary>Whether any field value differs from the stored record.</summary>
+    public bool HasChanges { get; }
+
+    /// <summary>
+    /// Message when no changes detected. Maps to COBOL WS-MESSAGE.
+    /// Null when changes are detected.
+    /// </summary>
+    public string? Message { get; }
+
+    private CardChangeDetectionResult(bool hasChanges, string? message)
+    {
+        HasChanges = hasChanges;
+        Message = message;
+    }
+
+    public static CardChangeDetectionResult Changed()
+        => new(true, null);
+
+    public static CardChangeDetectionResult NoChange()
+        => new(false, "No change detected with respect to values fetched.");
+}

--- a/src/NordKredit.Domain/CardManagement/CardUpdateValidationResult.cs
+++ b/src/NordKredit.Domain/CardManagement/CardUpdateValidationResult.cs
@@ -1,0 +1,31 @@
+namespace NordKredit.Domain.CardManagement;
+
+/// <summary>
+/// Result of card update field validation that collects ALL errors simultaneously.
+/// Improvement over COBOL: COCRDUPC.cbl only reports the first error via WS-RETURN-MSG-OFF flag.
+/// The migrated system validates all fields and returns every error at once.
+/// COBOL source: COCRDUPC.cbl:806-947.
+/// Regulations: FFFS 2014:5 Ch. 4 §3 (operational risk), PSD2 Art. 97, GDPR Art. 5(1)(d).
+/// </summary>
+public class CardUpdateValidationResult
+{
+    /// <summary>Whether all field validations passed with no errors.</summary>
+    public bool IsValid => Errors.Count == 0;
+
+    /// <summary>
+    /// All validation error messages. Empty when valid.
+    /// COBOL reported only the first error; this returns all errors simultaneously.
+    /// </summary>
+    public IReadOnlyList<string> Errors { get; }
+
+    private CardUpdateValidationResult(IReadOnlyList<string> errors)
+    {
+        Errors = errors;
+    }
+
+    public static CardUpdateValidationResult Success()
+        => new([]);
+
+    public static CardUpdateValidationResult WithErrors(IReadOnlyList<string> errors)
+        => new(errors);
+}

--- a/src/NordKredit.Domain/CardManagement/CardUpdateValidator.cs
+++ b/src/NordKredit.Domain/CardManagement/CardUpdateValidator.cs
@@ -1,0 +1,161 @@
+namespace NordKredit.Domain.CardManagement;
+
+/// <summary>
+/// Validates card update fields: embossed name, active status, expiry month, and expiry year.
+/// Also detects when no modifications were made (case-insensitive comparison).
+/// COBOL source: COCRDUPC.cbl:806-947, 87-99, 255-263.
+/// Business rule: CARD-BR-006.
+/// Regulations: FFFS 2014:5 Ch. 4 §3, PSD2 Art. 97, GDPR Art. 5(1)(d).
+/// </summary>
+public static class CardUpdateValidator
+{
+    /// <summary>
+    /// Validates the embossed name field.
+    /// COBOL: paragraph 1230-EDIT-NAME (COCRDUPC.cbl:806-843).
+    /// Must contain only Unicode letters and spaces. Extends COBOL A-Z/a-z to include
+    /// Swedish characters (Å, Ä, Ö) and other Unicode letter categories.
+    /// </summary>
+    public static CardValidationResult ValidateEmbossedName(string? embossedName)
+    {
+        // Blank check — COBOL: IF CCUP-NEW-CRDNAME = LOW-VALUES OR SPACES OR ZEROS
+        if (string.IsNullOrWhiteSpace(embossedName))
+        {
+            return CardValidationResult.Error("Card name not provided");
+        }
+
+        // Alpha check — COBOL: INSPECT CARD-NAME-CHECK CONVERTING LIT-ALL-ALPHA-FROM TO LIT-ALL-SPACES-TO
+        // Extended from COBOL A-Z/a-z (PIC X(52)) to Unicode letters for Swedish names (Å, Ä, Ö).
+        foreach (var c in embossedName)
+        {
+            if (!char.IsLetter(c) && c != ' ')
+            {
+                return CardValidationResult.Error("Card name can only contain alphabets and spaces");
+            }
+        }
+
+        return CardValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates the active status field.
+    /// COBOL: paragraph 1240-EDIT-CARDSTATUS (COCRDUPC.cbl:845-876).
+    /// Must be 'Y' or 'N' (uppercase only, per COBOL 88-level FLG-YES-NO-VALID).
+    /// </summary>
+    public static CardValidationResult ValidateActiveStatus(char activeStatus)
+    {
+        // COBOL: 88 FLG-YES-NO-VALID VALUES 'Y', 'N'.
+        if (activeStatus is 'Y' or 'N')
+        {
+            return CardValidationResult.Success();
+        }
+
+        return CardValidationResult.Error("Card Active Status must be Y or N");
+    }
+
+    /// <summary>
+    /// Validates the expiry month field.
+    /// COBOL: paragraph 1250-EDIT-EXPIRY-MON (COCRDUPC.cbl:877-912).
+    /// Must be between 1 and 12 inclusive. COBOL: 88 VALID-MONTH VALUES 1 THRU 12.
+    /// </summary>
+    public static CardValidationResult ValidateExpiryMonth(int expiryMonth)
+    {
+        // COBOL: 88 VALID-MONTH VALUES 1 THRU 12.
+        if (expiryMonth is >= 1 and <= 12)
+        {
+            return CardValidationResult.Success();
+        }
+
+        return CardValidationResult.Error("Card expiry month must be between 1 and 12");
+    }
+
+    /// <summary>
+    /// Validates the expiry year field.
+    /// COBOL: paragraph 1260-EDIT-EXPIRY-YEAR (COCRDUPC.cbl:913-947).
+    /// Must be between 1950 and 2099 inclusive. COBOL: 88 VALID-YEAR VALUES 1950 THRU 2099.
+    /// </summary>
+    public static CardValidationResult ValidateExpiryYear(int expiryYear)
+    {
+        // COBOL: 88 VALID-YEAR VALUES 1950 THRU 2099.
+        if (expiryYear is >= 1950 and <= 2099)
+        {
+            return CardValidationResult.Success();
+        }
+
+        return CardValidationResult.Error("Invalid card expiry year");
+    }
+
+    /// <summary>
+    /// Validates all update fields and returns ALL errors simultaneously.
+    /// Improvement over COBOL: COCRDUPC.cbl only reported the first error via WS-RETURN-MSG-OFF flag.
+    /// The migrated system collects every validation failure and returns them together.
+    /// </summary>
+    public static CardUpdateValidationResult ValidateUpdate(
+        string? embossedName,
+        char activeStatus,
+        int expiryMonth,
+        int expiryYear)
+    {
+        var errors = new List<string>();
+
+        var nameResult = ValidateEmbossedName(embossedName);
+        if (!nameResult.IsValid)
+        {
+            errors.Add(nameResult.ErrorMessage!);
+        }
+
+        var statusResult = ValidateActiveStatus(activeStatus);
+        if (!statusResult.IsValid)
+        {
+            errors.Add(statusResult.ErrorMessage!);
+        }
+
+        var monthResult = ValidateExpiryMonth(expiryMonth);
+        if (!monthResult.IsValid)
+        {
+            errors.Add(monthResult.ErrorMessage!);
+        }
+
+        var yearResult = ValidateExpiryYear(expiryYear);
+        if (!yearResult.IsValid)
+        {
+            errors.Add(yearResult.ErrorMessage!);
+        }
+
+        return errors.Count == 0
+            ? CardUpdateValidationResult.Success()
+            : CardUpdateValidationResult.WithErrors(errors);
+    }
+
+    /// <summary>
+    /// Detects whether new values differ from the existing card record.
+    /// Uses case-insensitive comparison for embossed name (COBOL: UPPER-CASE function).
+    /// Expiry day is NOT user-editable and is carried from the original record.
+    /// COBOL source: COCRDUPC.cbl 1200-EDIT-MAP-INPUTS.
+    /// </summary>
+    public static CardChangeDetectionResult DetectChanges(
+        Card existing,
+        string newEmbossedName,
+        char newActiveStatus,
+        int newExpiryMonth,
+        int newExpiryYear)
+    {
+        // COBOL: COMPARE new-card-data WITH old-card-data (case-insensitive via UPPER-CASE)
+        var nameChanged = !string.Equals(
+            existing.EmbossedName,
+            newEmbossedName,
+            StringComparison.OrdinalIgnoreCase);
+
+        var statusChanged = existing.ActiveStatus != newActiveStatus;
+
+        var monthChanged = existing.ExpirationDate.Month != newExpiryMonth;
+
+        var yearChanged = existing.ExpirationDate.Year != newExpiryYear;
+
+        if (nameChanged || statusChanged || monthChanged || yearChanged)
+        {
+            return CardChangeDetectionResult.Changed();
+        }
+
+        return CardChangeDetectionResult.NoChange();
+    }
+}

--- a/tests/NordKredit.UnitTests/CardManagement/CardUpdateValidatorTests.cs
+++ b/tests/NordKredit.UnitTests/CardManagement/CardUpdateValidatorTests.cs
@@ -1,0 +1,371 @@
+using NordKredit.Domain.CardManagement;
+
+namespace NordKredit.UnitTests.CardManagement;
+
+/// <summary>
+/// Unit tests for CardUpdateValidator.
+/// COBOL source: COCRDUPC.cbl:806-947, 87-99, 255-263.
+/// Covers card update field validation (CARD-BR-006).
+/// Regulations: FFFS 2014:5 Ch. 4 §3, PSD2 Art. 97, GDPR Art. 5(1)(d).
+/// </summary>
+public class CardUpdateValidatorTests
+{
+    // ===================================================================
+    // Embossed Name Validation — CARD-BR-006, paragraph 1230
+    // COBOL: COCRDUPC.cbl:806-843
+    // ===================================================================
+
+    [Fact]
+    public void ValidateEmbossedName_ValidAlphaAndSpaces_Passes()
+    {
+        var result = CardUpdateValidator.ValidateEmbossedName("JANE DOE");
+
+        Assert.True(result.IsValid);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateEmbossedName_WithNumbers_ReturnsAlphaError()
+    {
+        var result = CardUpdateValidator.ValidateEmbossedName("JOHN DOE 3RD");
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Card name can only contain alphabets and spaces", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateEmbossedName_SwedishCharacters_Passes()
+    {
+        // Edge case #1: extend COBOL A-Z to include Swedish characters (Å, Ä, Ö)
+        var result = CardUpdateValidator.ValidateEmbossedName("BJÖRK ÅSTRÖM");
+
+        Assert.True(result.IsValid);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateEmbossedName_Blank_ReturnsNotProvided()
+    {
+        var result = CardUpdateValidator.ValidateEmbossedName("");
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Card name not provided", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateEmbossedName_Null_ReturnsNotProvided()
+    {
+        var result = CardUpdateValidator.ValidateEmbossedName(null);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Card name not provided", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateEmbossedName_WhitespaceOnly_ReturnsNotProvided()
+    {
+        var result = CardUpdateValidator.ValidateEmbossedName("   ");
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Card name not provided", result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("JOHN-DOE")]
+    [InlineData("O'BRIEN")]
+    [InlineData("NAME@EMAIL")]
+    [InlineData("JOHN123")]
+    public void ValidateEmbossedName_SpecialCharacters_ReturnsAlphaError(string input)
+    {
+        var result = CardUpdateValidator.ValidateEmbossedName(input);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Card name can only contain alphabets and spaces", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateEmbossedName_LowercaseAlpha_Passes()
+    {
+        var result = CardUpdateValidator.ValidateEmbossedName("jane doe");
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ValidateEmbossedName_MixedCaseSwedish_Passes()
+    {
+        var result = CardUpdateValidator.ValidateEmbossedName("Björk Åström Öberg Ärling");
+
+        Assert.True(result.IsValid);
+    }
+
+    // ===================================================================
+    // Active Status Validation — CARD-BR-006, paragraph 1240
+    // COBOL: COCRDUPC.cbl:845-876
+    // ===================================================================
+
+    [Theory]
+    [InlineData('Y')]
+    [InlineData('N')]
+    public void ValidateActiveStatus_ValidValues_Passes(char status)
+    {
+        var result = CardUpdateValidator.ValidateActiveStatus(status);
+
+        Assert.True(result.IsValid);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData('A')]
+    [InlineData('X')]
+    [InlineData('y')]
+    [InlineData('n')]
+    [InlineData(' ')]
+    [InlineData('0')]
+    public void ValidateActiveStatus_InvalidValues_ReturnsError(char status)
+    {
+        var result = CardUpdateValidator.ValidateActiveStatus(status);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Card Active Status must be Y or N", result.ErrorMessage);
+    }
+
+    // ===================================================================
+    // Expiry Month Validation — CARD-BR-006, paragraph 1250
+    // COBOL: COCRDUPC.cbl:877-912
+    // ===================================================================
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(6)]
+    [InlineData(12)]
+    public void ValidateExpiryMonth_ValidRange_Passes(int month)
+    {
+        var result = CardUpdateValidator.ValidateExpiryMonth(month);
+
+        Assert.True(result.IsValid);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(13)]
+    [InlineData(-1)]
+    [InlineData(99)]
+    public void ValidateExpiryMonth_OutOfRange_ReturnsError(int month)
+    {
+        var result = CardUpdateValidator.ValidateExpiryMonth(month);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Card expiry month must be between 1 and 12", result.ErrorMessage);
+    }
+
+    // ===================================================================
+    // Expiry Year Validation — CARD-BR-006, paragraph 1260
+    // COBOL: COCRDUPC.cbl:913-947
+    // ===================================================================
+
+    [Theory]
+    [InlineData(1950)]
+    [InlineData(2028)]
+    [InlineData(2099)]
+    public void ValidateExpiryYear_ValidRange_Passes(int year)
+    {
+        var result = CardUpdateValidator.ValidateExpiryYear(year);
+
+        Assert.True(result.IsValid);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1949)]
+    [InlineData(2100)]
+    [InlineData(9999)]
+    public void ValidateExpiryYear_OutOfRange_ReturnsError(int year)
+    {
+        var result = CardUpdateValidator.ValidateExpiryYear(year);
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Invalid card expiry year", result.ErrorMessage);
+    }
+
+    // ===================================================================
+    // Change Detection — CARD-BR-006, paragraph 1200
+    // COBOL: COCRDUPC.cbl case-insensitive comparison via UPPER-CASE
+    // ===================================================================
+
+    [Fact]
+    public void DetectChanges_NoChanges_ReturnsNoChangeMessage()
+    {
+        var existing = new Card
+        {
+            EmbossedName = "JOHN DOE",
+            ActiveStatus = 'Y',
+            ExpirationDate = new DateOnly(2028, 6, 15)
+        };
+
+        var result = CardUpdateValidator.DetectChanges(
+            existing,
+            newEmbossedName: "JOHN DOE",
+            newActiveStatus: 'Y',
+            newExpiryMonth: 6,
+            newExpiryYear: 2028);
+
+        Assert.False(result.HasChanges);
+        Assert.Equal("No change detected with respect to values fetched.", result.Message);
+    }
+
+    [Fact]
+    public void DetectChanges_CaseInsensitive_ReturnsNoChange()
+    {
+        // Acceptance criteria scenario 12: case-insensitive comparison
+        var existing = new Card
+        {
+            EmbossedName = "JOHN DOE",
+            ActiveStatus = 'Y',
+            ExpirationDate = new DateOnly(2028, 6, 15)
+        };
+
+        var result = CardUpdateValidator.DetectChanges(
+            existing,
+            newEmbossedName: "John Doe",
+            newActiveStatus: 'Y',
+            newExpiryMonth: 6,
+            newExpiryYear: 2028);
+
+        Assert.False(result.HasChanges);
+        Assert.Equal("No change detected with respect to values fetched.", result.Message);
+    }
+
+    [Fact]
+    public void DetectChanges_NameChanged_ReturnsHasChanges()
+    {
+        var existing = new Card
+        {
+            EmbossedName = "JOHN DOE",
+            ActiveStatus = 'Y',
+            ExpirationDate = new DateOnly(2028, 6, 15)
+        };
+
+        var result = CardUpdateValidator.DetectChanges(
+            existing,
+            newEmbossedName: "JANE DOE",
+            newActiveStatus: 'Y',
+            newExpiryMonth: 6,
+            newExpiryYear: 2028);
+
+        Assert.True(result.HasChanges);
+        Assert.Null(result.Message);
+    }
+
+    [Fact]
+    public void DetectChanges_StatusChanged_ReturnsHasChanges()
+    {
+        var existing = new Card
+        {
+            EmbossedName = "JOHN DOE",
+            ActiveStatus = 'Y',
+            ExpirationDate = new DateOnly(2028, 6, 15)
+        };
+
+        var result = CardUpdateValidator.DetectChanges(
+            existing,
+            newEmbossedName: "JOHN DOE",
+            newActiveStatus: 'N',
+            newExpiryMonth: 6,
+            newExpiryYear: 2028);
+
+        Assert.True(result.HasChanges);
+    }
+
+    [Fact]
+    public void DetectChanges_ExpiryMonthChanged_ReturnsHasChanges()
+    {
+        var existing = new Card
+        {
+            EmbossedName = "JOHN DOE",
+            ActiveStatus = 'Y',
+            ExpirationDate = new DateOnly(2028, 6, 15)
+        };
+
+        var result = CardUpdateValidator.DetectChanges(
+            existing,
+            newEmbossedName: "JOHN DOE",
+            newActiveStatus: 'Y',
+            newExpiryMonth: 7,
+            newExpiryYear: 2028);
+
+        Assert.True(result.HasChanges);
+    }
+
+    [Fact]
+    public void DetectChanges_ExpiryYearChanged_ReturnsHasChanges()
+    {
+        var existing = new Card
+        {
+            EmbossedName = "JOHN DOE",
+            ActiveStatus = 'Y',
+            ExpirationDate = new DateOnly(2028, 6, 15)
+        };
+
+        var result = CardUpdateValidator.DetectChanges(
+            existing,
+            newEmbossedName: "JOHN DOE",
+            newActiveStatus: 'Y',
+            newExpiryMonth: 6,
+            newExpiryYear: 2029);
+
+        Assert.True(result.HasChanges);
+    }
+
+    // ===================================================================
+    // Full Update Validation — CARD-BR-006
+    // Improvement: returns ALL errors simultaneously (COBOL only returned first)
+    // ===================================================================
+
+    [Fact]
+    public void ValidateUpdate_AllFieldsValid_Passes()
+    {
+        var result = CardUpdateValidator.ValidateUpdate(
+            embossedName: "JANE DOE",
+            activeStatus: 'Y',
+            expiryMonth: 6,
+            expiryYear: 2028);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void ValidateUpdate_MultipleInvalidFields_ReturnsAllErrors()
+    {
+        // Acceptance criteria: ALL errors returned simultaneously
+        var result = CardUpdateValidator.ValidateUpdate(
+            embossedName: "",
+            activeStatus: 'A',
+            expiryMonth: 13,
+            expiryYear: 2100);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(4, result.Errors.Count);
+        Assert.Contains("Card name not provided", result.Errors);
+        Assert.Contains("Card Active Status must be Y or N", result.Errors);
+        Assert.Contains("Card expiry month must be between 1 and 12", result.Errors);
+        Assert.Contains("Invalid card expiry year", result.Errors);
+    }
+
+    [Fact]
+    public void ValidateUpdate_SingleInvalidField_ReturnsSingleError()
+    {
+        var result = CardUpdateValidator.ValidateUpdate(
+            embossedName: "JOHN DOE 3RD",
+            activeStatus: 'Y',
+            expiryMonth: 6,
+            expiryYear: 2028);
+
+        Assert.False(result.IsValid);
+        Assert.Single(result.Errors);
+        Assert.Contains("Card name can only contain alphabets and spaces", result.Errors);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements field-level validation for card update operations (CARD-BR-006)
- Validates embossed name (Unicode letters + spaces, extends COBOL A-Z to Swedish Å/Ä/Ö), active status (Y/N), expiry month (1-12), expiry year (1950-2099)
- Adds case-insensitive change detection to identify when no modifications were made
- Returns ALL validation errors simultaneously (improvement over COBOL first-error-only behavior)

## Changes
- `src/NordKredit.Domain/CardManagement/CardUpdateValidator.cs` — Static validator with field-level validation methods and aggregate ValidateUpdate
- `src/NordKredit.Domain/CardManagement/CardUpdateValidationResult.cs` — Multi-error result type for aggregate validation
- `src/NordKredit.Domain/CardManagement/CardChangeDetectionResult.cs` — Result type for change detection
- `tests/NordKredit.UnitTests/CardManagement/CardUpdateValidatorTests.cs` — 43 unit tests covering all 12 acceptance criteria

## COBOL Traceability
- **Source**: COCRDUPC.cbl:806-947 (paragraphs 1230-1260), 87-99 (validation constants), 255-263 (alphabet conversion)
- **Business Rule**: CARD-BR-006
- **Regulations**: FFFS 2014:5 Ch. 4 §3, PSD2 Art. 97, GDPR Art. 5(1)(d)

## Testing
- [x] 43 unit tests pass (all acceptance criteria covered)
- [x] Full test suite passes (262 unit + 1 BDD + 1 comparison)
- [x] Build passes with zero warnings (`dotnet build /warnaserror`)
- [x] Format passes (`dotnet format --verify-no-changes`)

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)