### PR TITLE
feat(#92): Add Card Detail API with lookup by card number or account

### DIFF
--- a/src/NordKredit.Api/Controllers/CardsController.cs
+++ b/src/NordKredit.Api/Controllers/CardsController.cs
@@ -1,0 +1,86 @@
+using Microsoft.AspNetCore.Mvc;
+using NordKredit.Domain.CardManagement;
+
+namespace NordKredit.Api.Controllers;
+
+/// <summary>
+/// REST API for card management operations.
+/// Replaces COBOL CICS programs COCRDSLC (detail) with REST endpoints.
+/// COBOL source: COCRDSLC.cbl:608-812 (card detail lookup).
+/// Regulations: PSD2 Art. 97 (SCA), GDPR Art. 15 (right of access), FFFS 2014:5 Ch. 8 section 4.
+/// </summary>
+[ApiController]
+[Route("api/cards")]
+public class CardsController : ControllerBase
+{
+    private readonly CardDetailService _detailService;
+
+    public CardsController(CardDetailService detailService)
+    {
+        _detailService = detailService;
+    }
+
+    /// <summary>
+    /// Retrieves full detail of a single card by card number.
+    /// COBOL: COCRDSLC.cbl:736-774 — 9100-GETCARD-BYACCTCARD (CICS READ on CARDDAT).
+    /// CVV code excluded from response per PCI-DSS compliance.
+    /// Regulations: PSD2 Art. 97, GDPR Art. 15.
+    /// </summary>
+    /// <param name="cardNumber">16-digit card number (primary key).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>200 OK with card detail, 400 for invalid input, 404 if not found.</returns>
+    [HttpGet("{cardNumber}")]
+    public async Task<IActionResult> GetCard(
+        string cardNumber,
+        CancellationToken cancellationToken)
+    {
+        // COBOL: COCRDSLC.cbl:685-724 — 2220-EDIT-CARD (card number validation)
+        var validation = CardValidationService.ValidateCardNumber(cardNumber, required: true);
+        if (!validation.IsValid)
+        {
+            return BadRequest(new { Message = validation.ErrorMessage });
+        }
+
+        var detail = await _detailService.GetByCardNumberAsync(cardNumber, cancellationToken);
+
+        if (detail is null)
+        {
+            // COBOL: COCRDSLC.cbl:745-748 — DFHRESP(NOTFND) handler
+            return NotFound(new { Message = "Did not find cards for this search condition" });
+        }
+
+        return Ok(detail);
+    }
+
+    /// <summary>
+    /// Retrieves cards by account ID.
+    /// COBOL: COCRDSLC.cbl:779-812 — 9150-GETCARD-BYACCT (CICS READ on CARDAIX alternate index).
+    /// Returns first card for the account, matching COBOL CICS READ behavior.
+    /// Regulations: PSD2 Art. 97, GDPR Art. 15.
+    /// </summary>
+    /// <param name="accountId">11-digit account ID for account-based lookup.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>200 OK with card detail, 400 for invalid input, 404 if not found.</returns>
+    [HttpGet]
+    public async Task<IActionResult> GetCardByAccount(
+        [FromQuery] string? accountId,
+        CancellationToken cancellationToken)
+    {
+        // COBOL: COCRDSLC.cbl:647-683 — 2210-EDIT-ACCOUNT (account number validation)
+        var validation = CardValidationService.ValidateAccountNumber(accountId, required: true);
+        if (!validation.IsValid)
+        {
+            return BadRequest(new { Message = validation.ErrorMessage });
+        }
+
+        var detail = await _detailService.GetByAccountIdAsync(accountId!, cancellationToken);
+
+        if (detail is null)
+        {
+            // COBOL: COCRDSLC.cbl:788-791 — DFHRESP(NOTFND) handler
+            return NotFound(new { Message = "Did not find cards for this search condition" });
+        }
+
+        return Ok(detail);
+    }
+}

--- a/src/NordKredit.Api/Program.cs
+++ b/src/NordKredit.Api/Program.cs
@@ -14,6 +14,9 @@ builder.Services.AddScoped<TransactionAddService>();
 builder.Services.AddScoped<TransactionDetailService>();
 builder.Services.AddScoped<TransactionListService>();
 
+// Card Management domain services (COCRDSLC — card detail lookup)
+builder.Services.AddScoped<NordKredit.Domain.CardManagement.CardDetailService>();
+
 // Infrastructure bindings — Azure SQL repositories replace VSAM file I/O
 builder.Services.AddScoped<ITransactionRepository, SqlTransactionRepository>();
 builder.Services.AddScoped<ITransactionIdGenerator, SqlTransactionIdGenerator>();

--- a/src/NordKredit.Domain/CardManagement/CardDetailResponse.cs
+++ b/src/NordKredit.Domain/CardManagement/CardDetailResponse.cs
@@ -1,0 +1,16 @@
+namespace NordKredit.Domain.CardManagement;
+
+/// <summary>
+/// Read-only detail view of a single card.
+/// COBOL source: COCRDSLC.cbl:608-812 (CICS program — card detail screen).
+/// CVV code is excluded from response per PCI-DSS compliance.
+/// Regulations: PSD2 Art. 97 (SCA for payment instrument access), GDPR Art. 15 (right of access).
+/// </summary>
+public sealed class CardDetailResponse
+{
+    public required string CardNumber { get; init; }
+    public required string AccountId { get; init; }
+    public required string EmbossedName { get; init; }
+    public required string ExpirationDate { get; init; }
+    public required char ActiveStatus { get; init; }
+}

--- a/src/NordKredit.Domain/CardManagement/CardDetailService.cs
+++ b/src/NordKredit.Domain/CardManagement/CardDetailService.cs
@@ -1,0 +1,52 @@
+namespace NordKredit.Domain.CardManagement;
+
+/// <summary>
+/// Retrieves and formats a single card for read-only detail view.
+/// COBOL source: COCRDSLC.cbl:608-812 (CICS program — card detail lookup).
+/// Replaces CICS READ on CARDDAT (primary key) and CARDAIX (alternate index).
+/// Regulations: PSD2 Art. 97, GDPR Art. 15, FFFS 2014:5 Ch. 8 section 4.
+/// </summary>
+public class CardDetailService
+{
+    private readonly ICardRepository _cardRepository;
+
+    public CardDetailService(ICardRepository cardRepository)
+    {
+        _cardRepository = cardRepository;
+    }
+
+    /// <summary>
+    /// Retrieves a card by its card number (primary key lookup).
+    /// COBOL: COCRDSLC.cbl:736-774 — 9100-GETCARD-BYACCTCARD (READ CARDDAT).
+    /// </summary>
+    public async Task<CardDetailResponse?> GetByCardNumberAsync(
+        string cardNumber,
+        CancellationToken cancellationToken = default)
+    {
+        var card = await _cardRepository.GetByCardNumberAsync(cardNumber, cancellationToken);
+        return card is null ? null : MapToResponse(card);
+    }
+
+    /// <summary>
+    /// Retrieves the first card for an account (alternate index lookup).
+    /// COBOL: COCRDSLC.cbl:779-812 — 9150-GETCARD-BYACCT (READ CARDAIX).
+    /// Returns first card by key order, matching COBOL CICS READ behavior on alternate index.
+    /// </summary>
+    public async Task<CardDetailResponse?> GetByAccountIdAsync(
+        string accountId,
+        CancellationToken cancellationToken = default)
+    {
+        var cards = await _cardRepository.GetByAccountIdAsync(accountId, cancellationToken);
+        var card = cards.Count > 0 ? cards[0] : null;
+        return card is null ? null : MapToResponse(card);
+    }
+
+    private static CardDetailResponse MapToResponse(Card card) => new()
+    {
+        CardNumber = card.CardNumber,
+        AccountId = card.AccountId,
+        EmbossedName = card.EmbossedName,
+        ExpirationDate = card.ExpirationDate.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture),
+        ActiveStatus = card.ActiveStatus
+    };
+}

--- a/tests/NordKredit.UnitTests/CardManagement/CardDetailServiceTests.cs
+++ b/tests/NordKredit.UnitTests/CardManagement/CardDetailServiceTests.cs
@@ -1,0 +1,172 @@
+using NordKredit.Domain.CardManagement;
+
+namespace NordKredit.UnitTests.CardManagement;
+
+/// <summary>
+/// Unit tests for CardDetailService — card detail lookup by card number or account ID.
+/// COBOL source: COCRDSLC.cbl:608-812 (card detail lookup logic).
+/// Regulations: PSD2 Art. 97 (SCA), GDPR Art. 15 (right of access).
+/// </summary>
+public class CardDetailServiceTests
+{
+    private readonly StubCardRepository _cardRepo = new();
+    private readonly CardDetailService _service;
+
+    public CardDetailServiceTests()
+    {
+        _service = new CardDetailService(_cardRepo);
+    }
+
+    // ===================================================================
+    // GetByCardNumberAsync — Primary key lookup (CICS READ on CARDDAT)
+    // COBOL: COCRDSLC.cbl:736-774 — 9100-GETCARD-BYACCTCARD
+    // ===================================================================
+
+    [Fact]
+    public async Task GetByCardNumber_ExistingCard_ReturnsCardDetail()
+    {
+        // GIVEN card "4000123456789012" exists
+        _cardRepo.AddCard(CreateTestCard());
+
+        // WHEN lookup by card number
+        var result = await _service.GetByCardNumberAsync("4000123456789012");
+
+        // THEN card detail is returned
+        Assert.NotNull(result);
+        Assert.Equal("4000123456789012", result.CardNumber);
+    }
+
+    [Fact]
+    public async Task GetByCardNumber_ExistingCard_ReturnsAllFields()
+    {
+        // GIVEN card "4000123456789012" exists with all fields populated
+        _cardRepo.AddCard(CreateTestCard());
+
+        // WHEN lookup by card number
+        var result = await _service.GetByCardNumberAsync("4000123456789012");
+
+        // THEN all fields are populated correctly
+        Assert.NotNull(result);
+        Assert.Equal("4000123456789012", result.CardNumber);
+        Assert.Equal("12345678901", result.AccountId);
+        Assert.Equal("JOHN DOE", result.EmbossedName);
+        Assert.Equal("2027-12-31", result.ExpirationDate);
+        Assert.Equal('Y', result.ActiveStatus);
+    }
+
+    [Fact]
+    public async Task GetByCardNumber_ExistingCard_ExcludesCvvCode()
+    {
+        // GIVEN card with CVV "123" exists (PCI-DSS: CVV must not be returned)
+        _cardRepo.AddCard(CreateTestCard());
+
+        // WHEN lookup by card number
+        var result = await _service.GetByCardNumberAsync("4000123456789012");
+
+        // THEN response type does not have a CvvCode property
+        Assert.NotNull(result);
+        var cvvProperty = result.GetType().GetProperty("CvvCode");
+        Assert.Null(cvvProperty);
+    }
+
+    [Fact]
+    public async Task GetByCardNumber_NonExistentCard_ReturnsNull()
+    {
+        // GIVEN no card with number "9999999999999999" exists
+        // WHEN lookup by card number
+        var result = await _service.GetByCardNumberAsync("9999999999999999");
+
+        // THEN null is returned (COBOL: DFHRESP(NOTFND))
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByCardNumber_ExpirationDateFormat_IsYYYYMMDD()
+    {
+        // GIVEN card with expiration date 2027-12-31
+        _cardRepo.AddCard(CreateTestCard());
+
+        // WHEN lookup by card number
+        var result = await _service.GetByCardNumberAsync("4000123456789012");
+
+        // THEN expiration date is in YYYY-MM-DD format (COBOL: CARD-EXPIRAION-DATE PIC X(10))
+        Assert.NotNull(result);
+        Assert.Matches(@"^\d{4}-\d{2}-\d{2}$", result.ExpirationDate);
+    }
+
+    // ===================================================================
+    // GetByAccountIdAsync — Alternate index lookup (CICS READ on CARDAIX)
+    // COBOL: COCRDSLC.cbl:779-812 — 9150-GETCARD-BYACCT
+    // ===================================================================
+
+    [Fact]
+    public async Task GetByAccountId_AccountWithCards_ReturnsFirstCard()
+    {
+        // GIVEN account "12345678901" has cards
+        _cardRepo.AddCard(CreateTestCard());
+        _cardRepo.AddCard(CreateTestCard("4000123456789099", "12345678901"));
+
+        // WHEN lookup by account ID
+        var result = await _service.GetByAccountIdAsync("12345678901");
+
+        // THEN first card by key order is returned (COBOL: CICS READ returns first match)
+        Assert.NotNull(result);
+        Assert.Equal("12345678901", result.AccountId);
+    }
+
+    [Fact]
+    public async Task GetByAccountId_NoCardsForAccount_ReturnsNull()
+    {
+        // GIVEN no cards for account "99999999999"
+        // WHEN lookup by account ID
+        var result = await _service.GetByAccountIdAsync("99999999999");
+
+        // THEN null is returned (COBOL: DFHRESP(NOTFND))
+        Assert.Null(result);
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    private static Card CreateTestCard(
+        string cardNumber = "4000123456789012",
+        string accountId = "12345678901") => new()
+        {
+            CardNumber = cardNumber,
+            AccountId = accountId,
+            CvvCode = "123",
+            EmbossedName = "JOHN DOE",
+            ExpirationDate = new DateOnly(2027, 12, 31),
+            ActiveStatus = 'Y',
+            RowVersion = [1, 2, 3, 4, 5, 6, 7, 8]
+        };
+
+    /// <summary>
+    /// In-memory stub for ICardRepository.
+    /// </summary>
+    internal sealed class StubCardRepository : ICardRepository
+    {
+        private readonly List<Card> _cards = [];
+
+        public void AddCard(Card card) => _cards.Add(card);
+
+        public Task<Card?> GetByCardNumberAsync(string cardNumber, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_cards.FirstOrDefault(c => c.CardNumber == cardNumber));
+
+        public Task<IReadOnlyList<Card>> GetByAccountIdAsync(string accountId, CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<Card> result = [.. _cards.Where(c => c.AccountId == accountId).OrderBy(c => c.CardNumber)];
+            return Task.FromResult(result);
+        }
+
+        public Task<IReadOnlyList<Card>> GetPageForwardAsync(int pageSize, string? startAfterCardNumber = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<Card>>([]);
+
+        public Task<IReadOnlyList<Card>> GetPageBackwardAsync(int pageSize, string? startBeforeCardNumber = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<Card>>([]);
+
+        public Task UpdateAsync(Card card, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+}

--- a/tests/NordKredit.UnitTests/CardManagement/CardsControllerTests.cs
+++ b/tests/NordKredit.UnitTests/CardManagement/CardsControllerTests.cs
@@ -1,0 +1,286 @@
+using Microsoft.AspNetCore.Mvc;
+using NordKredit.Api.Controllers;
+using NordKredit.Domain.CardManagement;
+
+namespace NordKredit.UnitTests.CardManagement;
+
+/// <summary>
+/// Unit tests for CardsController HTTP response mapping.
+/// COBOL source: COCRDSLC.cbl:608-812 — card detail lookup.
+/// Regulations: PSD2 Art. 97 (SCA), GDPR Art. 15 (right of access), FFFS 2014:5 Ch. 8 section 4.
+/// </summary>
+public class CardsControllerTests
+{
+    private readonly StubCardRepository _cardRepo = new();
+    private readonly CardsController _controller;
+
+    public CardsControllerTests()
+    {
+        var detailService = new CardDetailService(_cardRepo);
+        _controller = new CardsController(detailService);
+    }
+
+    // ===================================================================
+    // GET /api/cards/{cardNumber} — 200 OK (COCRDSLC.cbl:736-774)
+    // ===================================================================
+
+    [Fact]
+    public async Task GetCard_ExistingCard_Returns200Ok()
+    {
+        // GIVEN card "4000123456789012" exists for account "12345678901"
+        _cardRepo.AddCard(CreateTestCard());
+
+        // WHEN GET /api/cards/4000123456789012
+        var result = await _controller.GetCard("4000123456789012", CancellationToken.None);
+
+        // THEN 200 OK
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetCard_ExistingCard_ReturnsCardDetailWithAllFields()
+    {
+        // GIVEN card "4000123456789012" exists
+        _cardRepo.AddCard(CreateTestCard());
+
+        // WHEN GET /api/cards/4000123456789012
+        var result = await _controller.GetCard("4000123456789012", CancellationToken.None);
+
+        // THEN response contains cardNumber, accountId, embossedName, expirationDate, activeStatus
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var body = Assert.IsType<CardDetailResponse>(ok.Value);
+        Assert.Equal("4000123456789012", body.CardNumber);
+        Assert.Equal("12345678901", body.AccountId);
+        Assert.Equal("JOHN DOE", body.EmbossedName);
+        Assert.Equal("2027-12-31", body.ExpirationDate);
+        Assert.Equal('Y', body.ActiveStatus);
+    }
+
+    [Fact]
+    public async Task GetCard_ExistingCard_ExcludesCvvFromResponse()
+    {
+        // GIVEN card with CVV exists (PCI-DSS: CVV must not be in response)
+        _cardRepo.AddCard(CreateTestCard());
+
+        // WHEN GET /api/cards/4000123456789012
+        var result = await _controller.GetCard("4000123456789012", CancellationToken.None);
+
+        // THEN CvvCode is not present in response DTO
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var body = Assert.IsType<CardDetailResponse>(ok.Value);
+        Assert.Null(body.GetType().GetProperty("CvvCode"));
+    }
+
+    // ===================================================================
+    // GET /api/cards/{cardNumber} — 404 Not Found (DFHRESP(NOTFND))
+    // ===================================================================
+
+    [Fact]
+    public async Task GetCard_NonExistentCard_Returns404NotFound()
+    {
+        // GIVEN no card with number "9999999999999999" exists
+        // WHEN GET /api/cards/9999999999999999
+        var result = await _controller.GetCard("9999999999999999", CancellationToken.None);
+
+        // THEN 404 with "Did not find cards for this search condition"
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        var body = notFound.Value;
+        Assert.NotNull(body);
+        var message = body.GetType().GetProperty("Message")?.GetValue(body)?.ToString();
+        Assert.Equal("Did not find cards for this search condition", message);
+    }
+
+    // ===================================================================
+    // GET /api/cards/{cardNumber} — 400 Bad Request (validation errors)
+    // COBOL: COCRDSLC.cbl:685-724 — 2220-EDIT-CARD
+    // ===================================================================
+
+    [Fact]
+    public async Task GetCard_InvalidCardNumber_Returns400BadRequest()
+    {
+        // GIVEN invalid card number "ABC"
+        // WHEN GET /api/cards/ABC
+        var result = await _controller.GetCard("ABC", CancellationToken.None);
+
+        // THEN 400 with validation error
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(400, badRequest.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetCard_ShortCardNumber_Returns400WithValidationMessage()
+    {
+        // GIVEN card number "12345" (not 16 digits)
+        // WHEN GET /api/cards/12345
+        var result = await _controller.GetCard("12345", CancellationToken.None);
+
+        // THEN 400 with "CARD ID FILTER,IF SUPPLIED MUST BE A 16 DIGIT NUMBER"
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        var body = badRequest.Value;
+        Assert.NotNull(body);
+        var message = body.GetType().GetProperty("Message")?.GetValue(body)?.ToString();
+        Assert.Equal("CARD ID FILTER,IF SUPPLIED MUST BE A 16 DIGIT NUMBER", message);
+    }
+
+    [Fact]
+    public async Task GetCard_AllZerosCardNumber_Returns400()
+    {
+        // GIVEN all-zeros card number (COBOL: treated as blank)
+        // WHEN GET /api/cards/0000000000000000
+        var result = await _controller.GetCard("0000000000000000", CancellationToken.None);
+
+        // THEN 400 — all zeros treated as blank per COBOL logic
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        var body = badRequest.Value;
+        Assert.NotNull(body);
+        var message = body.GetType().GetProperty("Message")?.GetValue(body)?.ToString();
+        Assert.Equal("Card number not provided", message);
+    }
+
+    // ===================================================================
+    // GET /api/cards?accountId={id} — 200 OK (COCRDSLC.cbl:779-812)
+    // ===================================================================
+
+    [Fact]
+    public async Task GetCardByAccount_ExistingAccount_Returns200Ok()
+    {
+        // GIVEN account "12345678901" has cards
+        _cardRepo.AddCard(CreateTestCard());
+
+        // WHEN GET /api/cards?accountId=12345678901
+        var result = await _controller.GetCardByAccount("12345678901", CancellationToken.None);
+
+        // THEN 200 OK with card detail
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetCardByAccount_MultipleCards_ReturnsFirstByKeyOrder()
+    {
+        // GIVEN account "12345678901" has multiple cards
+        _cardRepo.AddCard(CreateTestCard("4000123456789012", "12345678901"));
+        _cardRepo.AddCard(CreateTestCard("4000123456789099", "12345678901"));
+
+        // WHEN GET /api/cards?accountId=12345678901
+        var result = await _controller.GetCardByAccount("12345678901", CancellationToken.None);
+
+        // THEN first card by key order is returned (COBOL: CICS READ returns first match)
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var body = Assert.IsType<CardDetailResponse>(ok.Value);
+        Assert.Equal("4000123456789012", body.CardNumber);
+    }
+
+    // ===================================================================
+    // GET /api/cards?accountId={id} — 404 Not Found
+    // ===================================================================
+
+    [Fact]
+    public async Task GetCardByAccount_NoCardsForAccount_Returns404()
+    {
+        // GIVEN no cards for account "99999999999"
+        // WHEN GET /api/cards?accountId=99999999999
+        var result = await _controller.GetCardByAccount("99999999999", CancellationToken.None);
+
+        // THEN 404 with "Did not find cards for this search condition"
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        var body = notFound.Value;
+        Assert.NotNull(body);
+        var message = body.GetType().GetProperty("Message")?.GetValue(body)?.ToString();
+        Assert.Equal("Did not find cards for this search condition", message);
+    }
+
+    // ===================================================================
+    // GET /api/cards?accountId={id} — 400 Bad Request (validation errors)
+    // COBOL: COCRDSLC.cbl:647-683 — 2210-EDIT-ACCOUNT
+    // ===================================================================
+
+    [Fact]
+    public async Task GetCardByAccount_InvalidAccountId_Returns400()
+    {
+        // GIVEN invalid account ID "ABC12345678"
+        // WHEN GET /api/cards?accountId=ABC12345678
+        var result = await _controller.GetCardByAccount("ABC12345678", CancellationToken.None);
+
+        // THEN 400 with "ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER"
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        var body = badRequest.Value;
+        Assert.NotNull(body);
+        var message = body.GetType().GetProperty("Message")?.GetValue(body)?.ToString();
+        Assert.Equal("ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER", message);
+    }
+
+    [Fact]
+    public async Task GetCardByAccount_MissingAccountId_Returns400()
+    {
+        // GIVEN no accountId parameter
+        // WHEN GET /api/cards
+        var result = await _controller.GetCardByAccount(null, CancellationToken.None);
+
+        // THEN 400 with "Account number not provided"
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        var body = badRequest.Value;
+        Assert.NotNull(body);
+        var message = body.GetType().GetProperty("Message")?.GetValue(body)?.ToString();
+        Assert.Equal("Account number not provided", message);
+    }
+
+    [Fact]
+    public async Task GetCardByAccount_EmptyAccountId_Returns400()
+    {
+        // GIVEN empty accountId
+        // WHEN GET /api/cards?accountId=
+        var result = await _controller.GetCardByAccount("", CancellationToken.None);
+
+        // THEN 400 with "Account number not provided"
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        var body = badRequest.Value;
+        Assert.NotNull(body);
+        var message = body.GetType().GetProperty("Message")?.GetValue(body)?.ToString();
+        Assert.Equal("Account number not provided", message);
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    private static Card CreateTestCard(
+        string cardNumber = "4000123456789012",
+        string accountId = "12345678901") => new()
+        {
+            CardNumber = cardNumber,
+            AccountId = accountId,
+            CvvCode = "123",
+            EmbossedName = "JOHN DOE",
+            ExpirationDate = new DateOnly(2027, 12, 31),
+            ActiveStatus = 'Y',
+            RowVersion = [1, 2, 3, 4, 5, 6, 7, 8]
+        };
+
+    /// <summary>
+    /// In-memory stub for ICardRepository.
+    /// </summary>
+    internal sealed class StubCardRepository : ICardRepository
+    {
+        private readonly List<Card> _cards = [];
+
+        public void AddCard(Card card) => _cards.Add(card);
+
+        public Task<Card?> GetByCardNumberAsync(string cardNumber, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_cards.FirstOrDefault(c => c.CardNumber == cardNumber));
+
+        public Task<IReadOnlyList<Card>> GetByAccountIdAsync(string accountId, CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<Card> result = [.. _cards.Where(c => c.AccountId == accountId).OrderBy(c => c.CardNumber)];
+            return Task.FromResult(result);
+        }
+
+        public Task<IReadOnlyList<Card>> GetPageForwardAsync(int pageSize, string? startAfterCardNumber = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<Card>>([]);
+
+        public Task<IReadOnlyList<Card>> GetPageBackwardAsync(int pageSize, string? startBeforeCardNumber = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<Card>>([]);
+
+        public Task UpdateAsync(Card card, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- Add REST API endpoints replacing CICS program COCRDSLC for card detail lookup
- `GET /api/cards/{cardNumber}` for primary key lookup, `GET /api/cards?accountId={id}` for alternate index lookup
- CVV excluded from response per PCI-DSS compliance; input validation via shared CardValidationService

## Changes
- `src/NordKredit.Api/Controllers/CardsController.cs` — New controller with GetCard and GetCardByAccount endpoints
- `src/NordKredit.Domain/CardManagement/CardDetailResponse.cs` — Immutable DTO (cardNumber, accountId, embossedName, expirationDate, activeStatus)
- `src/NordKredit.Domain/CardManagement/CardDetailService.cs` — Service orchestrating repository lookups and Card→DTO mapping
- `src/NordKredit.Api/Program.cs` — DI registration for CardDetailService
- `tests/NordKredit.UnitTests/CardManagement/CardDetailServiceTests.cs` — 7 unit tests for service layer
- `tests/NordKredit.UnitTests/CardManagement/CardsControllerTests.cs` — 12 unit tests for HTTP response mapping

## Business Rules
- **CARD-BR-003**: Card detail lookup by account and card number (COCRDSLC.cbl:608-812)
- **CARD-BR-011**: Inter-program navigation mapped to REST endpoints (CICS XCTL → REST routing)

## Regulatory Traceability
- PSD2 Art. 97 (SCA for payment instrument access)
- GDPR Art. 15 (right of access)
- FFFS 2014:5 Ch. 8 §4

## Testing
- [x] 282 unit tests pass (including 19 new card management tests)
- [x] `dotnet build /warnaserror` — 0 warnings
- [x] `dotnet format --verify-no-changes` — clean

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)