### PR TITLE
feat(#95): Extract detailed Account Management business rules from COBOL source

### DIFF
--- a/docs-site/docs/business-rules/account-management/acct-br-001.md
+++ b/docs-site/docs/business-rules/account-management/acct-br-001.md
@@ -1,0 +1,186 @@
+---
+id: "acct-br-001"
+title: "Account record data structure and field definitions"
+domain: "account-management"
+cobol_source: "CVACT01Y.cpy:1-30 (referenced, not in repository)"
+requirement_id: "ACCT-BR-001"
+regulations:
+  - "GDPR Art. 5(1)(c)"
+  - "GDPR Art. 5(1)(d)"
+  - "FSA FFFS 2014:5 Ch. 3"
+  - "PSD2 Art. 64"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# ACCT-BR-001: Account record data structure and field definitions
+
+## Summary
+
+The CVACT01Y copybook defines the primary account master record layout used across the core banking system. Each account record is a fixed-length 300-byte VSAM KSDS record keyed by an 11-digit account identifier. The record contains financial fields (current balance, credit limit, cash credit limit, cycle credits, cycle debits), status fields (active status, expiration date), and customer linkage fields. This structure is the single source of truth for account data and is referenced by card management programs (COCRDLIC, COCRDSLC, COCRDUPC), transaction batch programs (CBTRN02C for balance updates), and billing processes. The copybook itself is not available in the current repository but its structure has been reconstructed from field references across multiple programs and the .NET domain model.
+
+## Business Logic
+
+### Data Structure
+
+```
+ACCOUNT-RECORD (300 bytes total, reconstructed from program references):
+    ACCT-ID                   PIC 9(11)    -- Primary key, 11-digit account number
+    ACCT-ACTIVE-STATUS        PIC X(01)    -- 'Y' = active, 'N' = inactive
+    ACCT-CURR-BAL             PIC S9(10)V99 -- Current running balance (signed, 2 decimal)
+    ACCT-CREDIT-LIMIT         PIC S9(10)V99 -- Authorized credit ceiling
+    ACCT-CASH-CREDIT-LIMIT    PIC S9(10)V99 -- Cash advance credit limit
+    ACCT-CURR-CYC-CREDIT      PIC S9(10)V99 -- Current billing cycle credits
+    ACCT-CURR-CYC-DEBIT       PIC S9(10)V99 -- Current billing cycle debits
+    ACCT-EXPIRAION-DATE       PIC X(10)    -- Account expiry (YYYY-MM-DD format, note COBOL typo)
+    ACCT-GROUP-ID             PIC X(10)    -- Disclosure/interest group assignment
+    FILLER                    PIC X(...)   -- Reserved (remainder of 300 bytes)
+```
+
+### Field Specifications
+
+| Field | Type | Length | Format | Constraints |
+|-------|------|--------|--------|-------------|
+| ACCT-ID | Numeric | 11 | Zoned decimal | Must be 11 digits, not all zeros, primary key |
+| ACCT-ACTIVE-STATUS | Alphanumeric | 1 | 'Y' or 'N' | Binary active/inactive flag |
+| ACCT-CURR-BAL | Signed numeric | 12.2 | S9(10)V99 | Running balance, max ±9,999,999,999.99 |
+| ACCT-CREDIT-LIMIT | Signed numeric | 12.2 | S9(10)V99 | Credit ceiling, used for overlimit checks |
+| ACCT-CASH-CREDIT-LIMIT | Signed numeric | 12.2 | S9(10)V99 | Cash advance limit |
+| ACCT-CURR-CYC-CREDIT | Signed numeric | 12.2 | S9(10)V99 | Cycle charges (positive accumulation) |
+| ACCT-CURR-CYC-DEBIT | Signed numeric | 12.2 | S9(10)V99 | Cycle payments (negative accumulation) |
+| ACCT-EXPIRAION-DATE | Alphanumeric | 10 | YYYY-MM-DD | String comparison for date checks |
+| ACCT-GROUP-ID | Alphanumeric | 10 | Free-text | Links to disclosure group for interest rates |
+
+### VSAM File Organization
+
+| File | Key | Key Length | Access Method | Purpose |
+|------|-----|-----------|---------------|---------|
+| ACCTFILE | ACCT-ID | 11 bytes | Primary key (KSDS) | Direct account lookup by account ID |
+| CARDAIX | CARD-ACCT-ID | 11 bytes | Alternate index on CARDDAT | Card lookup by account ID |
+
+## Source COBOL Reference
+
+**Copybook:** `CVACT01Y.cpy` (not available in repository — referenced from multiple programs)
+**Reconstruction sources:**
+- `COCRDSLC.cbl:230-231` — commented COPY CVACT01Y reference
+- `COCRDUPC.cbl:349-350` — commented COPY CVACT01Y reference
+- `CBTRN02C.cbl:~100` — COPY CVACT01Y for ACCTFILE I-O operations
+- `src/NordKredit.Domain/Transactions/Account.cs` — .NET domain model with field mappings
+
+```cobol
+      *ACCOUNT RECORD LAYOUT
+      *COPY CVACT01Y.
+```
+*(Lines 230-231, COCRDSLC.cbl — copybook reference commented out in card detail program)*
+
+```cobol
+      *ACCOUNT RECORD LAYOUT
+      *COPY CVACT01Y.
+```
+*(Lines 349-350, COCRDUPC.cbl — copybook reference commented out in card update program)*
+
+**Field references in CBTRN02C.cbl (transaction posting):**
+
+```cobol
+000547           ADD DALYTRAN-AMT  TO ACCT-CURR-BAL
+000548           IF DALYTRAN-AMT >= 0
+000549              ADD DALYTRAN-AMT TO ACCT-CURR-CYC-CREDIT
+000550           ELSE
+000551              ADD DALYTRAN-AMT TO ACCT-CURR-CYC-DEBIT
+000552           END-IF
+```
+*(Lines 547-552 — demonstrates ACCT-CURR-BAL, ACCT-CURR-CYC-CREDIT, ACCT-CURR-CYC-DEBIT fields)*
+
+```cobol
+000403               COMPUTE WS-TEMP-BAL = ACCT-CURR-CYC-CREDIT
+000404                                   - ACCT-CURR-CYC-DEBIT
+000405                                   + DALYTRAN-AMT
+000407               IF ACCT-CREDIT-LIMIT >= WS-TEMP-BAL
+```
+*(Lines 403-407 — demonstrates ACCT-CREDIT-LIMIT field)*
+
+```cobol
+000414               IF ACCT-EXPIRAION-DATE >= DALYTRAN-ORIG-TS (1:10)
+```
+*(Line 414 — demonstrates ACCT-EXPIRAION-DATE field, note preserved COBOL typo)*
+
+## Acceptance Criteria
+
+### Scenario 1: Account record round-trip integrity
+
+```gherkin
+GIVEN an account record is written with:
+  | Field              | Value              |
+  | Account ID         | 12345678901        |
+  | Active Status      | Y                  |
+  | Current Balance    | 5000.00            |
+  | Credit Limit       | 10000.00           |
+  | Cash Credit Limit  | 2000.00            |
+  | Cycle Credit       | 5000.00            |
+  | Cycle Debit        | 0.00               |
+  | Expiration Date    | 2028-12-31         |
+WHEN the record is read back from the ACCTFILE
+THEN all field values match exactly as written
+  AND the record length is 300 bytes
+```
+
+### Scenario 2: Financial precision preservation
+
+```gherkin
+GIVEN an account record with ACCT-CURR-BAL = 9999999999.99
+WHEN the balance is read and stored in the migrated system
+THEN the value is exactly 9999999999.99 (no floating-point loss)
+  AND the migrated type is decimal(12,2)
+```
+
+### Scenario 3: Account ID as primary key
+
+```gherkin
+GIVEN an account with ID "00000000042"
+WHEN a lookup is performed by account ID
+THEN the account record is returned via KSDS primary key access
+  AND leading zeros are preserved in the 11-digit ID
+```
+
+### Scenario 4: Active status values
+
+```gherkin
+GIVEN an account record exists in the system
+WHEN the ACCT-ACTIVE-STATUS field is read
+THEN its value is either 'Y' (active) or 'N' (inactive)
+  AND no other values are valid for this field
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| GDPR | Art. 5(1)(c) | Data minimization — personal data must be adequate, relevant, and limited to what is necessary | The account record contains only financial and status fields necessary for account operations. Customer PII is stored separately in customer records, not in the account master. |
+| GDPR | Art. 5(1)(d) | Accuracy — personal data must be accurate and kept up to date | Financial balance fields are updated atomically via REWRITE in batch posting (CBTRN02C). The balance tracking mechanism maintains accuracy through cycle-based credit/debit classification. |
+| FSA FFFS 2014:5 | Ch. 3 | Accurate accounting records | The account record maintains running balance, credit/debit cycle tracking, and credit limits — the minimum fields required for accurate financial record-keeping. |
+| PSD2 | Art. 64 | Payment transaction data integrity | Balance fields updated during transaction posting reference this record structure; data integrity is maintained through VSAM KSDS keyed access. |
+
+## Edge Cases
+
+1. **EBCDIC to Unicode conversion**: COBOL PIC 9 fields (ACCT-ID) are stored in EBCDIC zoned decimal format. PIC S9(10)V99 fields use COBOL packed decimal. During migration, these must be converted to their numeric equivalents. The implied decimal point in V99 must be preserved exactly — any rounding or truncation would cause balance discrepancies.
+
+2. **Copybook not in repository**: The CVACT01Y.cpy copybook is referenced but commented out in card programs. The full record layout must be obtained from the mainframe team. The 300-byte record length is derived from the .NET domain model comment. Additional fields beyond those reconstructed here may exist in the filler area.
+
+3. **ACCT-EXPIRAION-DATE typo**: The COBOL field name contains a typo ("EXPIRAION" instead of "EXPIRATION"). This typo is preserved across all programs that reference the field. The migrated system should use the correct spelling but must document the mapping for traceability.
+
+4. **Balance overflow risk**: With `S9(10)V99`, the maximum balance is ±9,999,999,999.99. COBOL truncates silently on overflow. The migrated system must use `decimal(12,2)` and add explicit overflow detection.
+
+5. **Filler contents**: The 300-byte record likely contains additional fields not yet identified (customer reference, account opening date, last statement date, etc.). The filler area may contain data from older program versions. A full dump of the CVACT01Y copybook from the mainframe is needed to identify all fields.
+
+6. **Signed numeric fields**: All financial fields use signed (`S`) PIC notation. Negative balances and negative cycle debits are valid and expected. The migrated system must support negative values in all balance columns.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. CRITICAL: The CVACT01Y.cpy copybook must be obtained from the mainframe team to validate the reconstructed record layout. Key questions: (1) What additional fields exist in the 300-byte record beyond those referenced in available programs? (2) Is there an account opening date field? (3) Is there a customer ID field in the account record or only via the cross-reference? (4) What are the exact field positions and offsets? (5) Are there any account type or product code fields? (6) Is the 300-byte size correct or could it be different?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/account-management/acct-br-002.md
+++ b/docs-site/docs/business-rules/account-management/acct-br-002.md
@@ -1,0 +1,292 @@
+---
+id: "acct-br-002"
+title: "Account ID input validation rules"
+domain: "account-management"
+cobol_source: "COCRDLIC.cbl:1003-1034, COCRDSLC.cbl:647-683, COCRDUPC.cbl:721-760"
+requirement_id: "ACCT-BR-002"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 4 §3"
+  - "PSD2 Art. 97"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# ACCT-BR-002: Account ID input validation rules
+
+## Summary
+
+Account ID validation is a shared business rule implemented identically across all three card management online programs (COCRDLIC, COCRDSLC, COCRDUPC). The validation enforces that account IDs are exactly 11 numeric digits and rejects non-numeric input with a specific error message. Blank or zero account IDs are handled differently depending on context: in the card list program (COCRDLIC), a blank account ID means "show all cards" (no filter); in the card detail and update programs (COCRDSLC, COCRDUPC), a blank account ID is treated as an input error requiring the user to provide one. This validation is the first line of defense for all account-related operations and must be preserved exactly in the migrated system.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM EDIT-ACCOUNT:
+    IF account-id = LOW-VALUES
+    OR account-id = SPACES
+    OR account-id-numeric = ZEROS
+        -- Context-dependent handling:
+        -- COCRDLIC: SET filter-blank (no error, show all cards)
+        -- COCRDSLC/COCRDUPC: SET input-error, prompt for account
+        MOVE ZEROES TO demo-account-id
+        EXIT PARAGRAPH
+    END-IF
+
+    IF account-id IS NOT NUMERIC
+        SET input-error = TRUE
+        SET filter-not-ok = TRUE
+        MOVE 'ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER'
+            TO error-message
+        MOVE ZERO TO demo-account-id
+        EXIT PARAGRAPH
+    END-IF
+
+    -- Valid: 11 numeric digits, non-zero
+    MOVE account-id TO demo-account-id
+    SET filter-is-valid = TRUE
+```
+
+### Decision Table
+
+| Input Value | Numeric? | All Zeros? | Blank/Spaces? | COCRDLIC Outcome | COCRDSLC/COCRDUPC Outcome |
+|------------|----------|-----------|--------------|------------------|---------------------------|
+| "12345678901" | Yes | No | No | Filter active, show matching cards | Valid, proceed with lookup |
+| "00000000000" | Yes | Yes | No | No filter, show all cards | Input error, prompt for account |
+| "" (spaces) | N/A | N/A | Yes | No filter, show all cards | Input error, prompt for account |
+| LOW-VALUES | N/A | N/A | Yes (equivalent) | No filter, show all cards | Input error, prompt for account |
+| "1234567890A" | No | No | No | Error: must be 11 digit number | Error: must be 11 digit number |
+| "ABCDEFGHIJK" | No | No | No | Error: must be 11 digit number | Error: must be 11 digit number |
+| "1234567890" | No* | No | No | Error: must be 11 digit number | Error: must be 11 digit number |
+
+*Note: The PIC X(11) field is always 11 characters. A 10-digit number would be space-padded, making it non-numeric due to the trailing space.
+
+### Validation Flag States
+
+| Flag | Value | Meaning |
+|------|-------|---------|
+| FLG-ACCTFILTER-BLANK | ' ' | Account ID not provided (blank/zero/low-values) |
+| FLG-ACCTFILTER-ISVALID | '1' | Account ID is valid 11-digit numeric |
+| FLG-ACCTFILTER-NOT-OK | '0' | Account ID validation failed (non-numeric) |
+
+## Source COBOL Reference
+
+**Programs:** `COCRDLIC.cbl`, `COCRDSLC.cbl`, `COCRDUPC.cbl`
+**Lines:** COCRDLIC:1003-1034, COCRDSLC:647-683, COCRDUPC:721-760
+
+### COCRDLIC.cbl (card list — blank is acceptable)
+
+```cobol
+001003 2210-EDIT-ACCOUNT.
+001004     SET FLG-ACCTFILTER-BLANK TO TRUE
+001005
+001006*    Not supplied
+001007     IF CC-ACCT-ID   EQUAL LOW-VALUES
+001008     OR CC-ACCT-ID   EQUAL SPACES
+001009     OR CC-ACCT-ID-N EQUAL ZEROS
+001010        SET FLG-ACCTFILTER-BLANK  TO TRUE
+001011        MOVE ZEROES       TO CDEMO-ACCT-ID
+001012        GO TO  2210-EDIT-ACCOUNT-EXIT
+001013     END-IF
+001014*
+001015*    Not numeric
+001016*    Not 11 characters
+001017     IF CC-ACCT-ID  IS NOT NUMERIC
+001018        SET INPUT-ERROR TO TRUE
+001019        SET FLG-ACCTFILTER-NOT-OK TO TRUE
+001020        SET FLG-PROTECT-SELECT-ROWS-YES TO TRUE
+001021        MOVE
+001022        'ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER'
+001023                        TO WS-ERROR-MSG
+001024        MOVE ZERO       TO CDEMO-ACCT-ID
+001025        GO TO 2210-EDIT-ACCOUNT-EXIT
+001026     ELSE
+001027        MOVE CC-ACCT-ID TO CDEMO-ACCT-ID
+001028        SET FLG-ACCTFILTER-ISVALID TO TRUE
+001029     END-IF
+001030     .
+001031
+001032 2210-EDIT-ACCOUNT-EXIT.
+001033     EXIT
+001034     .
+```
+
+### COCRDSLC.cbl (card detail — blank is an error)
+
+```cobol
+000647 2210-EDIT-ACCOUNT.
+000648     SET FLG-ACCTFILTER-NOT-OK TO TRUE
+000649
+000650*    Not supplied
+000651     IF CC-ACCT-ID   EQUAL LOW-VALUES
+000652     OR CC-ACCT-ID   EQUAL SPACES
+000653     OR CC-ACCT-ID-N EQUAL ZEROS
+000654        SET INPUT-ERROR           TO TRUE
+000655        SET FLG-ACCTFILTER-BLANK  TO TRUE
+000656        IF WS-RETURN-MSG-OFF
+000657           SET WS-PROMPT-FOR-ACCT TO TRUE
+000658        END-IF
+000659        MOVE ZEROES       TO CDEMO-ACCT-ID
+000660        GO TO  2210-EDIT-ACCOUNT-EXIT
+000661     END-IF
+000662*
+000663*    Not numeric
+000664*    Not 11 characters
+000665     IF CC-ACCT-ID  IS NOT NUMERIC
+000666        SET INPUT-ERROR TO TRUE
+000667        SET FLG-ACCTFILTER-NOT-OK TO TRUE
+000668        IF WS-RETURN-MSG-OFF
+000669          MOVE
+000670        'ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER'
+000671                        TO WS-RETURN-MSG
+000672        END-IF
+000673        MOVE ZERO       TO CDEMO-ACCT-ID
+000674        GO TO 2210-EDIT-ACCOUNT-EXIT
+000675     ELSE
+000676        MOVE CC-ACCT-ID TO CDEMO-ACCT-ID
+000677        SET FLG-ACCTFILTER-ISVALID TO TRUE
+000678     END-IF
+000679     .
+000680
+000681 2210-EDIT-ACCOUNT-EXIT.
+000682     EXIT
+000683     .
+```
+
+### COCRDUPC.cbl (card update — blank is an error)
+
+```cobol
+000721 1210-EDIT-ACCOUNT.
+000722     SET FLG-ACCTFILTER-NOT-OK TO TRUE
+000723
+000724*    Not supplied
+000725     IF CC-ACCT-ID   EQUAL LOW-VALUES
+000726     OR CC-ACCT-ID   EQUAL SPACES
+000727     OR CC-ACCT-ID-N EQUAL ZEROS
+000728        SET INPUT-ERROR           TO TRUE
+000729        SET FLG-ACCTFILTER-BLANK  TO TRUE
+000730        IF WS-RETURN-MSG-OFF
+000731           SET WS-PROMPT-FOR-ACCT TO TRUE
+000732        END-IF
+000733        MOVE ZEROES       TO CDEMO-ACCT-ID
+000734        MOVE LOW-VALUES   TO CCUP-NEW-ACCTID
+000735        GO TO  1210-EDIT-ACCOUNT-EXIT
+000736     END-IF
+000737*
+000738*    Not numeric
+000739*    Not 11 characters
+000740     IF CC-ACCT-ID  IS NOT NUMERIC
+000741        SET INPUT-ERROR TO TRUE
+000742        SET FLG-ACCTFILTER-NOT-OK TO TRUE
+000743        IF WS-RETURN-MSG-OFF
+000744          MOVE
+000745        'ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER'
+000746                        TO WS-RETURN-MSG
+000747        END-IF
+000748        MOVE ZERO       TO CDEMO-ACCT-ID
+000749        MOVE LOW-VALUES TO CCUP-NEW-ACCTID
+000750        GO TO 1210-EDIT-ACCOUNT-EXIT
+000751     ELSE
+000752        MOVE CC-ACCT-ID TO CDEMO-ACCT-ID
+000753                           CCUP-NEW-ACCTID
+000754        SET FLG-ACCTFILTER-ISVALID TO TRUE
+000755     END-IF
+000756     .
+000757
+000758 1210-EDIT-ACCOUNT-EXIT.
+000759     EXIT
+000760     .
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Valid 11-digit account ID
+
+```gherkin
+GIVEN the user enters account ID "12345678901"
+WHEN account ID validation is performed
+THEN the account ID is accepted as valid
+  AND the account filter flag is set to ISVALID
+  AND no error message is displayed
+```
+
+### Scenario 2: Non-numeric account ID rejected
+
+```gherkin
+GIVEN the user enters account ID "1234567890A"
+WHEN account ID validation is performed
+THEN the input is rejected
+  AND the error message "ACCOUNT FILTER,IF SUPPLIED MUST BE A 11 DIGIT NUMBER" is displayed
+  AND the account filter flag is set to NOT-OK
+```
+
+### Scenario 3: Blank account ID in card list (acceptable)
+
+```gherkin
+GIVEN the card list screen is displayed
+  AND the user leaves the account ID field blank
+WHEN account ID validation is performed
+THEN no error is raised
+  AND the account filter flag is set to BLANK
+  AND all cards are displayed without account filtering
+```
+
+### Scenario 4: Blank account ID in card detail (error)
+
+```gherkin
+GIVEN the card detail screen is displayed
+  AND the user leaves the account ID field blank
+WHEN account ID validation is performed
+THEN an input error is raised
+  AND the user is prompted to provide an account ID
+  AND the account filter flag is set to BLANK with INPUT-ERROR
+```
+
+### Scenario 5: All-zeros account ID treated as blank
+
+```gherkin
+GIVEN the user enters account ID "00000000000"
+WHEN account ID validation is performed
+THEN the input is treated identically to a blank account ID
+  AND the demo-account-id is set to zeros
+```
+
+### Scenario 6: Leading zeros preserved
+
+```gherkin
+GIVEN the user enters account ID "00000000042"
+WHEN account ID validation is performed
+THEN the account ID is accepted as valid
+  AND leading zeros are preserved in the 11-digit field
+  AND the value "00000000042" is stored exactly as entered
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 4 §3 | Operational risk management — input validation must prevent erroneous data from entering the system | Strict 11-digit numeric validation prevents malformed account IDs from reaching database lookups or financial operations |
+| PSD2 | Art. 97 | Strong customer authentication for accessing payment account information | Account ID validation is the first step in identifying which account data to display; invalid IDs are rejected before any data access occurs |
+
+## Edge Cases
+
+1. **PIC X(11) vs PIC 9(11) dual check**: The COBOL code checks both `CC-ACCT-ID` (PIC X) and `CC-ACCT-ID-N` (PIC 9 REDEFINES). The alphanumeric check for SPACES/LOW-VALUES catches non-printable input, while the numeric check for ZEROS catches "00000000000". The IS NOT NUMERIC test catches mixed alphanumeric input. The migrated system should replicate all three checks.
+
+2. **Error message routing**: In COCRDLIC, errors go to `WS-ERROR-MSG`. In COCRDSLC and COCRDUPC, errors go to `WS-RETURN-MSG` (only if `WS-RETURN-MSG-OFF`). This means the first error takes precedence — subsequent validation failures do not overwrite the message. The migrated system should collect all validation errors.
+
+3. **Context-dependent blank handling**: The different treatment of blank account IDs between list (acceptable) and detail/update (error) programs reflects different use cases. The card list supports browsing all cards, while detail/update requires a specific account. The migrated API should enforce this at the endpoint level.
+
+4. **COCRDUPC additional field clear**: When account validation fails in the update program, `CCUP-NEW-ACCTID` is also cleared to LOW-VALUES (lines 734, 749). This prevents stale account data from being used in subsequent update operations.
+
+5. **Swedish characters in account ID**: Account IDs are strictly numeric, so character encoding is not a concern for this field. However, the error message text must be converted from EBCDIC to UTF-8 for the migrated system.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. Key questions: (1) Are there any account ID validation rules beyond 11-digit numeric (e.g., check digit algorithms like Luhn)? (2) Should the migrated system validate that the account ID exists in the database as part of input validation, or only check format? (3) Is the different blank-handling between list and detail/update programs intentional, or an inconsistency that should be normalized?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/account-management/acct-br-003.md
+++ b/docs-site/docs/business-rules/account-management/acct-br-003.md
@@ -1,0 +1,255 @@
+---
+id: "acct-br-003"
+title: "Account-card relationship and cross-reference lookup"
+domain: "account-management"
+cobol_source: "COCRDSLC.cbl:779-812, CVACT03Y.cpy:1-11, CVACT02Y.cpy:1-14"
+requirement_id: "ACCT-BR-003"
+regulations:
+  - "PSD2 Art. 97"
+  - "GDPR Art. 15"
+  - "AML 2017:11"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# ACCT-BR-003: Account-card relationship and cross-reference lookup
+
+## Summary
+
+The account-card relationship is maintained through two mechanisms: a direct foreign key (CARD-ACCT-ID in the card record, CVACT02Y.cpy) and a cross-reference structure (CARD-XREF-RECORD in CVACT03Y.cpy) that adds the customer dimension. The card file (CARDDAT) has an alternate index (CARDAIX) on the account ID field, enabling card lookup by account. The cross-reference file (XREFFILE) maps card numbers to customer IDs and account IDs, used primarily by batch transaction processing to resolve card-to-account relationships. This three-way linkage (card ↔ account ↔ customer) is fundamental to the entire system and must be preserved in the migrated relational model.
+
+## Business Logic
+
+### Pseudocode
+
+```
+-- Account-based card lookup (COCRDSLC: 9150-GETCARD-BYACCT)
+PERFORM GETCARD-BY-ACCOUNT:
+    EXEC CICS READ
+        FILE('CARDAIX')           -- Alternate index on CARDDAT
+        RIDFLD(account-id)        -- 11-digit account ID as key
+        KEYLENGTH(11)
+        INTO(CARD-RECORD)
+    END-EXEC
+
+    EVALUATE CICS-RESPONSE:
+        WHEN NORMAL:
+            SET found-cards-for-account = TRUE
+            -- CARD-RECORD now contains first card for this account
+        WHEN NOTFND:
+            SET input-error = TRUE
+            SET did-not-find-account-in-cardxref = TRUE
+        WHEN OTHER:
+            SET input-error = TRUE
+            MOVE file-error-message TO return-message
+    END-EVALUATE
+
+-- Cross-reference lookup (CBTRN01C/02C: batch processing)
+PERFORM LOOKUP-XREF:
+    READ XREFFILE BY card-number
+    IF found:
+        account-id = XREF-ACCT-ID
+        customer-id = XREF-CUST-ID
+    ELSE:
+        -- Card not in cross-reference, reject transaction
+    END-IF
+
+-- Account filtering in card list (COCRDLIC: 9500-FILTER-RECORDS)
+PERFORM FILTER-BY-ACCOUNT:
+    IF account-filter-active
+        IF CARD-ACCT-ID NOT = filter-account-id
+            SET record-skipped = TRUE
+            EXIT PARAGRAPH
+        END-IF
+    END-IF
+```
+
+### Relationship Model
+
+```
+CUSTOMER (9-digit CUST-ID)
+    |
+    +--< CARD-XREF-RECORD >-- links to -->
+    |       XREF-CARD-NUM (16)
+    |       XREF-CUST-ID  (9)  -- FK to customer
+    |       XREF-ACCT-ID  (11) -- FK to account
+    |
+    +--< ACCOUNT (11-digit ACCT-ID)
+            |
+            +--< CARD-RECORD >-- embedded FK -->
+                    CARD-NUM     (16) -- PK
+                    CARD-ACCT-ID (11) -- FK to account (direct)
+```
+
+### Decision Table
+
+| Lookup Method | Key | Source File | Returns | Use Case |
+|--------------|-----|-----------|---------|----------|
+| Primary key | CARD-NUM (16) | CARDDAT | Single card record | Card detail/update (COCRDSLC, COCRDUPC) |
+| Alternate index | CARD-ACCT-ID (11) | CARDAIX | First card for account | Account-based card lookup (COCRDSLC) |
+| Browse + filter | CARD-ACCT-ID (11) | CARDDAT | All matching cards | Card list with account filter (COCRDLIC) |
+| Cross-reference | XREF-CARD-NUM (16) | XREFFILE | Account + customer IDs | Batch transaction processing (CBTRN01C/02C) |
+
+## Source COBOL Reference
+
+**Programs:** `COCRDSLC.cbl`, `COCRDLIC.cbl`, `CBTRN01C.cbl`
+**Copybooks:** `CVACT02Y.cpy`, `CVACT03Y.cpy`
+
+### CVACT02Y.cpy — Card record with embedded account FK
+
+```cobol
+       01  CARD-RECORD.
+           05  CARD-NUM                          PIC X(16).
+           05  CARD-ACCT-ID                      PIC 9(11).
+           05  CARD-CVV-CD                       PIC 9(03).
+           05  CARD-EMBOSSED-NAME                PIC X(50).
+           05  CARD-EXPIRAION-DATE               PIC X(10).
+           05  CARD-ACTIVE-STATUS                PIC X(01).
+           05  FILLER                            PIC X(59).
+```
+*(Lines 1-14 — CARD-ACCT-ID at line 6 is the direct foreign key to account)*
+
+### CVACT03Y.cpy — Cross-reference structure
+
+```cobol
+       01 CARD-XREF-RECORD.
+           05  XREF-CARD-NUM                     PIC X(16).
+           05  XREF-CUST-ID                      PIC 9(09).
+           05  XREF-ACCT-ID                      PIC 9(11).
+           05  FILLER                            PIC X(14).
+```
+*(Lines 1-11 — three-way linkage: card → customer → account)*
+
+### COCRDSLC.cbl — Account-based card lookup via alternate index
+
+```cobol
+000779 9150-GETCARD-BYACCT.
+000780
+000781*    Read the Card file. Access via alternate index ACCTID
+000782*
+000783     EXEC CICS READ
+000784          FILE      (LIT-CARDFILENAME-ACCT-PATH)
+000785          RIDFLD    (WS-CARD-RID-ACCT-ID)
+000786          KEYLENGTH (LENGTH OF WS-CARD-RID-ACCT-ID)
+000787          INTO      (CARD-RECORD)
+000788          LENGTH    (LENGTH OF CARD-RECORD)
+000789          RESP      (WS-RESP-CD)
+000790          RESP2     (WS-REAS-CD)
+000791     END-EXEC
+000792
+000793     EVALUATE WS-RESP-CD
+000794         WHEN DFHRESP(NORMAL)
+000795            SET FOUND-CARDS-FOR-ACCOUNT TO TRUE
+000796         WHEN DFHRESP(NOTFND)
+000797            SET INPUT-ERROR                 TO TRUE
+000798            SET FLG-ACCTFILTER-NOT-OK                TO TRUE
+000799            SET DID-NOT-FIND-ACCT-IN-CARDXREF TO TRUE
+000800         WHEN OTHER
+000801            SET INPUT-ERROR                 TO TRUE
+000802            SET FLG-ACCTFILTER-NOT-OK                TO TRUE
+000803            MOVE 'READ'                     TO ERROR-OPNAME
+000804            MOVE LIT-CARDFILENAME-ACCT-PATH TO ERROR-FILE
+000805            MOVE WS-RESP-CD                 TO ERROR-RESP
+000806            MOVE WS-REAS-CD                 TO ERROR-RESP2
+000807            MOVE WS-FILE-ERROR-MESSAGE      TO WS-RETURN-MSG
+000808     END-EVALUATE
+000809     .
+000810 9150-GETCARD-BYACCT-EXIT.
+000811     EXIT
+000812     .
+```
+
+### COCRDLIC.cbl — Account filter in card list browse
+
+```cobol
+001382 9500-FILTER-RECORDS.
+001383     SET WS-RECORD-PASSES-FILTER TO TRUE.
+001384
+001385     IF WS-ACCT-FILTER-ACTIVE
+001386         IF CARD-ACCT-ID NOT = WS-FILTER-ACCOUNT-ID
+001387             SET WS-RECORD-PASSES-FILTER TO FALSE
+001388             GO TO 9500-FILTER-RECORDS-EXIT
+001389         END-IF
+001390     END-IF.
+```
+*(Lines 1382-1390 — filters cards by embedded account ID during browse)*
+
+## Acceptance Criteria
+
+### Scenario 1: Lookup cards by account via alternate index
+
+```gherkin
+GIVEN an account "12345678901" has associated cards in the system
+WHEN a card lookup is performed by account ID using the alternate index
+THEN the first card record for that account is returned
+  AND CARD-ACCT-ID in the returned record matches "12345678901"
+```
+
+### Scenario 2: Account not found in card file
+
+```gherkin
+GIVEN an account "99999999999" has no associated cards
+WHEN a card lookup is performed by account ID
+THEN the system sets DID-NOT-FIND-ACCT-IN-CARDXREF
+  AND an input error is raised
+```
+
+### Scenario 3: Card list filtered by account
+
+```gherkin
+GIVEN the card list contains cards for multiple accounts
+  AND the user filters by account "12345678901"
+WHEN the card list is browsed
+THEN only cards with CARD-ACCT-ID = "12345678901" are displayed
+  AND cards belonging to other accounts are excluded
+```
+
+### Scenario 4: Cross-reference resolves card to account
+
+```gherkin
+GIVEN a card "4000123456789012" exists in the cross-reference file
+  AND the cross-reference maps to account "12345678901" and customer "123456789"
+WHEN the cross-reference is read by card number
+THEN XREF-ACCT-ID = "12345678901"
+  AND XREF-CUST-ID = "123456789"
+```
+
+### Scenario 5: Multiple cards per account
+
+```gherkin
+GIVEN account "12345678901" has 3 associated cards
+WHEN the card list is filtered by account "12345678901"
+THEN all 3 cards are displayed across paginated results
+  AND the alternate index lookup returns only the first card by key order
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 97 | Strong customer authentication for accessing payment instrument data | Account-based card lookup ensures users access only cards associated with their authorized account |
+| GDPR | Art. 15 | Data subject's right of access to personal data | The cross-reference structure enables retrieving all cards and accounts for a given customer, supporting data subject access requests |
+| AML 2017:11 | Para. 3 | Transaction monitoring requires linking transactions to account holders | The card → account → customer chain enables full transaction attribution for AML monitoring purposes |
+
+## Edge Cases
+
+1. **Alternate index returns only first card**: When looking up by account ID using CARDAIX, CICS READ returns only the first matching record by primary key order. If an account has multiple cards, only one is displayed in the detail view. The migrated system should clarify whether single-card or multi-card display is expected for account-based lookups — a disambiguation list may be more appropriate.
+
+2. **Cross-reference vs direct FK redundancy**: The CARD-ACCT-ID field in the card record provides a direct card-to-account link, making the cross-reference partially redundant for that relationship. The cross-reference adds the customer dimension (XREF-CUST-ID) which is not in the card record. The migrated system should normalize this into proper foreign key relationships.
+
+3. **Orphaned cross-references**: If a cross-reference entry exists for a card that has been deleted, or maps to a non-existent account, the system has no referential integrity enforcement. The COBOL batch program (CBTRN01C) handles this by displaying a warning but continuing processing. The migrated system should enforce referential integrity at the database level.
+
+4. **One-to-many cardinality**: The relationship is: one account can have many cards, one card belongs to one account, and one customer can have multiple accounts and cards. The cross-reference captures the full N:M:N relationship chain.
+
+5. **File path aliasing**: The alternate index is accessed via `LIT-CARDFILENAME-ACCT-PATH` which maps to the CARDAIX DD name. This is a CICS file alias, not a separate physical file. The migrated system replaces this with a SQL index on the account ID column of the cards table.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. Key questions: (1) Should the card detail view display all cards for an account (multi-card list) or just the first one? (2) Is the cross-reference file (XREFFILE) a separate physical file or an alternate index path? (3) Are there any business rules about the maximum number of cards per account? (4) Is the customer-account relationship always 1:1 or can one customer have multiple accounts? (5) Should the migrated system enforce referential integrity between cards, accounts, and customers at the database level?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/account-management/acct-br-004.md
+++ b/docs-site/docs/business-rules/account-management/acct-br-004.md
@@ -1,0 +1,190 @@
+---
+id: "acct-br-004"
+title: "Account balance management and cycle tracking"
+domain: "account-management"
+cobol_source: "CBTRN02C.cbl:545-560"
+requirement_id: "ACCT-BR-004"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 3"
+  - "FSA FFFS 2014:5 Ch. 7"
+  - "PSD2 Art. 64"
+  - "DORA Art. 11"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# ACCT-BR-004: Account balance management and cycle tracking
+
+## Summary
+
+Account balance management is the most financially critical business rule in the system. The daily batch posting program (CBTRN02C) maintains three balance fields per account: the running current balance (`ACCT-CURR-BAL`), the current billing cycle credit total (`ACCT-CURR-CYC-CREDIT`), and the current billing cycle debit total (`ACCT-CURR-CYC-DEBIT`). Every posted transaction updates the current balance and classifies the amount into either cycle credit or cycle debit based on the sign of the transaction amount. This three-field tracking mechanism enables statement generation, interest calculation, and minimum payment computation. The balance update is performed via REWRITE to the ACCTFILE opened in I-O mode.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM 2800-UPDATE-ACCOUNT-REC:
+    -- Step 1: Update running balance (always, regardless of sign)
+    ADD DALYTRAN-AMT TO ACCT-CURR-BAL
+
+    -- Step 2: Classify into billing cycle bucket
+    IF DALYTRAN-AMT >= 0    (purchase/charge — positive amount)
+        ADD DALYTRAN-AMT TO ACCT-CURR-CYC-CREDIT
+    ELSE                     (payment/credit — negative amount)
+        ADD DALYTRAN-AMT TO ACCT-CURR-CYC-DEBIT
+    END-IF
+
+    -- Step 3: Persist updated record
+    REWRITE ACCOUNT-RECORD TO ACCTFILE
+
+BALANCE INVARIANT:
+    ACCT-CURR-BAL ≈ ACCT-CURR-CYC-CREDIT + ACCT-CURR-CYC-DEBIT
+    (approximately equal — may diverge at billing cycle boundaries
+     if carry-forward amounts exist from previous cycles)
+```
+
+### Decision Table
+
+| Transaction Amount | Sign | ACCT-CURR-BAL Update | ACCT-CURR-CYC-CREDIT Update | ACCT-CURR-CYC-DEBIT Update |
+|---|---|---|---|---|
+| +500.00 (purchase) | Positive | += 500.00 | += 500.00 | unchanged |
+| +0.00 (zero amount) | Non-negative | += 0.00 | += 0.00 | unchanged |
+| -200.00 (payment) | Negative | += -200.00 | unchanged | += -200.00 |
+| -1000.00 (large payment) | Negative | += -1000.00 | unchanged | += -1000.00 |
+| +0.01 (minimum charge) | Positive | += 0.01 | += 0.01 | unchanged |
+
+### Financial Precision
+
+| Field | COBOL PIC | Migrated Type | Range | Notes |
+|---|---|---|---|---|
+| DALYTRAN-AMT | S9(09)V99 | decimal(11,2) | ±999,999,999.99 | Input transaction amount |
+| ACCT-CURR-BAL | S9(10)V99 | decimal(12,2) | ±9,999,999,999.99 | Running account balance |
+| ACCT-CURR-CYC-CREDIT | S9(10)V99 | decimal(12,2) | ±9,999,999,999.99 | Current cycle charges |
+| ACCT-CURR-CYC-DEBIT | S9(10)V99 | decimal(12,2) | ±9,999,999,999.99 | Current cycle payments |
+
+## Source COBOL Reference
+
+**Program:** `CBTRN02C.cbl`
+**Lines:** 545-560 (account balance update paragraph)
+
+```cobol
+000545 2800-UPDATE-ACCOUNT-REC.
+000547           ADD DALYTRAN-AMT  TO ACCT-CURR-BAL
+000548           IF DALYTRAN-AMT >= 0
+000549              ADD DALYTRAN-AMT TO ACCT-CURR-CYC-CREDIT
+000550           ELSE
+000551              ADD DALYTRAN-AMT TO ACCT-CURR-CYC-DEBIT
+000552           END-IF
+```
+
+**Context — balance fields read from ACCTFILE (I-O mode):**
+
+The ACCTFILE is opened in I-O mode by CBTRN02C.cbl, allowing both READ and REWRITE operations. The account record is read during validation (paragraph 1500-B-LOOKUP-ACCT), and the balance fields are updated and written back during posting (paragraph 2800-UPDATE-ACCOUNT-REC).
+
+**Credit limit pre-check (lines 403-407):**
+
+```cobol
+000403               COMPUTE WS-TEMP-BAL = ACCT-CURR-CYC-CREDIT
+000404                                   - ACCT-CURR-CYC-DEBIT
+000405                                   + DALYTRAN-AMT
+000407               IF ACCT-CREDIT-LIMIT >= WS-TEMP-BAL
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Purchase transaction updates balance and cycle credit
+
+```gherkin
+GIVEN an account with:
+  | Field | Value |
+  | ACCT-CURR-BAL | 1000.00 |
+  | ACCT-CURR-CYC-CREDIT | 1000.00 |
+  | ACCT-CURR-CYC-DEBIT | 0.00 |
+WHEN a purchase transaction of +250.00 is posted
+THEN ACCT-CURR-BAL = 1250.00
+  AND ACCT-CURR-CYC-CREDIT = 1250.00
+  AND ACCT-CURR-CYC-DEBIT = 0.00 (unchanged)
+  AND the account record is written back via REWRITE
+```
+
+### Scenario 2: Payment transaction updates balance and cycle debit
+
+```gherkin
+GIVEN an account with:
+  | Field | Value |
+  | ACCT-CURR-BAL | 1000.00 |
+  | ACCT-CURR-CYC-CREDIT | 1200.00 |
+  | ACCT-CURR-CYC-DEBIT | -200.00 |
+WHEN a payment of -300.00 is posted
+THEN ACCT-CURR-BAL = 700.00
+  AND ACCT-CURR-CYC-CREDIT = 1200.00 (unchanged)
+  AND ACCT-CURR-CYC-DEBIT = -500.00
+```
+
+### Scenario 3: Zero amount classified as credit
+
+```gherkin
+GIVEN any account state
+WHEN a transaction of +0.00 is posted
+THEN ACCT-CURR-BAL is unchanged
+  AND ACCT-CURR-CYC-CREDIT is unchanged (0.00 added)
+  AND ACCT-CURR-CYC-DEBIT is NOT updated
+  AND the zero amount follows the >= 0 path (classified as credit)
+```
+
+### Scenario 4: Multiple transactions in same batch preserve order
+
+```gherkin
+GIVEN an account with all balances at 0.00
+WHEN the batch sequentially processes: +100.00, +200.00, -50.00
+THEN after all three transactions:
+  | Field | Value |
+  | ACCT-CURR-BAL | 250.00 |
+  | ACCT-CURR-CYC-CREDIT | 300.00 |
+  | ACCT-CURR-CYC-DEBIT | -50.00 |
+  AND the invariant CURR-BAL = CYC-CREDIT + CYC-DEBIT holds (250 = 300 + (-50))
+```
+
+### Scenario 5: Account record persisted after each transaction
+
+```gherkin
+GIVEN a transaction has been validated and posted
+WHEN the account balance update completes
+THEN the account record is written back to ACCTFILE via REWRITE
+  AND the updated balances are available for the next transaction in the batch
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 3 | Financial institutions must maintain accurate accounting records | Three-field balance tracking provides a complete picture of account activity: net position (CURR-BAL), charges (CYC-CREDIT), and payments (CYC-DEBIT) |
+| FSA FFFS 2014:5 | Ch. 7 | Financial system accuracy and completeness | Fixed-point COBOL arithmetic ensures no floating-point errors in balance calculations; the migrated system must use decimal types |
+| PSD2 | Art. 64 | Payment transaction data integrity — amounts must be processed accurately | Each transaction updates the balance atomically via REWRITE, maintaining data integrity |
+| DORA | Art. 11 | ICT risk management — data integrity and system resilience | Any I/O error during REWRITE triggers an ABEND, preventing partial balance updates that could leave the account in an inconsistent state |
+
+## Edge Cases
+
+1. **Balance overflow**: With `S9(10)V99`, the maximum balance is ±9,999,999,999.99. COBOL truncates silently on overflow without raising an exception. For high-value corporate accounts approaching this limit, transactions could silently corrupt the balance. The migrated system must use `decimal(12,2)` and add explicit overflow detection.
+
+2. **Credit/debit classification of zero**: A zero-amount transaction (`DALYTRAN-AMT = 0.00`) is classified as credit because the condition is `>= 0`. This is consistent but should be documented — zero-amount transactions (e.g., authorization-only) follow the credit path without changing any balance.
+
+3. **Negative cycle debit accumulation**: Since negative amounts are added to `ACCT-CURR-CYC-DEBIT`, this field becomes increasingly negative over the billing cycle. The relationship `ACCT-CURR-BAL ≈ CYC-CREDIT + CYC-DEBIT` holds. The migrated system should enforce this invariant.
+
+4. **No transaction isolation within batch**: Each transaction reads and updates the account record sequentially within the COBOL batch. There is no locking between transactions because the batch has exclusive file access. The migrated system must use database transactions with appropriate isolation levels (e.g., SERIALIZABLE or row-level locking) to prevent concurrent update anomalies.
+
+5. **Cycle reset timing unknown**: The available COBOL source does not show when cycle credits and debits are reset for a new billing cycle. This is likely handled by a separate statement generation batch job not in the repository. The migrated system must identify and preserve the cycle reset mechanism.
+
+6. **Working storage precision mismatch**: `WS-TEMP-BAL` uses `S9(09)V99` (9 integer digits) while account fields use `S9(10)V99` (10 integer digits). This means the credit limit check could truncate for accounts with very large balances. The migrated system should use consistent precision for all intermediate calculations.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. CRITICAL QUESTIONS: (1) Does the invariant `ACCT-CURR-BAL = CYC-CREDIT + CYC-DEBIT` always hold, or can the balance include carried-over amounts from previous cycles? (2) When and how are cycle credits and debits reset to zero — at statement generation, at cycle close, or another event? (3) Is there a separate batch job for billing cycle closing? If so, what is the program name? (4) Should the migrated system use database transactions to ensure atomicity of the balance update, or is the current sequential-in-batch approach sufficient? (5) Can multiple batch runs process the same account concurrently (e.g., intraday vs nightly)?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/account-management/acct-br-005.md
+++ b/docs-site/docs/business-rules/account-management/acct-br-005.md
@@ -1,0 +1,255 @@
+---
+id: "acct-br-005"
+title: "Account status transitions and lifecycle management"
+domain: "account-management"
+cobol_source: "CVACT02Y.cpy:10, COCRDUPC.cbl:845-876, CBTRN02C.cbl:414-420"
+requirement_id: "ACCT-BR-005"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 4 §3"
+  - "PSD2 Art. 97"
+  - "GDPR Art. 17"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# ACCT-BR-005: Account status transitions and lifecycle management
+
+## Summary
+
+Account status management in the COBOL system uses a simple binary active/inactive model. The card-level active status (`CARD-ACTIVE-STATUS` in CVACT02Y.cpy) is a single character field accepting only 'Y' (active) or 'N' (inactive), validated in the card update program (COCRDUPC.cbl). At the account level, the `ACCT-ACTIVE-STATUS` field follows the same pattern. Account expiration is enforced separately during batch transaction posting (CBTRN02C.cbl), where transactions for expired accounts are rejected. The expected coverage for the migrated system includes additional status transitions (dormant, frozen, closed) that are not explicitly present in the available COBOL source but are referenced in the .NET domain model and required by Swedish banking regulations.
+
+## Business Logic
+
+### Pseudocode
+
+```
+-- Card status validation (COCRDUPC: 1240-EDIT-CARDSTATUS)
+PERFORM EDIT-CARD-STATUS:
+    IF card-status = LOW-VALUES OR SPACES OR ZEROS
+        SET input-error = TRUE
+        SET card-status-must-be-yes-no = TRUE
+        EXIT PARAGRAPH
+    END-IF
+
+    MOVE card-status TO yes-no-check-field
+
+    IF yes-no-check-field IS VALID ('Y' or 'N')
+        SET card-status-is-valid = TRUE
+    ELSE
+        SET input-error = TRUE
+        SET card-status-must-be-yes-no = TRUE
+        EXIT PARAGRAPH
+    END-IF
+
+-- Account expiration check (CBTRN02C: credit limit validation)
+PERFORM CHECK-ACCOUNT-EXPIRATION:
+    IF ACCT-EXPIRAION-DATE < transaction-date(1:10)
+        SET fail-reason = 103
+        SET description = "TRANSACTION RECEIVED AFTER ACCT EXPIRATION"
+    END-IF
+
+-- Account active status (inferred from .NET domain model)
+ACCOUNT STATUS VALUES:
+    'Y' = Active (or 'A' in extended model)
+    'N' = Inactive
+    Extended model (not in available COBOL):
+        'A' = Active
+        'D' = Dormant
+        'F' = Frozen
+        'C' = Closed
+```
+
+### Status Transition Matrix (Available COBOL)
+
+| Current Status | Action | New Status | Validated In |
+|---------------|--------|-----------|-------------|
+| Y (Active) | Deactivate card | N (Inactive) | COCRDUPC.cbl:845-876 |
+| N (Inactive) | Activate card | Y (Active) | COCRDUPC.cbl:845-876 |
+| Any | Expired account | Rejected transactions | CBTRN02C.cbl:414-420 |
+
+### Expected Status Model (Extended for Migration)
+
+| Status | Code | Description | Allowed Operations |
+|--------|------|-------------|-------------------|
+| Active | A/Y | Account in good standing | All operations (transactions, inquiries, updates) |
+| Dormant | D | No activity for regulatory period | Inquiry only; reactivation on next transaction |
+| Frozen | F | Suspended by bank or regulatory order | Inquiry only; no transactions |
+| Closed | C | Account permanently closed | No operations; retained for regulatory period |
+| Inactive | N | Card/account deactivated | Inquiry only |
+
+### Validation Rules
+
+| Check | Value | Valid? | Error Message |
+|-------|-------|--------|---------------|
+| 'Y' | Active | Yes | — |
+| 'N' | Inactive | Yes | — |
+| 'y' | Lowercase | No | "CARD STATUS MUST BE YES OR NO" |
+| ' ' | Space | No | "CARD STATUS MUST BE YES OR NO" |
+| 'X' | Other | No | "CARD STATUS MUST BE YES OR NO" |
+| LOW-VALUES | Empty | No | "CARD STATUS MUST BE YES OR NO" |
+
+## Source COBOL Reference
+
+**Programs:** `COCRDUPC.cbl`, `CBTRN02C.cbl`
+**Copybook:** `CVACT02Y.cpy`
+
+### CVACT02Y.cpy — Status field in card record
+
+```cobol
+           05  CARD-ACTIVE-STATUS                PIC X(01).
+```
+*(Line 10 — single character, 'Y' or 'N')*
+
+### COCRDUPC.cbl — Card status validation
+
+```cobol
+000845 1240-EDIT-CARDSTATUS.
+000846*    Must be Y or N
+000847     SET FLG-CARDSTATUS-NOT-OK      TO TRUE
+000848
+000849*    Not supplied
+000850     IF CCUP-NEW-CRDSTCD   EQUAL LOW-VALUES
+000851     OR CCUP-NEW-CRDSTCD   EQUAL SPACES
+000852     OR CCUP-NEW-CRDSTCD   EQUAL ZEROS
+000853        SET INPUT-ERROR           TO TRUE
+000854        SET FLG-CARDSTATUS-BLANK  TO TRUE
+000855        IF WS-RETURN-MSG-OFF
+000856           SET CARD-STATUS-MUST-BE-YES-NO TO TRUE
+000857        END-IF
+000858        GO TO  1240-EDIT-CARDSTATUS-EXIT
+000859     END-IF
+000860
+000861     MOVE CCUP-NEW-CRDSTCD          TO FLG-YES-NO-CHECK
+000862
+000863     IF FLG-YES-NO-VALID
+000864        SET FLG-CARDSTATUS-ISVALID  TO TRUE
+000865     ELSE
+000866        SET INPUT-ERROR             TO TRUE
+000867        SET FLG-CARDSTATUS-NOT-OK   TO TRUE
+000868        IF WS-RETURN-MSG-OFF
+000869           SET CARD-STATUS-MUST-BE-YES-NO  TO TRUE
+000870        END-IF
+000871        GO TO  1240-EDIT-CARDSTATUS-EXIT
+000872     END-IF
+000873     .
+000874 1240-EDIT-CARDSTATUS-EXIT.
+000875     EXIT
+000876     .
+```
+
+### COCRDUPC.cbl — Yes/No validation flag definition
+
+```cobol
+000091        05  FLG-YES-NO-CHECK              PIC X(1).
+000092            88  FLG-YES-NO-VALID          VALUES 'Y', 'N'.
+```
+*(Lines 91-92 — defines the valid values for status fields)*
+
+### CBTRN02C.cbl — Account expiration enforcement
+
+```cobol
+000414               IF ACCT-EXPIRAION-DATE >= DALYTRAN-ORIG-TS (1:10)
+000415                 CONTINUE
+000416               ELSE
+000417                 MOVE 103 TO WS-VALIDATION-FAIL-REASON
+000418                 MOVE 'TRANSACTION RECEIVED AFTER ACCT EXPIRATION'
+000419                   TO WS-VALIDATION-FAIL-REASON-DESC
+000420               END-IF
+```
+
+### .NET Domain Model — Extended status values
+
+```csharp
+/// <summary>Active status ('A' = active, 'D' = dormant). COBOL: ACCT-ACTIVE-STATUS PIC X(01).</summary>
+public string ActiveStatus { get; set; } = string.Empty;
+```
+*(src/NordKredit.Domain/Transactions/Account.cs:14 — note 'A' and 'D' values, extending COBOL 'Y'/'N')*
+
+## Acceptance Criteria
+
+### Scenario 1: Valid active status accepted
+
+```gherkin
+GIVEN the user enters card status "Y"
+WHEN card status validation is performed
+THEN the status is accepted as valid
+  AND the card status flag is set to ISVALID
+```
+
+### Scenario 2: Valid inactive status accepted
+
+```gherkin
+GIVEN the user enters card status "N"
+WHEN card status validation is performed
+THEN the status is accepted as valid
+  AND the card status flag is set to ISVALID
+```
+
+### Scenario 3: Invalid status rejected
+
+```gherkin
+GIVEN the user enters card status "X"
+WHEN card status validation is performed
+THEN the input is rejected
+  AND the message "CARD STATUS MUST BE YES OR NO" is displayed
+```
+
+### Scenario 4: Blank status rejected
+
+```gherkin
+GIVEN the user leaves the card status field blank
+WHEN card status validation is performed
+THEN the input is rejected
+  AND the message "CARD STATUS MUST BE YES OR NO" is displayed
+```
+
+### Scenario 5: Expired account blocks transactions
+
+```gherkin
+GIVEN an account with expiration date "2025-06-30"
+  AND a daily transaction with origination date "2025-07-01"
+WHEN the batch program validates the transaction
+THEN the transaction is rejected with code 103
+  AND reason "TRANSACTION RECEIVED AFTER ACCT EXPIRATION"
+```
+
+### Scenario 6: Non-expired account allows transactions
+
+```gherkin
+GIVEN an account with expiration date "2028-12-31"
+  AND a daily transaction with origination date "2026-02-17"
+WHEN the batch program validates the transaction
+THEN the expiration check passes
+  AND the transaction proceeds to the next validation step
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 4 §3 | Operational risk — systems must enforce access controls and prevent unauthorized operations | Status validation prevents transactions on inactive or expired accounts |
+| PSD2 | Art. 97 | Payment instruments must be properly managed with clear activation/deactivation controls | The Y/N status flag provides explicit activation/deactivation for card payment instruments |
+| GDPR | Art. 17 | Right to erasure — upon account closure, PII must be handled according to data retention policies | The account status model must support a "Closed" state that triggers data retention/erasure workflows (not present in current COBOL but required for compliance) |
+
+## Edge Cases
+
+1. **Case sensitivity**: The COBOL validation accepts only uppercase 'Y' and 'N'. Lowercase 'y' and 'n' are rejected. The migrated system should either enforce uppercase or perform case-insensitive comparison — the approach must be documented and consistent.
+
+2. **Status at card level vs account level**: The available COBOL source validates status at the card level (CARD-ACTIVE-STATUS). The account-level status (ACCT-ACTIVE-STATUS) is referenced in the .NET domain model but the validation logic is not in the available COBOL source. The migrated system must clarify the relationship: can an active account have inactive cards? Can an inactive account have active cards?
+
+3. **Missing dormant/frozen states**: Swedish banking regulations (FSA FFFS 2014:5) require dormancy handling (accounts with no activity for a defined period) and freeze capability (for AML/regulatory holds). These states are not in the available COBOL source but are referenced in the .NET domain model ('D' for dormant). The migrated system must implement the full status lifecycle.
+
+4. **Expiration date string comparison**: The COBOL code compares `ACCT-EXPIRAION-DATE` as a string against the first 10 characters of the transaction timestamp. This works because YYYY-MM-DD format preserves chronological ordering in string comparison. The migrated system should use proper date comparison.
+
+5. **No state machine enforcement**: The COBOL system allows direct Y↔N transitions without intermediate states. There is no audit trail of status changes in the available source. The migrated system should implement a state machine with transition rules and an audit log.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. CRITICAL QUESTIONS: (1) What account status values exist beyond Y/N — are dormant ('D'), frozen ('F'), and closed ('C') used on the mainframe? (2) Are there state transition rules (e.g., can an account go from Closed to Active)? (3) Is there a dormancy detection batch job? If so, what defines the dormancy period? (4) Can an account be frozen independently of its cards? (5) What happens to pending transactions when an account transitions from Active to Frozen? (6) Is there an account status change audit trail on the mainframe?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/account-management/acct-br-006.md
+++ b/docs-site/docs/business-rules/account-management/acct-br-006.md
@@ -1,0 +1,304 @@
+---
+id: "acct-br-006"
+title: "Account expiration date management and enforcement"
+domain: "account-management"
+cobol_source: "CBTRN02C.cbl:414-420, COCRDUPC.cbl:913-947"
+requirement_id: "ACCT-BR-006"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 4 §3"
+  - "PSD2 Art. 97"
+  - "GDPR Art. 5(1)(e)"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# ACCT-BR-006: Account expiration date management and enforcement
+
+## Summary
+
+Account expiration is enforced at two levels in the COBOL system: at the card level through expiration date validation in the card update program (COCRDUPC.cbl), and at the account level through batch transaction rejection in the posting program (CBTRN02C.cbl). The expiration date is stored as a string in YYYY-MM-DD format (10 characters) and compared as a string against transaction dates — this works because the ISO date format preserves chronological ordering. Card expiration date components (year, month, day) are validated individually, with year constrained to 1950-2099 and month to 01-12. Account expiration is checked during daily batch posting, and expired accounts have all transactions rejected with code 103.
+
+## Business Logic
+
+### Pseudocode
+
+```
+-- Account expiration check during batch posting (CBTRN02C)
+PERFORM CHECK-ACCOUNT-EXPIRATION:
+    -- Compare account expiry date with transaction origination date
+    -- Both in YYYY-MM-DD string format
+    IF ACCT-EXPIRAION-DATE >= DALYTRAN-ORIG-TS(1:10)
+        -- Account not expired, transaction proceeds
+        CONTINUE
+    ELSE
+        -- Account expired, reject transaction
+        MOVE 103 TO fail-reason
+        MOVE 'TRANSACTION RECEIVED AFTER ACCT EXPIRATION'
+            TO fail-reason-description
+    END-IF
+
+-- Card expiration date validation (COCRDUPC)
+PERFORM VALIDATE-EXPIRY-YEAR:
+    IF expiry-year = LOW-VALUES OR SPACES OR ZEROS
+        SET input-error = TRUE
+        EXIT PARAGRAPH
+    END-IF
+    IF expiry-year IS NUMERIC
+        AND expiry-year >= 1950
+        AND expiry-year <= 2099
+            SET year-is-valid = TRUE
+    ELSE
+        SET input-error = TRUE
+        MOVE 'VALID YEAR MUST BE BETWEEN 1950 AND 2099'
+            TO error-message
+    END-IF
+
+PERFORM VALIDATE-EXPIRY-MONTH:
+    IF expiry-month = LOW-VALUES OR SPACES OR ZEROS
+        SET input-error = TRUE
+        EXIT PARAGRAPH
+    END-IF
+    IF expiry-month IS NUMERIC
+        AND expiry-month >= 01
+        AND expiry-month <= 12
+            SET month-is-valid = TRUE
+    ELSE
+        SET input-error = TRUE
+        MOVE 'VALID MONTH MUST BE BETWEEN 01 AND 12'
+            TO error-message
+    END-IF
+```
+
+### Decision Table — Account Expiration Enforcement
+
+| Account Expiry Date | Transaction Date | Comparison | Result |
+|---|---|---|---|
+| 2028-12-31 | 2026-02-17 | 2028-12-31 >= 2026-02-17 | Transaction proceeds |
+| 2026-02-17 | 2026-02-17 | 2026-02-17 >= 2026-02-17 | Transaction proceeds (same-day is valid) |
+| 2025-06-30 | 2026-02-17 | 2025-06-30 >= 2026-02-17 | REJECTED: code 103 |
+| NULL/spaces | 2026-02-17 | Undefined | See edge case #3 |
+
+### Decision Table — Card Expiry Year Validation
+
+| Year Value | Numeric? | Range | Outcome |
+|-----------|----------|-------|---------|
+| "2027" | Yes | 1950-2099 | Valid |
+| "1949" | Yes | Below range | Error: "VALID YEAR MUST BE BETWEEN 1950 AND 2099" |
+| "2100" | Yes | Above range | Error: "VALID YEAR MUST BE BETWEEN 1950 AND 2099" |
+| "ABCD" | No | N/A | Error: not numeric |
+| "0000" | Yes | Treated as zeros | Error: blank/zero handling |
+
+### Decision Table — Card Expiry Month Validation
+
+| Month Value | Numeric? | Range | Outcome |
+|------------|----------|-------|---------|
+| "06" | Yes | 01-12 | Valid |
+| "00" | Yes | Below range | Error: blank/zero handling |
+| "13" | Yes | Above range | Error: "VALID MONTH MUST BE BETWEEN 01 AND 12" |
+| "AB" | No | N/A | Error: not numeric |
+
+## Source COBOL Reference
+
+**Programs:** `CBTRN02C.cbl`, `COCRDUPC.cbl`
+
+### CBTRN02C.cbl — Account expiration enforcement in batch
+
+```cobol
+000414               IF ACCT-EXPIRAION-DATE >= DALYTRAN-ORIG-TS (1:10)
+000415                 CONTINUE
+000416               ELSE
+000417                 MOVE 103 TO WS-VALIDATION-FAIL-REASON
+000418                 MOVE 'TRANSACTION RECEIVED AFTER ACCT EXPIRATION'
+000419                   TO WS-VALIDATION-FAIL-REASON-DESC
+000420               END-IF
+```
+*(Lines 414-420 — string comparison of YYYY-MM-DD formatted dates)*
+
+### COCRDUPC.cbl — Card expiry year validation
+
+```cobol
+000913 1250-EDIT-EXPIRY-YEAR.
+000914*    Must be between 1950 and 2099
+000915     SET FLG-EXPYEAR-NOT-OK      TO TRUE
+000916
+000917*    Not supplied
+000918     IF CCUP-NEW-EXPYEAR   EQUAL LOW-VALUES
+000919     OR CCUP-NEW-EXPYEAR   EQUAL SPACES
+000920     OR CCUP-NEW-EXPYEAR   EQUAL ZEROS
+000921        SET INPUT-ERROR           TO TRUE
+000922        SET FLG-EXPYEAR-BLANK     TO TRUE
+000923        IF WS-RETURN-MSG-OFF
+000924           SET EXP-YEAR-MUST-BE-VALID TO TRUE
+000925        END-IF
+000926        GO TO  1250-EDIT-EXPIRY-YEAR-EXIT
+000927     END-IF
+000928
+000929     IF CCUP-NEW-EXPYEAR IS NUMERIC
+000930       IF CCUP-NEW-EXPYEAR >= 1950
+000931         AND CCUP-NEW-EXPYEAR <= 2099
+000932            SET FLG-EXPYEAR-ISVALID  TO TRUE
+000933       ELSE
+000934            SET INPUT-ERROR           TO TRUE
+000935            SET FLG-EXPYEAR-NOT-OK    TO TRUE
+000936            IF WS-RETURN-MSG-OFF
+000937               SET EXP-YEAR-MUST-BE-VALID TO TRUE
+000938            END-IF
+000939       END-IF
+000940     ELSE
+000941        SET INPUT-ERROR             TO TRUE
+000942        SET FLG-EXPYEAR-NOT-OK      TO TRUE
+000943        IF WS-RETURN-MSG-OFF
+000944           SET EXP-YEAR-MUST-BE-VALID TO TRUE
+000945        END-IF
+000946     END-IF
+000947     .
+```
+
+### COCRDUPC.cbl — Card expiry month validation
+
+```cobol
+000877 1260-EDIT-EXPIRY-MONTH.
+000878*    Must be between 01 and 12
+000879     SET FLG-EXPMON-NOT-OK      TO TRUE
+000880
+000881*    Not supplied
+000882     IF CCUP-NEW-EXPMON   EQUAL LOW-VALUES
+000883     OR CCUP-NEW-EXPMON   EQUAL SPACES
+000884     OR CCUP-NEW-EXPMON   EQUAL ZEROS
+000885        SET INPUT-ERROR           TO TRUE
+000886        SET FLG-EXPMON-BLANK      TO TRUE
+000887        IF WS-RETURN-MSG-OFF
+000888           SET EXP-MON-MUST-BE-VALID TO TRUE
+000889        END-IF
+000890        GO TO  1260-EDIT-EXPIRY-MONTH-EXIT
+000891     END-IF
+000892
+000893     IF CCUP-NEW-EXPMON IS NUMERIC
+000894       IF CCUP-NEW-EXPMON >= 01
+000895         AND CCUP-NEW-EXPMON <= 12
+000896            SET FLG-EXPMON-ISVALID  TO TRUE
+000897       ELSE
+000898            SET INPUT-ERROR           TO TRUE
+000899            SET FLG-EXPMON-NOT-OK     TO TRUE
+000900            IF WS-RETURN-MSG-OFF
+000901               SET EXP-MON-MUST-BE-VALID TO TRUE
+000902            END-IF
+000903       END-IF
+000904     ELSE
+000905        SET INPUT-ERROR             TO TRUE
+000906        SET FLG-EXPMON-NOT-OK       TO TRUE
+000907        IF WS-RETURN-MSG-OFF
+000908           SET EXP-MON-MUST-BE-VALID TO TRUE
+000909        END-IF
+000910     END-IF
+000911     .
+```
+
+### Expiration date structure in COBOL
+
+```cobol
+          05 CCUP-OLD-EXPIRAION-DATE.
+             25 CCUP-OLD-EXPYEAR             PIC X(4).
+             25 CCUP-OLD-EXPMON              PIC X(2).
+             25 CCUP-OLD-EXPDAY              PIC X(2).
+```
+*(COCRDUPC.cbl lines ~296-299 — date broken into year/month/day components, 8 chars without separators)*
+
+## Acceptance Criteria
+
+### Scenario 1: Non-expired account allows transactions
+
+```gherkin
+GIVEN an account with expiration date "2028-12-31"
+  AND a daily transaction with origination date "2026-02-17"
+WHEN the batch validates the transaction
+THEN the expiration check passes (2028-12-31 >= 2026-02-17)
+  AND the transaction proceeds to the next validation step
+```
+
+### Scenario 2: Same-day expiration allows transactions
+
+```gherkin
+GIVEN an account with expiration date "2026-02-17"
+  AND a daily transaction with origination date "2026-02-17"
+WHEN the batch validates the transaction
+THEN the expiration check passes (2026-02-17 >= 2026-02-17)
+  AND the transaction proceeds (same-day is valid)
+```
+
+### Scenario 3: Expired account rejects transactions
+
+```gherkin
+GIVEN an account with expiration date "2025-06-30"
+  AND a daily transaction with origination date "2026-02-17"
+WHEN the batch validates the transaction
+THEN the transaction is rejected with code 103
+  AND reason "TRANSACTION RECEIVED AFTER ACCT EXPIRATION"
+```
+
+### Scenario 4: Valid expiry year accepted
+
+```gherkin
+GIVEN the user enters expiry year "2027"
+WHEN expiry year validation is performed
+THEN the year is accepted as valid (within 1950-2099 range)
+```
+
+### Scenario 5: Invalid expiry year rejected
+
+```gherkin
+GIVEN the user enters expiry year "2100"
+WHEN expiry year validation is performed
+THEN the year is rejected
+  AND the error message indicates year must be between 1950 and 2099
+```
+
+### Scenario 6: Valid expiry month accepted
+
+```gherkin
+GIVEN the user enters expiry month "06"
+WHEN expiry month validation is performed
+THEN the month is accepted as valid (within 01-12 range)
+```
+
+### Scenario 7: Invalid expiry month rejected
+
+```gherkin
+GIVEN the user enters expiry month "13"
+WHEN expiry month validation is performed
+THEN the month is rejected
+  AND the error message indicates month must be between 01 and 12
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 4 §3 | Operational risk — expired instruments must not process new transactions | Account expiration enforcement prevents transactions on expired accounts, reducing operational risk from stale payment instruments |
+| PSD2 | Art. 97 | Payment instrument lifecycle management — expired instruments must be blocked | The batch rejection (code 103) automatically blocks transactions on expired accounts without manual intervention |
+| GDPR | Art. 5(1)(e) | Storage limitation — data should not be kept longer than necessary | Account expiration dates support data lifecycle management; expired accounts can be flagged for data retention review |
+
+## Edge Cases
+
+1. **EXPIRAION-DATE typo**: The COBOL field name contains a persistent typo ("EXPIRAION" instead of "EXPIRATION"). This typo is present in both the ACCT and CARD record structures. The migrated system should use the correct spelling but must document the mapping.
+
+2. **String comparison for dates**: The COBOL code compares dates as strings (`ACCT-EXPIRAION-DATE >= DALYTRAN-ORIG-TS(1:10)`). This works because YYYY-MM-DD format preserves chronological ordering. The migrated system should use proper date types (`DateOnly` in .NET) for type safety.
+
+3. **Null/missing expiration date**: The COBOL source does not explicitly handle a null or spaces expiration date in the batch check. If `ACCT-EXPIRAION-DATE` is spaces and the transaction date is a valid date string, the comparison `spaces >= "2026-02-17"` would fail (spaces < digits in EBCDIC), rejecting the transaction. The .NET domain model uses `DateTime?` (nullable) to handle accounts without expiration. The migrated system must define explicit behavior for null expiration.
+
+4. **Day component not validated**: While year (1950-2099) and month (01-12) are validated in the card update program, the day component is NOT validated and is NOT editable by users. Invalid days (e.g., "2027-02-30") could exist in the data. The migrated system should validate the complete date.
+
+5. **Year 2099 limit**: The valid year range (1950-2099) has an upper boundary that will eventually need adjustment. This is a Y2.1K concern — the migrated system should use a wider range or remove the artificial ceiling.
+
+6. **8-char vs 10-char date format**: The card record stores the expiry date in 10-char format with separators (YYYY-MM-DD), but the internal working storage breaks it into 4+2+2 = 8 characters without separators. The batch comparison uses the 10-character format. The migrated system should standardize on a single date representation.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. Key questions: (1) What should happen when an account has no expiration date (null/spaces) — should it be treated as "never expires" or as an error? (2) Is the day component of the expiration date meaningful, or does expiration only apply at the month/year level (like credit card expiry)? (3) Are there business processes to extend account expiration dates? (4) Should expired accounts be automatically transitioned to a "Closed" status, or can they be reactivated by updating the expiration date? (5) Is the 1950-2099 year range correct for account expiration, or should it be narrower?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/account-management/acct-br-007.md
+++ b/docs-site/docs/business-rules/account-management/acct-br-007.md
@@ -1,0 +1,215 @@
+---
+id: "acct-br-007"
+title: "Account credit limit enforcement"
+domain: "account-management"
+cobol_source: "CBTRN02C.cbl:403-413"
+requirement_id: "ACCT-BR-007"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 6"
+  - "PSD2 Art. 64"
+  - "EU Consumer Credit Directive 2008/48/EC"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# ACCT-BR-007: Account credit limit enforcement
+
+## Summary
+
+Credit limit enforcement is performed during daily batch transaction posting (CBTRN02C.cbl) as part of the multi-step validation pipeline. Before a transaction is posted, the system calculates a projected balance by adding the transaction amount to the difference between current cycle credits and cycle debits. If this projected balance exceeds the account's credit limit, the transaction is rejected with code 102 ("OVERLIMIT TRANSACTION"). The credit limit is stored in the account master record (`ACCT-CREDIT-LIMIT` field, PIC S9(10)V99) and a separate cash credit limit (`ACCT-CASH-CREDIT-LIMIT`) exists but is not used in the available validation logic. This enforcement is the primary mechanism preventing accounts from exceeding their authorized credit ceiling.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM CREDIT-LIMIT-CHECK (within 1500-VALIDATE-TRAN):
+    -- Step 1: Calculate projected balance
+    COMPUTE WS-TEMP-BAL = ACCT-CURR-CYC-CREDIT
+                        - ACCT-CURR-CYC-DEBIT
+                        + DALYTRAN-AMT
+
+    -- Step 2: Compare against credit limit
+    IF ACCT-CREDIT-LIMIT >= WS-TEMP-BAL
+        -- Within limit, transaction proceeds
+        CONTINUE
+    ELSE
+        -- Over limit, reject transaction
+        MOVE 102 TO WS-VALIDATION-FAIL-REASON
+        MOVE 'OVERLIMIT TRANSACTION'
+            TO WS-VALIDATION-FAIL-REASON-DESC
+    END-IF
+```
+
+### Projected Balance Formula
+
+```
+Projected Balance = Cycle Credits - Cycle Debits + Transaction Amount
+
+Where:
+  Cycle Credits  = sum of all positive transactions this billing cycle
+  Cycle Debits   = sum of all negative transactions this billing cycle (negative value)
+  Transaction Amount = current transaction being validated (positive or negative)
+
+Decision:
+  IF Credit Limit >= Projected Balance → APPROVED
+  IF Credit Limit <  Projected Balance → REJECTED (code 102)
+```
+
+### Decision Table
+
+| CYC-CREDIT | CYC-DEBIT | DALYTRAN-AMT | Projected Balance | Credit Limit | Result |
+|---|---|---|---|---|---|
+| 5000.00 | -1000.00 | +500.00 | 6500.00 | 10000.00 | Approved (6500 <= 10000) |
+| 9000.00 | -500.00 | +2000.00 | 11500.00 | 10000.00 | REJECTED (11500 > 10000) |
+| 9000.00 | -500.00 | -200.00 | 9300.00 | 10000.00 | Approved (9300 <= 10000) |
+| 10000.00 | 0.00 | +0.01 | 10000.01 | 10000.00 | REJECTED (10000.01 > 10000) |
+| 10000.00 | 0.00 | +0.00 | 10000.00 | 10000.00 | Approved (10000 <= 10000) |
+| 0.00 | 0.00 | +10000.00 | 10000.00 | 10000.00 | Approved (exactly at limit) |
+| 5000.00 | -3000.00 | -500.00 | 2500.00 | 10000.00 | Approved (payment reduces projected) |
+
+### Financial Precision
+
+| Field | COBOL PIC | Migrated Type | Range |
+|---|---|---|---|
+| ACCT-CURR-CYC-CREDIT | S9(10)V99 | decimal(12,2) | ±9,999,999,999.99 |
+| ACCT-CURR-CYC-DEBIT | S9(10)V99 | decimal(12,2) | ±9,999,999,999.99 |
+| DALYTRAN-AMT | S9(09)V99 | decimal(11,2) | ±999,999,999.99 |
+| WS-TEMP-BAL | S9(09)V99 | decimal(11,2) | ±999,999,999.99 |
+| ACCT-CREDIT-LIMIT | S9(10)V99 | decimal(12,2) | ±9,999,999,999.99 |
+
+## Source COBOL Reference
+
+**Program:** `CBTRN02C.cbl`
+**Lines:** 403-413 (credit limit validation within 1500-B-LOOKUP-ACCT)
+
+```cobol
+000403               COMPUTE WS-TEMP-BAL = ACCT-CURR-CYC-CREDIT
+000404                                   - ACCT-CURR-CYC-DEBIT
+000405                                   + DALYTRAN-AMT
+000406
+000407               IF ACCT-CREDIT-LIMIT >= WS-TEMP-BAL
+000408                 CONTINUE
+000409               ELSE
+000410                 MOVE 102 TO WS-VALIDATION-FAIL-REASON
+000411                 MOVE 'OVERLIMIT TRANSACTION'
+000412                   TO WS-VALIDATION-FAIL-REASON-DESC
+000413               END-IF
+```
+
+**Context — validation order (lines 370-422):**
+
+The credit limit check occurs after the account lookup succeeds. The validation sequence is:
+1. Card number lookup in XREF file (fail code 100)
+2. Account lookup by account ID (fail code 101)
+3. **Credit limit check** (fail code 102)
+4. Account expiration check (fail code 103)
+
+If multiple validations fail, only the last one's code is retained (sequential overwrite).
+
+## Acceptance Criteria
+
+### Scenario 1: Transaction within credit limit
+
+```gherkin
+GIVEN an account with:
+  | Field | Value |
+  | ACCT-CREDIT-LIMIT | 10000.00 |
+  | ACCT-CURR-CYC-CREDIT | 5000.00 |
+  | ACCT-CURR-CYC-DEBIT | -1000.00 |
+  AND a transaction amount of +500.00
+WHEN the credit limit is checked
+THEN projected balance = 5000.00 - (-1000.00) + 500.00 = 6500.00
+  AND 10000.00 >= 6500.00 is TRUE
+  AND the transaction proceeds
+```
+
+### Scenario 2: Transaction exceeds credit limit
+
+```gherkin
+GIVEN an account with:
+  | Field | Value |
+  | ACCT-CREDIT-LIMIT | 10000.00 |
+  | ACCT-CURR-CYC-CREDIT | 9000.00 |
+  | ACCT-CURR-CYC-DEBIT | -500.00 |
+  AND a transaction amount of +2000.00
+WHEN the credit limit is checked
+THEN projected balance = 9000.00 - (-500.00) + 2000.00 = 11500.00
+  AND 10000.00 >= 11500.00 is FALSE
+  AND the transaction is rejected with code 102
+  AND reason "OVERLIMIT TRANSACTION"
+```
+
+### Scenario 3: Transaction exactly at credit limit
+
+```gherkin
+GIVEN an account with:
+  | Field | Value |
+  | ACCT-CREDIT-LIMIT | 10000.00 |
+  | ACCT-CURR-CYC-CREDIT | 0.00 |
+  | ACCT-CURR-CYC-DEBIT | 0.00 |
+  AND a transaction amount of +10000.00
+WHEN the credit limit is checked
+THEN projected balance = 0.00 - 0.00 + 10000.00 = 10000.00
+  AND 10000.00 >= 10000.00 is TRUE
+  AND the transaction proceeds (boundary: exactly at limit is approved)
+```
+
+### Scenario 4: Payment reduces projected balance
+
+```gherkin
+GIVEN an account near its credit limit
+  | Field | Value |
+  | ACCT-CREDIT-LIMIT | 10000.00 |
+  | ACCT-CURR-CYC-CREDIT | 9800.00 |
+  | ACCT-CURR-CYC-DEBIT | 0.00 |
+  AND a payment (negative transaction) of -500.00
+WHEN the credit limit is checked
+THEN projected balance = 9800.00 - 0.00 + (-500.00) = 9300.00
+  AND 10000.00 >= 9300.00 is TRUE
+  AND the payment proceeds (negative amounts free up credit)
+```
+
+### Scenario 5: Sequential transactions within same batch
+
+```gherkin
+GIVEN an account with credit limit 10000.00 and initial cycle credit 0.00, cycle debit 0.00
+WHEN the batch processes transactions: +8000.00, +1500.00, +1000.00
+THEN +8000.00 projected = 8000.00 → approved (within limit)
+  AND +1500.00 projected = 9500.00 → approved (within limit)
+  AND +1000.00 projected = 10500.00 → REJECTED code 102 (exceeds limit)
+  AND the rejection occurs because cycle credits were updated by prior approved transactions
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 6 | Credit risk management — institutions must manage credit exposure within authorized limits | The credit limit check prevents account balances from exceeding the authorized credit ceiling, maintaining credit risk within approved parameters |
+| PSD2 | Art. 64 | Payment transaction validation — payment service providers must validate transactions | The overlimit check is part of the multi-step validation pipeline that ensures only valid transactions are posted |
+| EU Consumer Credit Directive | 2008/48/EC Art. 10 | Credit agreements must specify credit limit and consequences of exceeding it | The ACCT-CREDIT-LIMIT field captures the agreed credit ceiling; the overlimit rejection (code 102) is the enforcement mechanism |
+
+## Edge Cases
+
+1. **WS-TEMP-BAL precision mismatch**: The projected balance is stored in `WS-TEMP-BAL` which is `S9(09)V99` (9 integer digits), while account fields are `S9(10)V99` (10 integer digits) and the credit limit is also `S9(10)V99`. If `CYC-CREDIT - CYC-DEBIT` exceeds 999,999,999.99, the result is truncated in WS-TEMP-BAL, potentially allowing overlimit transactions. The migrated system must use consistent precision.
+
+2. **Negative amounts reduce projected balance**: The formula `CYC-CREDIT - CYC-DEBIT + AMT` means payment transactions (negative amounts) reduce the projected balance, freeing up credit. This is correct business logic and must be preserved.
+
+3. **Sequential validation overwrite**: If both overlimit (102) and expired (103) conditions are true, code 103 overwrites 102 because the checks are sequential. The migrated system should capture ALL validation failures, not just the last one.
+
+4. **Credit limit of zero**: An account with `ACCT-CREDIT-LIMIT = 0` would reject any positive transaction (projected balance > 0). This could be used for debit-only accounts or as a soft freeze mechanism.
+
+5. **Cash credit limit unused**: The `ACCT-CASH-CREDIT-LIMIT` field exists in the account record (referenced in the .NET domain model) but is not used in the available validation logic. This may be enforced in a separate cash advance processing program not in the repository.
+
+6. **Batch ordering affects approval**: Because cycle credits and debits are updated between transactions within the same batch, the order of transactions affects which ones are approved. A large purchase followed by a payment may exceed the limit, while the same payment followed by the purchase may not.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. CRITICAL QUESTIONS: (1) Is `CYC-CREDIT - CYC-DEBIT + AMT` the correct projected balance formula, or should it use ACCT-CURR-BAL + AMT? (2) Should overlimit transactions be rejected outright, or should there be a tolerance/grace amount? (3) Is the cash credit limit (ACCT-CASH-CREDIT-LIMIT) enforced in a separate program? (4) Are there credit limit increase/decrease procedures in the COBOL system? (5) Should the migrated system enforce real-time credit limit checks (not just batch), and if so, what concurrency model should be used? (6) Are there different credit limit enforcement rules for different transaction types?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/account-management/acct-br-008.md
+++ b/docs-site/docs/business-rules/account-management/acct-br-008.md
@@ -1,0 +1,207 @@
+---
+id: "acct-br-008"
+title: "Account display and list screen presentation"
+domain: "account-management"
+cobol_source: "COCRDLIC.cbl:258-260, 847-852, 1167-1175"
+requirement_id: "ACCT-BR-008"
+regulations:
+  - "PSD2 Art. 97"
+  - "GDPR Art. 15"
+  - "FSA FFFS 2014:5 Ch. 7"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "medium"
+---
+
+# ACCT-BR-008: Account display and list screen presentation
+
+## Summary
+
+Account information is displayed within the card management screens as part of the card list and card detail views. The card list screen (COCRDLIC.cbl) shows the account ID alongside each card in a 7-row paginated display. The card detail screen (COCRDSLC.cbl) shows the full account context when viewing a specific card. Account data is presented either from the current COMMAREA context (`CDEMO-ACCT-ID`) or from the card record itself (`CARD-ACCT-ID`), with zero-value handling to suppress display of empty account fields. There is no dedicated account list or account detail screen in the available COBOL source — account information is always presented in the context of card operations.
+
+## Business Logic
+
+### Pseudocode
+
+```
+-- Card list screen: display account alongside each card (COCRDLIC)
+PERFORM DISPLAY-CARD-LIST-ROW:
+    FOR each card in page (up to 7 rows):
+        MOVE CARD-NUM          TO WS-ROW-CARD-NUM(row-index)
+        MOVE CARD-ACCT-ID      TO WS-ROW-ACCTNO(row-index)
+        MOVE CARD-ACTIVE-STATUS TO WS-ROW-CARD-STATUS(row-index)
+
+        -- Track first card on page for backward navigation
+        IF row-index = 1
+            MOVE CARD-ACCT-ID  TO WS-CA-FIRST-CARD-ACCT-ID
+            MOVE CARD-NUM      TO WS-CA-FIRST-CARD-NUM
+        END-IF
+
+        -- Track last card on page for forward navigation
+        MOVE CARD-ACCT-ID      TO WS-CA-LAST-CARD-ACCT-ID
+
+-- Card detail/search screen: display account context (COCRDSLC/COCRDUPC)
+PERFORM DISPLAY-ACCOUNT-CONTEXT:
+    IF CDEMO-ACCT-ID = 0
+        MOVE LOW-VALUES TO screen-account-field
+        -- Suppress display of zero account ID
+    ELSE
+        MOVE CC-ACCT-ID TO screen-account-field
+    END-IF
+
+-- Card list header: display account filter (COCRDLIC)
+PERFORM DISPLAY-FILTER-CONTEXT:
+    IF CC-ACCT-ID NOT = ZEROES AND NOT = SPACES
+        MOVE CC-ACCT-ID    TO screen-filter-account
+    ELSE
+        IF CDEMO-ACCT-ID = 0
+            MOVE LOW-VALUES TO screen-filter-account
+        ELSE
+            MOVE CDEMO-ACCT-ID TO screen-filter-account
+        END-IF
+    END-IF
+```
+
+### Screen Layout — Card List (7 rows)
+
+| Column | Field | Width | Source |
+|--------|-------|-------|--------|
+| Account No | WS-ROW-ACCTNO | 11 chars | CARD-ACCT-ID from card record |
+| Card Number | WS-ROW-CARD-NUM | 16 chars | CARD-NUM from card record |
+| Status | WS-ROW-CARD-STATUS | 1 char | CARD-ACTIVE-STATUS from card record |
+
+### Zero-Value Suppression Rules
+
+| Context Field | Value | Display Behavior |
+|--------------|-------|-----------------|
+| CDEMO-ACCT-ID | Non-zero | Display account ID normally |
+| CDEMO-ACCT-ID | 0 | Suppress display (show LOW-VALUES/blank) |
+| CC-ACCT-ID | Spaces or zeros | Suppress filter display |
+| CARD-ACCT-ID | Any value | Always display (from card record) |
+
+## Source COBOL Reference
+
+**Programs:** `COCRDLIC.cbl`, `COCRDSLC.cbl`
+
+### COCRDLIC.cbl — Screen row data structure
+
+```cobol
+000256          05  WS-SCREEN-DATA OCCURS 7 TIMES.
+000258                     25 WS-ROW-ACCTNO           PIC X(11).
+000259                     25 WS-ROW-CARD-NUM         PIC X(16).
+000260                     25 WS-ROW-CARD-STATUS      PIC X(1).
+```
+*(Lines 256-260 — 7 rows, each with account number, card number, and status)*
+
+### COCRDLIC.cbl — Populating account in card list rows
+
+```cobol
+001167                      MOVE CARD-NUM     TO WS-ROW-CARD-NUM(
+001168                      WS-SCRN-COUNTER)
+001169                      MOVE CARD-ACCT-ID TO
+001170                      WS-ROW-ACCTNO(WS-SCRN-COUNTER)
+001171                      MOVE CARD-ACTIVE-STATUS
+001172                                        TO WS-ROW-CARD-STATUS(
+001173                                        WS-SCRN-COUNTER)
+001174
+001175                      IF WS-SCRN-COUNTER = 1
+001176                         MOVE CARD-ACCT-ID
+001177                                        TO WS-CA-FIRST-CARD-ACCT-ID
+001178                         MOVE CARD-NUM  TO WS-CA-FIRST-CARD-NUM
+```
+*(Lines 1167-1178 — card data including account ID mapped to screen rows)*
+
+### COCRDLIC.cbl — Account context display with zero suppression
+
+```cobol
+000847                   IF CC-ACCT-ID NOT = ZEROES
+000848                   AND CC-ACCT-ID NOT = SPACES
+000849                     MOVE CC-ACCT-ID   TO ACCTSIDO OF CCRDLIAO
+000850                   ELSE
+000851                  WHEN CDEMO-ACCT-ID = 0
+000852                     MOVE LOW-VALUES   TO ACCTSIDO OF CCRDLIAO
+```
+*(Lines 847-852 — account filter display with zero suppression)*
+
+### COCRDSLC.cbl — Account context on detail screen
+
+```cobol
+000462              IF CDEMO-ACCT-ID = 0
+000463                 MOVE LOW-VALUES   TO ACCTSIDO OF CCRDSLAO
+000464              ELSE
+000465                 MOVE CC-ACCT-ID   TO ACCTSIDO OF CCRDSLAO
+000466              END-IF
+```
+*(Lines 462-466 — account ID displayed on card detail search screen)*
+
+## Acceptance Criteria
+
+### Scenario 1: Card list displays account alongside each card
+
+```gherkin
+GIVEN the card list screen is loaded with cards from multiple accounts
+WHEN the list is displayed
+THEN each row shows the card number, account ID, and card status
+  AND up to 7 rows are displayed per page
+  AND the account ID is the 11-digit CARD-ACCT-ID from each card record
+```
+
+### Scenario 2: Zero account ID suppressed on search screen
+
+```gherkin
+GIVEN the card detail search screen is loaded
+  AND no account context is set (CDEMO-ACCT-ID = 0)
+WHEN the screen is rendered
+THEN the account ID field displays as blank (LOW-VALUES)
+  AND the user can enter an account ID to search
+```
+
+### Scenario 3: Account context preserved from filter
+
+```gherkin
+GIVEN the user has entered account filter "12345678901"
+  AND the card list is displaying filtered results
+WHEN the account context is displayed in the header
+THEN the account ID "12345678901" is shown in the filter field
+  AND only cards for that account are listed
+```
+
+### Scenario 4: Pagination preserves account keys
+
+```gherkin
+GIVEN the card list is displaying page 1
+WHEN the user navigates to page 2
+THEN the first and last card keys (including account IDs) from page 1 are used for navigation
+  AND the WS-CA-FIRST-CARD-ACCT-ID stores the first card's account
+  AND the WS-CA-LAST-CARD-ACCT-ID stores the last card's account
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 97 | Strong customer authentication before displaying payment account data | Account display is gated by CICS terminal authentication; the migrated system must enforce SCA before showing account/card data |
+| GDPR | Art. 15 | Right of access — data subjects can request access to their personal data | The card list with account filtering provides a mechanism for targeted data retrieval in response to GDPR access requests |
+| FSA FFFS 2014:5 | Ch. 7 | Information systems must provide accurate and timely data to authorized users | The screen presentation ensures accurate account-card relationships are displayed from the live VSAM files |
+
+## Edge Cases
+
+1. **No dedicated account screen**: The available COBOL source has no standalone account list or account detail screen. Account data is always shown in the card management context. The migrated system should consider whether a dedicated account management UI is needed.
+
+2. **Zero suppression inconsistency**: The card list and card detail screens use different logic for zero suppression. The list checks for ZEROES and SPACES separately (line 847), while the detail screen checks only for CDEMO-ACCT-ID = 0 (line 462). The migrated system should standardize the null/empty handling.
+
+3. **Account ID from card record vs context**: The card list populates WS-ROW-ACCTNO from `CARD-ACCT-ID` (the card record's embedded account), while the search screen uses `CC-ACCT-ID` from the COMMAREA context. If these diverge (e.g., after a card is reassigned to a different account), the display may be inconsistent.
+
+4. **7-row page limitation**: The card list displays only 7 rows per page. For accounts with many cards, users must paginate through multiple pages. The migrated system should support configurable page sizes.
+
+5. **Screen field as output map**: The `ACCTSIDO OF CCRDLIAO` references a BMS map field (CICS screen definition). In the migrated REST API, this becomes a JSON response field. The field name should be meaningful (e.g., `accountId`) rather than preserving the COBOL map name.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. Key questions: (1) Does the mainframe have a dedicated account management screen/program (e.g., COACCTLC for account list)? If so, the program name and function are needed for extraction. (2) Is there an account detail screen that shows full account information (balance, limits, status, expiration)? (3) Should the migrated system include a dedicated account management UI, or is account data always accessed through card operations? (4) Are there any account-level reports or screens for balance inquiry?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/account-management/index.md
+++ b/docs-site/docs/business-rules/account-management/index.md
@@ -5,16 +5,79 @@ sidebar_position: 1
 
 # Account Management Business Rules
 
-Business rules for account lifecycle, balance management, and account operations extracted from COBOL source programs.
+Business rules for account lifecycle, balance management, credit limit enforcement, account-card relationships, and account data presentation extracted from COBOL source programs in the AWS CardDemo application and related batch processing programs.
+
+## Source Programs
+
+| Program | Type | Function | Rules Extracted |
+|---------|------|----------|----------------|
+| `COCRDLIC.cbl` | CICS Online | Credit card list with account filtering and display | ACCT-BR-002, ACCT-BR-003, ACCT-BR-008 |
+| `COCRDSLC.cbl` | CICS Online | Card detail with account lookup via alternate index | ACCT-BR-002, ACCT-BR-003, ACCT-BR-008 |
+| `COCRDUPC.cbl` | CICS Online | Card update with account validation and status management | ACCT-BR-002, ACCT-BR-005, ACCT-BR-006 |
+| `CBTRN02C.cbl` | Batch | Daily transaction posting with balance updates and limit checks | ACCT-BR-004, ACCT-BR-006, ACCT-BR-007 |
+
+### Related Copybooks
+
+| Copybook | Purpose | Rules Extracted |
+|----------|---------|----------------|
+| `CVACT01Y.cpy` | Account master record layout (300-byte VSAM record, referenced but not in repository) | ACCT-BR-001 |
+| `CVACT02Y.cpy` | Card record layout — contains embedded account FK (CARD-ACCT-ID) | ACCT-BR-003 |
+| `CVACT03Y.cpy` | Card cross-reference — card-customer-account linkage | ACCT-BR-003 |
+| `CVCRD01Y.cpy` | Card work area — account ID input/output fields | ACCT-BR-002 |
+
+## Extracted Rules
+
+| Rule ID | Title | Priority | Source | Regulation |
+|---------|-------|----------|--------|------------|
+| [ACCT-BR-001](./acct-br-001) | Account record data structure and field definitions | Critical | CVACT01Y.cpy (reconstructed) | GDPR, FSA FFFS 2014:5, PSD2 |
+| [ACCT-BR-002](./acct-br-002) | Account ID input validation rules | High | COCRDLIC/COCRDSLC/COCRDUPC.cbl | FSA FFFS 2014:5, PSD2 |
+| [ACCT-BR-003](./acct-br-003) | Account-card relationship and cross-reference lookup | High | COCRDSLC.cbl, CVACT02Y/03Y.cpy | PSD2, GDPR, AML/KYC |
+| [ACCT-BR-004](./acct-br-004) | Account balance management and cycle tracking | Critical | CBTRN02C.cbl | FSA FFFS 2014:5, PSD2, DORA |
+| [ACCT-BR-005](./acct-br-005) | Account status transitions and lifecycle management | High | COCRDUPC.cbl, CBTRN02C.cbl | FSA FFFS 2014:5, PSD2, GDPR |
+| [ACCT-BR-006](./acct-br-006) | Account expiration date management and enforcement | High | CBTRN02C.cbl, COCRDUPC.cbl | FSA FFFS 2014:5, PSD2, GDPR |
+| [ACCT-BR-007](./acct-br-007) | Account credit limit enforcement | Critical | CBTRN02C.cbl | FSA FFFS 2014:5, PSD2, Consumer Credit Directive |
+| [ACCT-BR-008](./acct-br-008) | Account display and list screen presentation | Medium | COCRDLIC.cbl, COCRDSLC.cbl | PSD2, GDPR, FSA FFFS 2014:5 |
 
 ## Status
 
-No business rules have been extracted for this domain yet. Rules will be added as they are identified and validated by domain experts.
+All 8 business rules have been extracted from the COBOL source. All rules have `status: extracted` and are awaiting domain expert validation.
 
-## Expected Coverage
+**Note on COBOL source coverage**: The available COBOL source programs do not include dedicated account management programs (e.g., account opening, account closing, dormancy management, or standalone account inquiry). The rules extracted here represent account management logic embedded within card management and transaction processing programs. The CVACT01Y.cpy copybook (account master record layout) is referenced but not present in the repository — the record structure has been reconstructed from field references across multiple programs and the .NET domain model. The following areas require dedicated COBOL source programs to be obtained from the mainframe team:
 
-- Account opening and closing procedures
-- Balance enquiry and statement generation
-- Account status transitions (active, dormant, frozen, closed)
-- Interest calculation rules
-- Account holder management
+- **Account opening**: No account creation program found in available source
+- **Account closing**: No account closure or termination program found
+- **Dormancy management**: No dormancy detection or reactivation batch job found
+- **Standalone balance inquiry**: No dedicated balance inquiry screen found (balance shown only in transaction context)
+- **Interest calculation**: Account-level interest computation batch program not found (disclosure group structure exists in CVTRA02Y.cpy)
+- **Statement generation**: No statement generation or cycle-close program found
+- **Account holder management**: No customer-account relationship management program found
+
+## Regulatory Coverage
+
+| Regulation | Rules Covering |
+|------------|---------------|
+| PSD2 Art. 64 (Transaction Data Integrity) | ACCT-BR-001, ACCT-BR-004, ACCT-BR-007 |
+| PSD2 Art. 97 (Strong Customer Authentication) | ACCT-BR-002, ACCT-BR-005, ACCT-BR-008 |
+| GDPR Art. 5(1)(c) (Data Minimization) | ACCT-BR-001 |
+| GDPR Art. 5(1)(d) (Accuracy) | ACCT-BR-001 |
+| GDPR Art. 5(1)(e) (Storage Limitation) | ACCT-BR-006 |
+| GDPR Art. 15 (Right of Access) | ACCT-BR-003, ACCT-BR-008 |
+| GDPR Art. 17 (Right to Erasure) | ACCT-BR-005 |
+| FSA FFFS 2014:5 Ch. 3 (Accounting Records) | ACCT-BR-001, ACCT-BR-004 |
+| FSA FFFS 2014:5 Ch. 4 §3 (Operational Risk) | ACCT-BR-002, ACCT-BR-005, ACCT-BR-006 |
+| FSA FFFS 2014:5 Ch. 6 (Credit Risk Management) | ACCT-BR-007 |
+| FSA FFFS 2014:5 Ch. 7 (Financial Systems) | ACCT-BR-004, ACCT-BR-008 |
+| AML 2017:11 (Transaction Monitoring) | ACCT-BR-003 |
+| EU Consumer Credit Directive 2008/48/EC | ACCT-BR-007 |
+| DORA Art. 11 (ICT Risk Management) | ACCT-BR-004 |
+
+## Migration Considerations
+
+1. **CVACT01Y.cpy acquisition**: The account master record copybook must be obtained from the mainframe team. The reconstructed layout covers fields referenced in available programs, but additional fields (account opening date, last statement date, customer reference, account type/product code) likely exist in the filler area.
+2. **VSAM to SQL mapping**: The ACCTFILE KSDS record (300 bytes) should be mapped to a normalized Azure SQL table. The 11-digit ACCT-ID becomes a primary key. Financial fields must use `decimal(12,2)` — no floating-point types.
+3. **Account-card foreign key**: The `CARD-ACCT-ID` embedded in card records and the CARDAIX alternate index should be mapped to a proper SQL foreign key with referential integrity.
+4. **Status model extension**: The COBOL Y/N status model must be extended to support dormant, frozen, and closed states as required by Swedish banking regulations. A state machine with transition rules and audit logging should be implemented.
+5. **Credit limit enforcement**: Currently batch-only in COBOL. The migrated system should consider real-time credit limit checking for online transactions, with appropriate concurrency controls.
+6. **Dedicated account UI**: The COBOL system has no standalone account management screens. The migrated system should implement dedicated account management API endpoints and UI for account lifecycle operations.
+7. **Character encoding**: EBCDIC to UTF-8 conversion for all text fields. Account IDs are numeric-only, but error messages and descriptions need encoding conversion.
+8. **Billing cycle integration**: Account balance management (ACCT-BR-004) is tightly coupled with billing cycle tracking. The cycle reset mechanism must be identified from the mainframe before implementing balance management.


### PR DESCRIPTION
## Summary
- Extracted 8 detailed Account Management business rules from COBOL source programs
- Each BR file follows the established template with pseudocode, decision tables, COBOL source references, Gherkin acceptance criteria, regulatory mapping, and edge cases
- Updated the Account Management index.md with rules table, regulatory coverage matrix, and migration considerations

## Changes
- **New files**: `acct-br-001.md` through `acct-br-008.md` (8 business rule documents)
- **Updated**: `docs-site/docs/business-rules/account-management/index.md` (from placeholder to complete index)

## Business Rules Extracted
| Rule ID | Title | Priority |
|---------|-------|----------|
| ACCT-BR-001 | Account record data structure and field definitions | Critical |
| ACCT-BR-002 | Account ID input validation rules | High |
| ACCT-BR-003 | Account-card relationship and cross-reference lookup | High |
| ACCT-BR-004 | Account balance management and cycle tracking | Critical |
| ACCT-BR-005 | Account status transitions and lifecycle management | High |
| ACCT-BR-006 | Account expiration date management and enforcement | High |
| ACCT-BR-007 | Account credit limit enforcement | Critical |
| ACCT-BR-008 | Account display and list screen presentation | Medium |

## Key Findings
- The CVACT01Y.cpy copybook (account master record) is referenced but not present in the repository — the record structure was reconstructed from field references across multiple programs and the .NET domain model
- Account management logic is embedded within card management (COCRDLIC, COCRDSLC, COCRDUPC) and transaction processing (CBTRN02C) programs — no standalone account programs exist in available source
- Several areas require mainframe team input: account opening/closing programs, dormancy management, statement generation, interest calculation

## Testing
- [x] Build passes with zero warnings (`dotnet build /warnaserror`)
- [x] All 393 tests pass (`dotnet test`)
- [x] Format check passes (`dotnet format --verify-no-changes`)
- [x] Documentation only — no code changes

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)