### PR TITLE
feat(#78): Add daily transaction detail report function (TRN-BR-009)

### DIFF
--- a/src/NordKredit.Domain/Transactions/ITransactionCategoryRepository.cs
+++ b/src/NordKredit.Domain/Transactions/ITransactionCategoryRepository.cs
@@ -1,0 +1,11 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Repository for transaction category lookups.
+/// COBOL source: CVTRA04Y.cpy (TRAN-CAT-RECORD), VSAM TRANCATG file.
+/// Used by CBTRN03C for report enrichment — type+category code to description mapping.
+/// </summary>
+public interface ITransactionCategoryRepository
+{
+    Task<TransactionCategory?> GetAsync(string typeCode, int categoryCode, CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/Transactions/ITransactionRepository.cs
+++ b/src/NordKredit.Domain/Transactions/ITransactionRepository.cs
@@ -30,4 +30,14 @@ public interface ITransactionRepository
     /// COBOL: COTRN02C.cbl — COPY-LAST-TRAN-DATA (PF5 handler).
     /// </summary>
     Task<Transaction?> GetLastTransactionAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves transactions within a processing timestamp date range, ordered by CardNumber then Id.
+    /// COBOL: CBTRN03C.cbl:159-373 — report generation reads TRANSACT sequentially.
+    /// The sort order matches the COBOL assumption that the file is sorted by card number.
+    /// </summary>
+    Task<IReadOnlyList<Transaction>> GetByDateRangeAsync(
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken = default);
 }

--- a/src/NordKredit.Domain/Transactions/ITransactionTypeRepository.cs
+++ b/src/NordKredit.Domain/Transactions/ITransactionTypeRepository.cs
@@ -1,0 +1,11 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Repository for transaction type lookups.
+/// COBOL source: CVTRA03Y.cpy (TRAN-TYPE-RECORD), VSAM TRANTYPE file.
+/// Used by CBTRN03C for report enrichment — type code to description mapping.
+/// </summary>
+public interface ITransactionTypeRepository
+{
+    Task<TransactionType?> GetByCodeAsync(string typeCode, CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/Transactions/TransactionCategory.cs
+++ b/src/NordKredit.Domain/Transactions/TransactionCategory.cs
@@ -1,0 +1,19 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Transaction category lookup record.
+/// COBOL source: CVTRA04Y.cpy (TRAN-CAT-RECORD), VSAM TRANCATG file.
+/// Maps type+category composite key to human-readable descriptions for report enrichment.
+/// Regulations: FSA FFFS 2014:5 Ch.7 (financial reporting), PSD2 Art.94 (accessibility).
+/// </summary>
+public class TransactionCategory
+{
+    /// <summary>Transaction type code. COBOL: TRAN-TYPE PIC X(02).</summary>
+    public string TypeCode { get; set; } = string.Empty;
+
+    /// <summary>Category code. COBOL: TRAN-CAT-CD PIC 9(04).</summary>
+    public int CategoryCode { get; set; }
+
+    /// <summary>Category description. COBOL: TRAN-CAT-DESC PIC X(50).</summary>
+    public string Description { get; set; } = string.Empty;
+}

--- a/src/NordKredit.Domain/Transactions/TransactionDetailReportService.cs
+++ b/src/NordKredit.Domain/Transactions/TransactionDetailReportService.cs
@@ -1,0 +1,233 @@
+using Microsoft.Extensions.Logging;
+
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Generates the daily transaction detail report — replaces CBTRN03C.cbl:159-373.
+/// Reads posted transactions for a date range, enriches with type/category descriptions
+/// from lookup tables, groups by card number, and produces page totals (every N lines),
+/// account totals (on card change), and a grand total.
+/// COBOL source: CBTRN03C.cbl:159-373 (report generation).
+/// Regulations: FFFS 2014:5 Ch.7 (financial reporting), PSD2 Art.94 (accessibility),
+/// AML 2017:11 Para.3 (monitoring).
+/// </summary>
+public partial class TransactionDetailReportService
+{
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly ICardCrossReferenceRepository _xrefRepository;
+    private readonly ITransactionTypeRepository _typeRepository;
+    private readonly ITransactionCategoryRepository _categoryRepository;
+    private readonly ILogger<TransactionDetailReportService> _logger;
+
+    public TransactionDetailReportService(
+        ITransactionRepository transactionRepository,
+        ICardCrossReferenceRepository xrefRepository,
+        ITransactionTypeRepository typeRepository,
+        ITransactionCategoryRepository categoryRepository,
+        ILogger<TransactionDetailReportService> logger)
+    {
+        _transactionRepository = transactionRepository;
+        _xrefRepository = xrefRepository;
+        _typeRepository = typeRepository;
+        _categoryRepository = categoryRepository;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Generates the daily transaction detail report for the specified date range.
+    /// COBOL: CBTRN03C.cbl main loop (lines 159-373).
+    /// </summary>
+    /// <param name="startDate">Start of date range (inclusive).</param>
+    /// <param name="endDate">End of date range (inclusive).</param>
+    /// <param name="pageSize">Lines per page before page total (default 20, per COBOL WS-PAGE-SIZE).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task<TransactionReportResult> GenerateReportAsync(
+        DateTime startDate,
+        DateTime endDate,
+        int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        LogReportStart(_logger, startDate, endDate, pageSize);
+
+        var transactions = await _transactionRepository
+            .GetByDateRangeAsync(startDate, endDate, cancellationToken);
+
+        if (transactions.Count == 0)
+        {
+            LogReportEmpty(_logger);
+            return new TransactionReportResult
+            {
+                TotalTransactions = 0,
+                DetailLineCount = 0,
+                PageCount = 0,
+                AccountGroupCount = 0,
+                GrandTotal = 0.00m,
+                Lines = [],
+                PageTotals = [],
+                AccountTotals = []
+            };
+        }
+
+        var lines = new List<TransactionReportLine>();
+        var pageTotals = new List<decimal>();
+        var accountTotals = new List<AccountTotal>();
+
+        var pageLineCount = 0;
+        var pageTotal = 0.00m;
+        var accountTotal = 0.00m;
+        var grandTotal = 0.00m;
+        string? currentCardNumber = null;
+        string? currentAccountId = null;
+        var accountGroupCount = 0;
+
+        foreach (var transaction in transactions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Detect card number change — write account total for previous group
+            // COBOL: CBTRN03C.cbl:158-217 — card change detection
+            if (currentCardNumber is not null && transaction.CardNumber != currentCardNumber)
+            {
+                accountTotals.Add(new AccountTotal
+                {
+                    CardNumber = currentCardNumber,
+                    AccountId = currentAccountId!,
+                    Total = accountTotal
+                });
+                accountTotal = 0.00m;
+            }
+
+            // Detect page boundary — write page total when page is full
+            // COBOL: CBTRN03C.cbl:274-290 — page size check
+            if (pageLineCount >= pageSize && pageSize > 0)
+            {
+                pageTotals.Add(pageTotal);
+                pageTotal = 0.00m;
+                pageLineCount = 0;
+            }
+
+            // Track card number change
+            if (currentCardNumber != transaction.CardNumber)
+            {
+                currentCardNumber = transaction.CardNumber;
+                accountGroupCount++;
+            }
+
+            // Lookup card cross-reference — ABEND on failure
+            // COBOL: CBTRN03C.cbl AF-1
+            var xref = await _xrefRepository
+                .GetByCardNumberAsync(transaction.CardNumber, cancellationToken);
+            if (xref is null)
+            {
+                LogXrefLookupFailure(_logger, transaction.CardNumber, transaction.Id);
+                throw new InvalidOperationException(
+                    $"Card cross-reference not found for card {transaction.CardNumber} " +
+                    $"(transaction {transaction.Id}). ABEND — data integrity issue.");
+            }
+
+            currentAccountId = xref.AccountId;
+
+            // Lookup type description — ABEND on failure
+            // COBOL: CBTRN03C.cbl AF-2
+            var transactionType = await _typeRepository
+                .GetByCodeAsync(transaction.TypeCode, cancellationToken);
+            if (transactionType is null)
+            {
+                LogTypeLookupFailure(_logger, transaction.TypeCode, transaction.Id);
+                throw new InvalidOperationException(
+                    $"Transaction type '{transaction.TypeCode}' not found " +
+                    $"(transaction {transaction.Id}). ABEND — data integrity issue.");
+            }
+
+            // Lookup category description — ABEND on failure
+            // COBOL: CBTRN03C.cbl AF-3
+            var category = await _categoryRepository
+                .GetAsync(transaction.TypeCode, transaction.CategoryCode, cancellationToken);
+            if (category is null)
+            {
+                LogCategoryLookupFailure(_logger, transaction.TypeCode,
+                    transaction.CategoryCode, transaction.Id);
+                throw new InvalidOperationException(
+                    $"Transaction category '{transaction.TypeCode}'+'{transaction.CategoryCode}' not found " +
+                    $"(transaction {transaction.Id}). ABEND — data integrity issue.");
+            }
+
+            // Build enriched report line
+            // COBOL: CBTRN03C.cbl:361-370 — TRANSACTION-DETAIL-REPORT
+            var line = new TransactionReportLine
+            {
+                TransactionId = transaction.Id,
+                AccountId = xref.AccountId,
+                TypeDescription = $"{transaction.TypeCode}-{transactionType.Description}",
+                CategoryDescription = $"{transaction.CategoryCode:D4}-{category.Description}",
+                Source = transaction.Source,
+                Amount = transaction.Amount,
+                CardNumber = transaction.CardNumber
+            };
+
+            lines.Add(line);
+
+            // Accumulate totals
+            // COBOL: CBTRN03C.cbl:287-289 — ADD TRAN-AMT TO WS-PAGE-TOTAL, WS-ACCOUNT-TOTAL
+            pageTotal += transaction.Amount;
+            accountTotal += transaction.Amount;
+            grandTotal += transaction.Amount;
+            pageLineCount++;
+        }
+
+        // Write final page total
+        pageTotals.Add(pageTotal);
+
+        // Write final account total (COBOL edge case: card-change detection doesn't fire at EOF)
+        if (currentCardNumber is not null)
+        {
+            accountTotals.Add(new AccountTotal
+            {
+                CardNumber = currentCardNumber,
+                AccountId = currentAccountId!,
+                Total = accountTotal
+            });
+        }
+
+        LogReportComplete(_logger, transactions.Count, lines.Count,
+            pageTotals.Count, accountGroupCount, grandTotal);
+
+        return new TransactionReportResult
+        {
+            TotalTransactions = transactions.Count,
+            DetailLineCount = lines.Count,
+            PageCount = pageTotals.Count,
+            AccountGroupCount = accountGroupCount,
+            GrandTotal = grandTotal,
+            Lines = lines,
+            PageTotals = pageTotals,
+            AccountTotals = accountTotals
+        };
+    }
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Start of daily transaction report generation (replaces CBTRN03C). Date range: {StartDate:yyyy-MM-dd} to {EndDate:yyyy-MM-dd}, page size: {PageSize}")]
+    private static partial void LogReportStart(ILogger logger, DateTime startDate, DateTime endDate, int pageSize);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "No transactions found in date range. Report will contain headers and zero grand total")]
+    private static partial void LogReportEmpty(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Daily transaction report complete. Transactions: {TransactionCount}, Lines: {LineCount}, Pages: {PageCount}, Account groups: {AccountGroupCount}, Grand total: {GrandTotal}")]
+    private static partial void LogReportComplete(ILogger logger, int transactionCount, int lineCount, int pageCount, int accountGroupCount, decimal grandTotal);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Card cross-reference lookup failed for card {CardNumber} (transaction {TransactionId}). ABEND")]
+    private static partial void LogXrefLookupFailure(ILogger logger, string cardNumber, string transactionId);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Transaction type lookup failed for type code '{TypeCode}' (transaction {TransactionId}). ABEND")]
+    private static partial void LogTypeLookupFailure(ILogger logger, string typeCode, string transactionId);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Transaction category lookup failed for type '{TypeCode}' category '{CategoryCode}' (transaction {TransactionId}). ABEND")]
+    private static partial void LogCategoryLookupFailure(ILogger logger, string typeCode, int categoryCode, string transactionId);
+}

--- a/src/NordKredit.Domain/Transactions/TransactionReportLine.cs
+++ b/src/NordKredit.Domain/Transactions/TransactionReportLine.cs
@@ -1,0 +1,31 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// A single detail line in the daily transaction report.
+/// COBOL source: CBTRN03C.cbl:361-370 — TRANSACTION-DETAIL-REPORT layout.
+/// Enriched with type/category descriptions from lookup tables.
+/// Regulations: FSA FFFS 2014:5 Ch.7 (financial reporting), PSD2 Art.94 (accessibility).
+/// </summary>
+public class TransactionReportLine
+{
+    /// <summary>Transaction ID. COBOL: TRAN-ID PIC X(16).</summary>
+    public required string TransactionId { get; init; }
+
+    /// <summary>Account ID resolved from CARDXREF. COBOL: XREF-ACCT-ID PIC 9(11).</summary>
+    public required string AccountId { get; init; }
+
+    /// <summary>Formatted type: "code-description". E.g., "01-Purchase".</summary>
+    public required string TypeDescription { get; init; }
+
+    /// <summary>Formatted category: "code-description". E.g., "0001-Groceries".</summary>
+    public required string CategoryDescription { get; init; }
+
+    /// <summary>Transaction source. COBOL: TRAN-SOURCE PIC X(10).</summary>
+    public required string Source { get; init; }
+
+    /// <summary>Transaction amount. COBOL: TRAN-AMT PIC S9(09)V99.</summary>
+    public required decimal Amount { get; init; }
+
+    /// <summary>Card number for grouping. COBOL: TRAN-CARD-NUM PIC X(16).</summary>
+    public required string CardNumber { get; init; }
+}

--- a/src/NordKredit.Domain/Transactions/TransactionReportResult.cs
+++ b/src/NordKredit.Domain/Transactions/TransactionReportResult.cs
@@ -1,0 +1,49 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Result of the daily transaction detail report generation.
+/// COBOL source: CBTRN03C.cbl:159-373 — report output summary.
+/// Contains the enriched report lines plus aggregate totals for validation.
+/// Regulations: FSA FFFS 2014:5 Ch.7 (financial reporting), AML 2017:11 Para.3 (monitoring).
+/// </summary>
+public class TransactionReportResult
+{
+    /// <summary>Total number of transactions within the date range.</summary>
+    public required int TotalTransactions { get; init; }
+
+    /// <summary>Number of detail lines written to the report.</summary>
+    public required int DetailLineCount { get; init; }
+
+    /// <summary>Number of page breaks in the report.</summary>
+    public required int PageCount { get; init; }
+
+    /// <summary>Number of distinct card/account groups.</summary>
+    public required int AccountGroupCount { get; init; }
+
+    /// <summary>Grand total of all transaction amounts. COBOL: WS-GRAND-TOTAL PIC S9(09)V99.</summary>
+    public required decimal GrandTotal { get; init; }
+
+    /// <summary>Enriched report lines for structured output (JSON/CSV).</summary>
+    public required IReadOnlyList<TransactionReportLine> Lines { get; init; }
+
+    /// <summary>Page totals in order of occurrence for validation.</summary>
+    public required IReadOnlyList<decimal> PageTotals { get; init; }
+
+    /// <summary>Account totals in order of occurrence (keyed by card number) for validation.</summary>
+    public required IReadOnlyList<AccountTotal> AccountTotals { get; init; }
+}
+
+/// <summary>
+/// Account-level total for report validation.
+/// </summary>
+public class AccountTotal
+{
+    /// <summary>Card number for this account group.</summary>
+    public required string CardNumber { get; init; }
+
+    /// <summary>Account ID resolved from CARDXREF.</summary>
+    public required string AccountId { get; init; }
+
+    /// <summary>Sum of transaction amounts for this account group.</summary>
+    public required decimal Total { get; init; }
+}

--- a/src/NordKredit.Domain/Transactions/TransactionType.cs
+++ b/src/NordKredit.Domain/Transactions/TransactionType.cs
@@ -1,0 +1,16 @@
+namespace NordKredit.Domain.Transactions;
+
+/// <summary>
+/// Transaction type lookup record.
+/// COBOL source: CVTRA03Y.cpy (TRAN-TYPE-RECORD), VSAM TRANTYPE file.
+/// Maps type codes to human-readable descriptions for report enrichment.
+/// Regulations: FSA FFFS 2014:5 Ch.7 (financial reporting), PSD2 Art.94 (accessibility).
+/// </summary>
+public class TransactionType
+{
+    /// <summary>Transaction type code. COBOL: TRAN-TYPE PIC X(02).</summary>
+    public string TypeCode { get; set; } = string.Empty;
+
+    /// <summary>Transaction type description. COBOL: TRAN-TYPE-DESC PIC X(50).</summary>
+    public string Description { get; set; } = string.Empty;
+}

--- a/src/NordKredit.Functions/Batch/TransactionReportFunction.cs
+++ b/src/NordKredit.Functions/Batch/TransactionReportFunction.cs
@@ -1,0 +1,66 @@
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.Functions.Batch;
+
+/// <summary>
+/// Batch transaction report function — replaces CBTRN03C.cbl:159-373.
+/// Activity function for the daily batch pipeline (step 3 after transaction posting).
+/// Generates a detailed transaction report for a configurable date range with
+/// type/category description lookups, page totals, account totals, and grand total.
+/// COBOL source: CBTRN03C.cbl:159-373 (report generation).
+/// Regulations: FFFS 2014:5 Ch.7 (financial reporting), PSD2 Art.94 (accessibility),
+/// AML 2017:11 Para.3 (monitoring).
+/// </summary>
+public partial class TransactionReportFunction
+{
+    private readonly TransactionDetailReportService _reportService;
+    private readonly ILogger<TransactionReportFunction> _logger;
+
+    public TransactionReportFunction(
+        TransactionDetailReportService reportService,
+        ILogger<TransactionReportFunction> logger)
+    {
+        _reportService = reportService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Executes the daily transaction report generation.
+    /// COBOL: CBTRN03C.cbl main program (lines 159-373).
+    /// Replaces COBOL DISPLAY with structured logging to Application Insights.
+    /// Throws on lookup failures (replaces COBOL ABEND 999).
+    /// </summary>
+    public async Task<TransactionReportFunctionResult> RunAsync(
+        DateTime startDate,
+        DateTime endDate,
+        int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        // COBOL: DISPLAY 'START OF EXECUTION OF PROGRAM CBTRN03C'
+        LogBatchStarted(_logger, startDate, endDate);
+
+        var serviceResult = await _reportService
+            .GenerateReportAsync(startDate, endDate, pageSize, cancellationToken);
+
+        // COBOL: DISPLAY 'END OF EXECUTION OF PROGRAM CBTRN03C'
+        LogBatchCompleted(_logger, serviceResult.TotalTransactions,
+            serviceResult.PageCount, serviceResult.AccountGroupCount, serviceResult.GrandTotal);
+
+        return new TransactionReportFunctionResult
+        {
+            TotalTransactions = serviceResult.TotalTransactions,
+            DetailLineCount = serviceResult.DetailLineCount,
+            PageCount = serviceResult.PageCount,
+            AccountGroupCount = serviceResult.AccountGroupCount,
+            GrandTotal = serviceResult.GrandTotal
+        };
+    }
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Start of execution of TransactionReportFunction (replaces CBTRN03C). Date range: {StartDate:yyyy-MM-dd} to {EndDate:yyyy-MM-dd}")]
+    private static partial void LogBatchStarted(ILogger logger, DateTime startDate, DateTime endDate);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "End of execution of TransactionReportFunction. Transactions: {TransactionCount}, Pages: {PageCount}, AccountGroups: {AccountGroupCount}, GrandTotal: {GrandTotal}")]
+    private static partial void LogBatchCompleted(ILogger logger, int transactionCount, int pageCount, int accountGroupCount, decimal grandTotal);
+}

--- a/src/NordKredit.Functions/Batch/TransactionReportFunctionResult.cs
+++ b/src/NordKredit.Functions/Batch/TransactionReportFunctionResult.cs
@@ -1,0 +1,26 @@
+namespace NordKredit.Functions.Batch;
+
+/// <summary>
+/// Result of the daily batch transaction report function.
+/// COBOL source: CBTRN03C.cbl:159-373 — output summary of the report run.
+/// Contains aggregate counts for monitoring and alerting.
+/// Regulations: FFFS 2014:5 Ch.7 (financial reporting), PSD2 Art.94 (accessibility),
+/// AML 2017:11 Para.3 (monitoring).
+/// </summary>
+public class TransactionReportFunctionResult
+{
+    /// <summary>Total number of transactions within the date range.</summary>
+    public required int TotalTransactions { get; init; }
+
+    /// <summary>Number of detail lines in the report.</summary>
+    public required int DetailLineCount { get; init; }
+
+    /// <summary>Number of pages in the report.</summary>
+    public required int PageCount { get; init; }
+
+    /// <summary>Number of distinct card/account groups.</summary>
+    public required int AccountGroupCount { get; init; }
+
+    /// <summary>Grand total of all transaction amounts. COBOL: WS-GRAND-TOTAL PIC S9(09)V99.</summary>
+    public required decimal GrandTotal { get; init; }
+}

--- a/src/NordKredit.Functions/Program.cs
+++ b/src/NordKredit.Functions/Program.cs
@@ -23,6 +23,10 @@ builder.Services.AddScoped<ITransactionCategoryBalanceRepository, SqlTransaction
 builder.Services.AddScoped<IUnitOfWork, SqlUnitOfWork>();
 builder.Services.AddScoped<TransactionPostingService>();
 builder.Services.AddScoped<TransactionPostingFunction>();
+builder.Services.AddScoped<ITransactionTypeRepository, SqlTransactionTypeRepository>();
+builder.Services.AddScoped<ITransactionCategoryRepository, SqlTransactionCategoryRepository>();
+builder.Services.AddScoped<TransactionDetailReportService>();
+builder.Services.AddScoped<TransactionReportFunction>();
 
 builder.Services.AddHostedService<Worker>();
 

--- a/src/NordKredit.Infrastructure/NordKreditDbContext.cs
+++ b/src/NordKredit.Infrastructure/NordKreditDbContext.cs
@@ -23,6 +23,8 @@ public class NordKreditDbContext : DbContext
     public DbSet<TransactionCardCrossReference> CardCrossReferences => Set<TransactionCardCrossReference>();
     public DbSet<Account> Accounts => Set<Account>();
     public DbSet<DailyReject> DailyRejects => Set<DailyReject>();
+    public DbSet<TransactionType> TransactionTypes => Set<TransactionType>();
+    public DbSet<TransactionCategory> TransactionCategories => Set<TransactionCategory>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -35,6 +37,8 @@ public class NordKreditDbContext : DbContext
         ConfigureCardCrossReference(modelBuilder);
         ConfigureAccount(modelBuilder);
         ConfigureDailyReject(modelBuilder);
+        ConfigureTransactionType(modelBuilder);
+        ConfigureTransactionCategory(modelBuilder);
     }
 
     /// <summary>
@@ -184,6 +188,39 @@ public class NordKreditDbContext : DbContext
             entity.Property(e => e.RejectReason).HasMaxLength(100).IsRequired();
             entity.Property(e => e.TransactionAmount).HasColumnType("decimal(11,2)").IsRequired();
             entity.Property(e => e.RejectedAt).IsRequired();
+        });
+    }
+
+    /// <summary>
+    /// Transaction type lookup mapping. COBOL source: CVTRA03Y.cpy (TRAN-TYPE-RECORD).
+    /// VSAM TRANTYPE (primary key = TRAN-TYPE PIC X(02)).
+    /// </summary>
+    private static void ConfigureTransactionType(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TransactionType>(entity =>
+        {
+            entity.ToTable("TransactionTypes");
+            entity.HasKey(e => e.TypeCode);
+
+            entity.Property(e => e.TypeCode).HasMaxLength(2).IsRequired();
+            entity.Property(e => e.Description).HasMaxLength(50).IsRequired();
+        });
+    }
+
+    /// <summary>
+    /// Transaction category lookup mapping. COBOL source: CVTRA04Y.cpy (TRAN-CAT-RECORD).
+    /// VSAM TRANCATG (composite key = TRAN-TYPE PIC X(02) + TRAN-CAT-CD PIC 9(04)).
+    /// </summary>
+    private static void ConfigureTransactionCategory(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TransactionCategory>(entity =>
+        {
+            entity.ToTable("TransactionCategories");
+            entity.HasKey(e => new { e.TypeCode, e.CategoryCode });
+
+            entity.Property(e => e.TypeCode).HasMaxLength(2).IsRequired();
+            entity.Property(e => e.CategoryCode).IsRequired();
+            entity.Property(e => e.Description).HasMaxLength(50).IsRequired();
         });
     }
 }

--- a/src/NordKredit.Infrastructure/Transactions/SqlTransactionCategoryRepository.cs
+++ b/src/NordKredit.Infrastructure/Transactions/SqlTransactionCategoryRepository.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.Infrastructure.Transactions;
+
+/// <summary>
+/// Azure SQL implementation of <see cref="ITransactionCategoryRepository"/>.
+/// Replaces VSAM TRANCATG indexed file random-read operations.
+/// COBOL source: CVTRA04Y.cpy (TRAN-CAT-RECORD).
+/// </summary>
+public class SqlTransactionCategoryRepository : ITransactionCategoryRepository
+{
+    private readonly NordKreditDbContext _dbContext;
+
+    public SqlTransactionCategoryRepository(NordKreditDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<TransactionCategory?> GetAsync(
+        string typeCode, int categoryCode, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.TransactionCategories
+            .FirstOrDefaultAsync(c => c.TypeCode == typeCode && c.CategoryCode == categoryCode,
+                cancellationToken);
+    }
+}

--- a/src/NordKredit.Infrastructure/Transactions/SqlTransactionRepository.cs
+++ b/src/NordKredit.Infrastructure/Transactions/SqlTransactionRepository.cs
@@ -80,4 +80,21 @@ public class SqlTransactionRepository : ITransactionRepository
             .OrderByDescending(t => t.Id)
             .FirstOrDefaultAsync(cancellationToken);
     }
+
+    /// <summary>
+    /// Retrieves transactions within a processing timestamp date range, ordered by CardNumber then Id.
+    /// COBOL: CBTRN03C.cbl:159-373 — report generation reads TRANSACT sequentially.
+    /// </summary>
+    public async Task<IReadOnlyList<Transaction>> GetByDateRangeAsync(
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Transactions
+            .Where(t => t.ProcessingTimestamp.Date >= startDate.Date
+                     && t.ProcessingTimestamp.Date <= endDate.Date)
+            .OrderBy(t => t.CardNumber)
+            .ThenBy(t => t.Id)
+            .ToListAsync(cancellationToken);
+    }
 }

--- a/src/NordKredit.Infrastructure/Transactions/SqlTransactionTypeRepository.cs
+++ b/src/NordKredit.Infrastructure/Transactions/SqlTransactionTypeRepository.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.Infrastructure.Transactions;
+
+/// <summary>
+/// Azure SQL implementation of <see cref="ITransactionTypeRepository"/>.
+/// Replaces VSAM TRANTYPE indexed file random-read operations.
+/// COBOL source: CVTRA03Y.cpy (TRAN-TYPE-RECORD).
+/// </summary>
+public class SqlTransactionTypeRepository : ITransactionTypeRepository
+{
+    private readonly NordKreditDbContext _dbContext;
+
+    public SqlTransactionTypeRepository(NordKreditDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<TransactionType?> GetByCodeAsync(string typeCode, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.TransactionTypes
+            .FirstOrDefaultAsync(t => t.TypeCode == typeCode, cancellationToken);
+    }
+}

--- a/tests/NordKredit.UnitTests/Batch/TransactionReportFunctionTests.cs
+++ b/tests/NordKredit.UnitTests/Batch/TransactionReportFunctionTests.cs
@@ -1,0 +1,184 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NordKredit.Domain.Transactions;
+using NordKredit.Functions.Batch;
+
+namespace NordKredit.UnitTests.Batch;
+
+/// <summary>
+/// Unit tests for TransactionReportFunction — daily transaction report batch function.
+/// COBOL source: CBTRN03C.cbl:159-373 (report generation).
+/// Verifies the function delegates to TransactionDetailReportService and maps results.
+/// Regulations: FFFS 2014:5 Ch.7 (financial reporting), PSD2 Art.94 (accessibility),
+/// AML 2017:11 Para.3 (monitoring).
+/// </summary>
+public class TransactionReportFunctionTests
+{
+    private readonly StubTransactionRepositoryForReportFunction _transactionRepo = new();
+    private readonly StubCardXrefRepoForReportFunction _xrefRepo = new();
+    private readonly StubTypeRepoForReportFunction _typeRepo = new();
+    private readonly StubCategoryRepoForReportFunction _categoryRepo = new();
+    private readonly ILogger<TransactionDetailReportService> _serviceLogger =
+        NullLogger<TransactionDetailReportService>.Instance;
+    private readonly ILogger<TransactionReportFunction> _functionLogger =
+        NullLogger<TransactionReportFunction>.Instance;
+    private readonly TransactionReportFunction _sut;
+
+    public TransactionReportFunctionTests()
+    {
+        var service = new TransactionDetailReportService(
+            _transactionRepo, _xrefRepo, _typeRepo, _categoryRepo, _serviceLogger);
+        _sut = new TransactionReportFunction(service, _functionLogger);
+    }
+
+    [Fact]
+    public async Task RunAsync_DelegatesToServiceAndReturnsResult()
+    {
+        _typeRepo.Add("01", "Purchase");
+        _categoryRepo.Add("01", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        _transactionRepo.Add(new Transaction
+        {
+            Id = "TXN001",
+            CardNumber = "4000000000000001",
+            TypeCode = "01",
+            CategoryCode = 1,
+            Source = "BATCH",
+            Description = "Test",
+            Amount = 500.00m,
+            MerchantId = 1,
+            MerchantName = "Test",
+            MerchantCity = "Stockholm",
+            MerchantZip = "11122",
+            OriginationTimestamp = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            ProcessingTimestamp = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc)
+        });
+
+        var result = await _sut.RunAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(1, result.TotalTransactions);
+        Assert.Equal(1, result.DetailLineCount);
+        Assert.Equal(500.00m, result.GrandTotal);
+    }
+
+    [Fact]
+    public async Task RunAsync_EmptyDateRange_ReturnsZero()
+    {
+        var result = await _sut.RunAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(0, result.TotalTransactions);
+        Assert.Equal(0.00m, result.GrandTotal);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReportResult_HasErrorsOnLookupFailure()
+    {
+        // No type lookup set up — will cause ABEND
+        _xrefRepo.Add("4000000000000001", "00000000001");
+        _transactionRepo.Add(new Transaction
+        {
+            Id = "TXN001",
+            CardNumber = "4000000000000001",
+            TypeCode = "99",
+            CategoryCode = 1,
+            Source = "BATCH",
+            Description = "Test",
+            Amount = 100.00m,
+            MerchantId = 1,
+            MerchantName = "Test",
+            MerchantCity = "Stockholm",
+            MerchantZip = "11122",
+            OriginationTimestamp = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            ProcessingTimestamp = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc)
+        });
+
+        // ABEND behavior — the exception should propagate
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.RunAsync(new DateTime(2026, 1, 1), new DateTime(2026, 1, 31)));
+    }
+}
+
+// ===================================================================
+// Test doubles for function tests
+// ===================================================================
+
+internal sealed class StubTransactionRepositoryForReportFunction : ITransactionRepository
+{
+    private readonly List<Transaction> _transactions = [];
+
+    public void Add(Transaction transaction) => _transactions.Add(transaction);
+
+    public Task<Transaction?> GetByIdAsync(string transactionId, CancellationToken cancellationToken = default)
+        => Task.FromResult(_transactions.FirstOrDefault(t => t.Id == transactionId));
+
+    public Task<IReadOnlyList<Transaction>> GetByAccountIdAsync(
+        string accountId, int pageSize, string? startAfterTransactionId = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<Transaction>>([]);
+
+    public Task AddAsync(Transaction transaction, CancellationToken cancellationToken = default)
+    {
+        _transactions.Add(transaction);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<Transaction>> GetPageAsync(
+        int pageSize, string? startAfterTransactionId = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<Transaction>>([]);
+
+    public Task<Transaction?> GetLastTransactionAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<Transaction?>(null);
+
+    public Task<IReadOnlyList<Transaction>> GetByDateRangeAsync(
+        DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<Transaction> result = [.. _transactions
+            .Where(t => t.ProcessingTimestamp.Date >= startDate.Date
+                     && t.ProcessingTimestamp.Date <= endDate.Date)
+            .OrderBy(t => t.CardNumber)
+            .ThenBy(t => t.Id)];
+        return Task.FromResult(result);
+    }
+}
+
+internal sealed class StubCardXrefRepoForReportFunction : ICardCrossReferenceRepository
+{
+    private readonly Dictionary<string, CardCrossReference> _xrefs = [];
+
+    public void Add(string cardNumber, string accountId)
+        => _xrefs[cardNumber] = new CardCrossReference
+        { CardNumber = cardNumber, AccountId = accountId, CustomerId = 100000001 };
+
+    public Task<CardCrossReference?> GetByCardNumberAsync(string cardNumber, CancellationToken cancellationToken = default)
+        => Task.FromResult(_xrefs.GetValueOrDefault(cardNumber));
+
+    public Task<CardCrossReference?> GetByAccountIdAsync(string accountId, CancellationToken cancellationToken = default)
+        => Task.FromResult(_xrefs.Values.FirstOrDefault(x => x.AccountId == accountId));
+}
+
+internal sealed class StubTypeRepoForReportFunction : ITransactionTypeRepository
+{
+    private readonly Dictionary<string, TransactionType> _types = [];
+
+    public void Add(string typeCode, string description)
+        => _types[typeCode] = new TransactionType { TypeCode = typeCode, Description = description };
+
+    public Task<TransactionType?> GetByCodeAsync(string typeCode, CancellationToken cancellationToken = default)
+        => Task.FromResult(_types.GetValueOrDefault(typeCode));
+}
+
+internal sealed class StubCategoryRepoForReportFunction : ITransactionCategoryRepository
+{
+    private readonly Dictionary<string, TransactionCategory> _categories = [];
+
+    public void Add(string typeCode, int categoryCode, string description)
+        => _categories[$"{typeCode}|{categoryCode}"] = new TransactionCategory
+        { TypeCode = typeCode, CategoryCode = categoryCode, Description = description };
+
+    public Task<TransactionCategory?> GetAsync(string typeCode, int categoryCode, CancellationToken cancellationToken = default)
+        => Task.FromResult(_categories.GetValueOrDefault($"{typeCode}|{categoryCode}"));
+}

--- a/tests/NordKredit.UnitTests/Transactions/TransactionAddServiceTests.cs
+++ b/tests/NordKredit.UnitTests/Transactions/TransactionAddServiceTests.cs
@@ -424,6 +424,10 @@ internal sealed class StubTransactionRepository : ITransactionRepository
 
     public Task<Transaction?> GetLastTransactionAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(_transactions.OrderByDescending(t => t.Id).FirstOrDefault());
+
+    public Task<IReadOnlyList<Transaction>> GetByDateRangeAsync(
+        DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<Transaction>>([]);
 }
 
 /// <summary>

--- a/tests/NordKredit.UnitTests/Transactions/TransactionDetailReportServiceTests.cs
+++ b/tests/NordKredit.UnitTests/Transactions/TransactionDetailReportServiceTests.cs
@@ -1,0 +1,608 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NordKredit.Domain.Transactions;
+
+namespace NordKredit.UnitTests.Transactions;
+
+/// <summary>
+/// Unit tests for TransactionDetailReportService — daily transaction detail report generation.
+/// COBOL source: CBTRN03C.cbl:159-373 (report generation).
+/// Covers date filtering, type/category enrichment, card grouping with account totals,
+/// page totals every 20 lines, and grand total consistency.
+/// Regulations: FFFS 2014:5 Ch.7 (financial reporting), PSD2 Art.94 (accessibility),
+/// AML 2017:11 Para.3 (monitoring).
+/// </summary>
+public class TransactionDetailReportServiceTests
+{
+    private readonly StubTransactionRepositoryForReport _transactionRepo = new();
+    private readonly StubCardCrossReferenceRepositoryForReport _xrefRepo = new();
+    private readonly StubTransactionTypeRepositoryForReport _typeRepo = new();
+    private readonly StubTransactionCategoryRepositoryForReport _categoryRepo = new();
+    private readonly ILogger<TransactionDetailReportService> _logger =
+        NullLogger<TransactionDetailReportService>.Instance;
+    private readonly TransactionDetailReportService _sut;
+
+    public TransactionDetailReportServiceTests()
+    {
+        _sut = new TransactionDetailReportService(
+            _transactionRepo,
+            _xrefRepo,
+            _typeRepo,
+            _categoryRepo,
+            _logger);
+    }
+
+    // ===================================================================
+    // AC-1: Date range filtering — only transactions within range included
+    // CBTRN03C.cbl:173-178 — date comparison using TRAN-PROC-TS(1:10)
+    // ===================================================================
+
+    [Fact]
+    public async Task DateRangeFiltering_OnlyIncludesTransactionsInRange()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        _transactionRepo.AddRange(
+            CreateTransaction("TXN001", "4000000000000001", "01", 1, 100.00m,
+                new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)),
+            CreateTransaction("TXN002", "4000000000000001", "01", 1, 200.00m,
+                new DateTime(2025, 12, 31, 23, 59, 59, DateTimeKind.Utc)), // outside range
+            CreateTransaction("TXN003", "4000000000000001", "01", 1, 300.00m,
+                new DateTime(2026, 1, 31, 23, 59, 59, DateTimeKind.Utc)));
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(2, result.TotalTransactions);
+        Assert.Equal(2, result.DetailLineCount);
+        Assert.Equal(400.00m, result.GrandTotal);
+    }
+
+    // ===================================================================
+    // AC-2: Date range uses processing timestamp, not origination
+    // CBTRN03C.cbl:173 — TRAN-PROC-TS(1:10)
+    // ===================================================================
+
+    [Fact]
+    public async Task DateRangeFiltering_UsesProcessingTimestamp()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        // Origination in Dec 2025, processing in Jan 2026 — should be included
+        var txn = CreateTransaction("TXN001", "4000000000000001", "01", 1, 500.00m,
+            new DateTime(2026, 1, 2, 10, 0, 0, DateTimeKind.Utc));
+        txn.OriginationTimestamp = new DateTime(2025, 12, 31, 10, 0, 0, DateTimeKind.Utc);
+        _transactionRepo.AddRange(txn);
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(1, result.TotalTransactions);
+        Assert.Equal(500.00m, result.GrandTotal);
+    }
+
+    // ===================================================================
+    // AC-3: Page totals every 20 lines
+    // CBTRN03C.cbl:274-290 — WS-PAGE-SIZE PIC 9(03) COMP-3 VALUE 20
+    // ===================================================================
+
+    [Fact]
+    public async Task PageTotals_AppearEvery20Lines()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        // Add 25 transactions
+        for (var i = 1; i <= 25; i++)
+        {
+            _transactionRepo.AddRange(CreateTransaction(
+                $"TXN{i:D3}", "4000000000000001", "01", 1, 100.00m,
+                new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+        }
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(25, result.TotalTransactions);
+        // 2 pages: first page 20 lines, second page 5 lines
+        Assert.Equal(2, result.PageTotals.Count);
+        Assert.Equal(2000.00m, result.PageTotals[0]); // 20 * 100
+        Assert.Equal(500.00m, result.PageTotals[1]);   // 5 * 100
+    }
+
+    // ===================================================================
+    // AC-4: Configurable page size
+    // ===================================================================
+
+    [Fact]
+    public async Task PageTotals_RespectsConfigurablePageSize()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        for (var i = 1; i <= 10; i++)
+        {
+            _transactionRepo.AddRange(CreateTransaction(
+                $"TXN{i:D3}", "4000000000000001", "01", 1, 50.00m,
+                new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+        }
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31), pageSize: 5);
+
+        Assert.Equal(2, result.PageTotals.Count);
+        Assert.Equal(250.00m, result.PageTotals[0]); // 5 * 50
+        Assert.Equal(250.00m, result.PageTotals[1]); // 5 * 50
+    }
+
+    // ===================================================================
+    // AC-5: Account total on card number change
+    // CBTRN03C.cbl:158-217 — card change detection
+    // ===================================================================
+
+    [Fact]
+    public async Task AccountTotals_WrittenOnCardNumberChange()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+        _xrefRepo.Add("4000000000000002", "00000000002");
+
+        _transactionRepo.AddRange(
+            CreateTransaction("TXN001", "4000000000000001", "01", 1, 500.00m,
+                new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)),
+            CreateTransaction("TXN002", "4000000000000001", "01", 1, 1000.00m,
+                new DateTime(2026, 1, 15, 11, 0, 0, DateTimeKind.Utc)),
+            CreateTransaction("TXN003", "4000000000000002", "01", 1, 800.00m,
+                new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc)));
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(2, result.AccountTotals.Count);
+        Assert.Equal("4000000000000001", result.AccountTotals[0].CardNumber);
+        Assert.Equal("00000000001", result.AccountTotals[0].AccountId);
+        Assert.Equal(1500.00m, result.AccountTotals[0].Total);
+        Assert.Equal("4000000000000002", result.AccountTotals[1].CardNumber);
+        Assert.Equal("00000000002", result.AccountTotals[1].AccountId);
+        Assert.Equal(800.00m, result.AccountTotals[1].Total);
+    }
+
+    // ===================================================================
+    // AC-6: Final account total at end of file
+    // Edge case: COBOL card-change detection may not fire at EOF
+    // ===================================================================
+
+    [Fact]
+    public async Task AccountTotals_FinalGroupWrittenAtEndOfFile()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        _transactionRepo.AddRange(
+            CreateTransaction("TXN001", "4000000000000001", "01", 1, 300.00m,
+                new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)),
+            CreateTransaction("TXN002", "4000000000000001", "01", 1, 200.00m,
+                new DateTime(2026, 1, 15, 11, 0, 0, DateTimeKind.Utc)));
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Single(result.AccountTotals);
+        Assert.Equal(500.00m, result.AccountTotals[0].Total);
+    }
+
+    // ===================================================================
+    // AC-7: Grand total equals sum of all page totals
+    // CBTRN03C.cbl:318-322 — grand total write
+    // ===================================================================
+
+    [Fact]
+    public async Task GrandTotal_EqualsSumOfAllPageTotals()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        for (var i = 1; i <= 25; i++)
+        {
+            _transactionRepo.AddRange(CreateTransaction(
+                $"TXN{i:D3}", "4000000000000001", "01", 1, 100.00m,
+                new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+        }
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(result.GrandTotal, result.PageTotals.Sum());
+    }
+
+    // ===================================================================
+    // AC-8: Type/category enrichment
+    // CBTRN03C.cbl:361-370 — type/category description lookups
+    // ===================================================================
+
+    [Fact]
+    public async Task Enrichment_TypeAndCategoryDescriptionsFormatted()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        _transactionRepo.AddRange(CreateTransaction(
+            "TXN001", "4000000000000001", "01", 1, 100.00m,
+            new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        var line = Assert.Single(result.Lines);
+        Assert.Equal("01-Purchase", line.TypeDescription);
+        Assert.Equal("0001-Groceries", line.CategoryDescription);
+    }
+
+    // ===================================================================
+    // AC-9: Type lookup failure — ABEND (throws exception)
+    // CBTRN03C.cbl AF-2: program ABENDs on missing type
+    // ===================================================================
+
+    [Fact]
+    public async Task TypeLookupFailure_ThrowsException()
+    {
+        // Only set up category, not type — type "99" will fail lookup
+        _categoryRepo.Add("99", 1, "SomeCategory");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        _transactionRepo.AddRange(CreateTransaction(
+            "TXN001", "4000000000000001", "99", 1, 100.00m,
+            new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.GenerateReportAsync(
+                new DateTime(2026, 1, 1), new DateTime(2026, 1, 31)));
+    }
+
+    // ===================================================================
+    // AC-10: Category lookup failure — ABEND (throws exception)
+    // CBTRN03C.cbl AF-3: program ABENDs on missing category
+    // ===================================================================
+
+    [Fact]
+    public async Task CategoryLookupFailure_ThrowsException()
+    {
+        _typeRepo.Add("01", "Purchase");
+        // No category setup — will fail lookup
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        _transactionRepo.AddRange(CreateTransaction(
+            "TXN001", "4000000000000001", "01", 9999, 100.00m,
+            new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.GenerateReportAsync(
+                new DateTime(2026, 1, 1), new DateTime(2026, 1, 31)));
+    }
+
+    // ===================================================================
+    // AC-11: Card XREF lookup failure — ABEND (throws exception)
+    // CBTRN03C.cbl AF-1: program ABENDs on invalid card number
+    // ===================================================================
+
+    [Fact]
+    public async Task CardXrefLookupFailure_ThrowsException()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        // No XREF setup — card lookup will fail
+
+        _transactionRepo.AddRange(CreateTransaction(
+            "TXN001", "4000000000000001", "01", 1, 100.00m,
+            new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.GenerateReportAsync(
+                new DateTime(2026, 1, 1), new DateTime(2026, 1, 31)));
+    }
+
+    // ===================================================================
+    // AC-12: Empty result when no transactions in date range
+    // AF-5: report with zero grand total
+    // ===================================================================
+
+    [Fact]
+    public async Task EmptyDateRange_ReturnsZeroTotals()
+    {
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(0, result.TotalTransactions);
+        Assert.Equal(0, result.DetailLineCount);
+        Assert.Equal(0, result.PageCount);
+        Assert.Equal(0, result.AccountGroupCount);
+        Assert.Equal(0.00m, result.GrandTotal);
+        Assert.Empty(result.Lines);
+        Assert.Empty(result.PageTotals);
+        Assert.Empty(result.AccountTotals);
+    }
+
+    // ===================================================================
+    // AC-13: Report lines have correct field mapping
+    // ===================================================================
+
+    [Fact]
+    public async Task ReportLines_HaveCorrectFieldMapping()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        _transactionRepo.AddRange(CreateTransaction(
+            "TXN001", "4000000000000001", "01", 1, -125.50m,
+            new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        var line = Assert.Single(result.Lines);
+        Assert.Equal("TXN001", line.TransactionId);
+        Assert.Equal("00000000001", line.AccountId);
+        Assert.Equal("BATCH", line.Source);
+        Assert.Equal(-125.50m, line.Amount);
+        Assert.Equal("4000000000000001", line.CardNumber);
+    }
+
+    // ===================================================================
+    // AC-14: Account group count matches distinct card groups
+    // ===================================================================
+
+    [Fact]
+    public async Task AccountGroupCount_MatchesDistinctCardGroups()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+        _xrefRepo.Add("4000000000000002", "00000000002");
+        _xrefRepo.Add("4000000000000003", "00000000003");
+
+        _transactionRepo.AddRange(
+            CreateTransaction("TXN001", "4000000000000001", "01", 1, 100.00m,
+                new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)),
+            CreateTransaction("TXN002", "4000000000000002", "01", 1, 200.00m,
+                new DateTime(2026, 1, 15, 11, 0, 0, DateTimeKind.Utc)),
+            CreateTransaction("TXN003", "4000000000000003", "01", 1, 300.00m,
+                new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc)));
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(3, result.AccountGroupCount);
+    }
+
+    // ===================================================================
+    // AC-15: Cancellation support
+    // ===================================================================
+
+    [Fact]
+    public async Task CancellationRequested_ThrowsOperationCanceledException()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        _transactionRepo.AddRange(CreateTransaction(
+            "TXN001", "4000000000000001", "01", 1, 100.00m,
+            new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _sut.GenerateReportAsync(
+                new DateTime(2026, 1, 1), new DateTime(2026, 1, 31),
+                cancellationToken: cts.Token));
+    }
+
+    // ===================================================================
+    // AC-16: Page count is correct
+    // ===================================================================
+
+    [Fact]
+    public async Task PageCount_MatchesNumberOfPages()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        // 45 transactions = 3 pages (20 + 20 + 5)
+        for (var i = 1; i <= 45; i++)
+        {
+            _transactionRepo.AddRange(CreateTransaction(
+                $"TXN{i:D3}", "4000000000000001", "01", 1, 10.00m,
+                new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+        }
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(3, result.PageCount);
+        Assert.Equal(3, result.PageTotals.Count);
+        Assert.Equal(200.00m, result.PageTotals[0]); // 20 * 10
+        Assert.Equal(200.00m, result.PageTotals[1]); // 20 * 10
+        Assert.Equal(50.00m, result.PageTotals[2]);   // 5 * 10
+    }
+
+    // ===================================================================
+    // AC-17: Exactly 20 transactions — one full page, no partial
+    // ===================================================================
+
+    [Fact]
+    public async Task ExactlyOnePage_ProducesOnePageTotal()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+
+        for (var i = 1; i <= 20; i++)
+        {
+            _transactionRepo.AddRange(CreateTransaction(
+                $"TXN{i:D3}", "4000000000000001", "01", 1, 10.00m,
+                new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+        }
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(1, result.PageCount);
+        Assert.Single(result.PageTotals);
+        Assert.Equal(200.00m, result.PageTotals[0]);
+    }
+
+    // ===================================================================
+    // AC-18: Mixed card groups across page boundaries
+    // ===================================================================
+
+    [Fact]
+    public async Task MixedCardGroups_AccountTotalsCorrectAcrossPageBoundaries()
+    {
+        SetupLookups("01", "Purchase", 1, "Groceries");
+        _xrefRepo.Add("4000000000000001", "00000000001");
+        _xrefRepo.Add("4000000000000002", "00000000002");
+
+        // 15 transactions for card 1, then 10 for card 2
+        // Card 1 transactions on first page, card change at line 16
+        for (var i = 1; i <= 15; i++)
+        {
+            _transactionRepo.AddRange(CreateTransaction(
+                $"TXN{i:D3}", "4000000000000001", "01", 1, 100.00m,
+                new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+        }
+
+        for (var i = 16; i <= 25; i++)
+        {
+            _transactionRepo.AddRange(CreateTransaction(
+                $"TXN{i:D3}", "4000000000000002", "01", 1, 50.00m,
+                new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)));
+        }
+
+        var result = await _sut.GenerateReportAsync(
+            new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+        Assert.Equal(2, result.AccountTotals.Count);
+        Assert.Equal(1500.00m, result.AccountTotals[0].Total); // 15 * 100
+        Assert.Equal(500.00m, result.AccountTotals[1].Total);  // 10 * 50
+        Assert.Equal(2000.00m, result.GrandTotal);
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    private void SetupLookups(string typeCode, string typeDesc, int catCode, string catDesc)
+    {
+        _typeRepo.Add(typeCode, typeDesc);
+        _categoryRepo.Add(typeCode, catCode, catDesc);
+    }
+
+    private static Transaction CreateTransaction(
+        string id, string cardNumber, string typeCode, int categoryCode,
+        decimal amount, DateTime processingTimestamp) => new()
+        {
+            Id = id,
+            CardNumber = cardNumber,
+            TypeCode = typeCode,
+            CategoryCode = categoryCode,
+            Source = "BATCH",
+            Description = "Test transaction",
+            Amount = amount,
+            MerchantId = 1,
+            MerchantName = "Test Merchant",
+            MerchantCity = "Stockholm",
+            MerchantZip = "11122",
+            OriginationTimestamp = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            ProcessingTimestamp = processingTimestamp
+        };
+}
+
+// ===================================================================
+// Test doubles for report tests
+// ===================================================================
+
+internal sealed class StubTransactionRepositoryForReport : ITransactionRepository
+{
+    private readonly List<Transaction> _transactions = [];
+
+    public void AddRange(params Transaction[] transactions) =>
+        _transactions.AddRange(transactions);
+
+    public Task<Transaction?> GetByIdAsync(string transactionId, CancellationToken cancellationToken = default)
+        => Task.FromResult(_transactions.FirstOrDefault(t => t.Id == transactionId));
+
+    public Task<IReadOnlyList<Transaction>> GetByAccountIdAsync(
+        string accountId, int pageSize, string? startAfterTransactionId = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<Transaction>>([]);
+
+    public Task AddAsync(Transaction transaction, CancellationToken cancellationToken = default)
+    {
+        _transactions.Add(transaction);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<Transaction>> GetPageAsync(
+        int pageSize, string? startAfterTransactionId = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<Transaction>>([]);
+
+    public Task<Transaction?> GetLastTransactionAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<Transaction?>(null);
+
+    public Task<IReadOnlyList<Transaction>> GetByDateRangeAsync(
+        DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<Transaction> result = [.. _transactions
+            .Where(t => t.ProcessingTimestamp.Date >= startDate.Date
+                     && t.ProcessingTimestamp.Date <= endDate.Date)
+            .OrderBy(t => t.CardNumber)
+            .ThenBy(t => t.Id)];
+        return Task.FromResult(result);
+    }
+}
+
+internal sealed class StubCardCrossReferenceRepositoryForReport : ICardCrossReferenceRepository
+{
+    private readonly Dictionary<string, CardCrossReference> _xrefs = [];
+
+    public void Add(string cardNumber, string accountId)
+        => _xrefs[cardNumber] = new CardCrossReference
+        {
+            CardNumber = cardNumber,
+            AccountId = accountId,
+            CustomerId = 100000001
+        };
+
+    public Task<CardCrossReference?> GetByCardNumberAsync(string cardNumber, CancellationToken cancellationToken = default)
+        => Task.FromResult(_xrefs.GetValueOrDefault(cardNumber));
+
+    public Task<CardCrossReference?> GetByAccountIdAsync(string accountId, CancellationToken cancellationToken = default)
+        => Task.FromResult(_xrefs.Values.FirstOrDefault(x => x.AccountId == accountId));
+}
+
+internal sealed class StubTransactionTypeRepositoryForReport : ITransactionTypeRepository
+{
+    private readonly Dictionary<string, TransactionType> _types = [];
+
+    public void Add(string typeCode, string description)
+        => _types[typeCode] = new TransactionType { TypeCode = typeCode, Description = description };
+
+    public Task<TransactionType?> GetByCodeAsync(string typeCode, CancellationToken cancellationToken = default)
+        => Task.FromResult(_types.GetValueOrDefault(typeCode));
+}
+
+internal sealed class StubTransactionCategoryRepositoryForReport : ITransactionCategoryRepository
+{
+    private readonly Dictionary<string, TransactionCategory> _categories = [];
+
+    public void Add(string typeCode, int categoryCode, string description)
+        => _categories[$"{typeCode}|{categoryCode}"] = new TransactionCategory
+        {
+            TypeCode = typeCode,
+            CategoryCode = categoryCode,
+            Description = description
+        };
+
+    public Task<TransactionCategory?> GetAsync(string typeCode, int categoryCode, CancellationToken cancellationToken = default)
+        => Task.FromResult(_categories.GetValueOrDefault($"{typeCode}|{categoryCode}"));
+}

--- a/tests/NordKredit.UnitTests/Transactions/TransactionDetailServiceTests.cs
+++ b/tests/NordKredit.UnitTests/Transactions/TransactionDetailServiceTests.cs
@@ -168,4 +168,8 @@ internal sealed class StubDetailRepository : ITransactionRepository
 
     public Task<Transaction?> GetLastTransactionAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<Transaction?>(null);
+
+    public Task<IReadOnlyList<Transaction>> GetByDateRangeAsync(
+        DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<Transaction>>([]);
 }

--- a/tests/NordKredit.UnitTests/Transactions/TransactionListServiceTests.cs
+++ b/tests/NordKredit.UnitTests/Transactions/TransactionListServiceTests.cs
@@ -273,4 +273,8 @@ internal sealed class StubTransactionListRepository : ITransactionRepository
 
     public Task<Transaction?> GetLastTransactionAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(_transactions.OrderByDescending(t => t.Id).FirstOrDefault());
+
+    public Task<IReadOnlyList<Transaction>> GetByDateRangeAsync(
+        DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<Transaction>>([]);
 }

--- a/tests/NordKredit.UnitTests/Transactions/TransactionPostingServiceTests.cs
+++ b/tests/NordKredit.UnitTests/Transactions/TransactionPostingServiceTests.cs
@@ -537,6 +537,10 @@ internal sealed class StubTransactionRepositoryForPosting : ITransactionReposito
 
     public Task<Transaction?> GetLastTransactionAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<Transaction?>(null);
+
+    public Task<IReadOnlyList<Transaction>> GetByDateRangeAsync(
+        DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<Transaction>>([]);
 }
 
 internal sealed class StubTransactionCategoryBalanceRepositoryForPosting : ITransactionCategoryBalanceRepository


### PR DESCRIPTION
## Summary

- Implements Azure Function replacing CBTRN03C.cbl — generates a daily transaction detail report for a configurable date range
- TransactionDetailReportService with date filtering, CARDXREF/TRANTYPE/TRANCATG lookups, card grouping, page totals, account totals, and grand total
- ABEND behavior on lookup failures (throws exception) matching COBOL error handling

## Changes

### Domain Layer
- `TransactionType`, `TransactionCategory` — lookup entities (CVTRA03Y.cpy, CVTRA04Y.cpy)
- `TransactionReportLine`, `TransactionReportResult`, `AccountTotal` — report output models
- `ITransactionTypeRepository`, `ITransactionCategoryRepository` — lookup repository interfaces
- `ITransactionRepository.GetByDateRangeAsync` — date-range query ordered by CardNumber, Id
- `TransactionDetailReportService` — report generation business logic (CBTRN03C.cbl:159-373)

### Functions Layer
- `TransactionReportFunction` — thin batch function wrapper with structured logging
- `TransactionReportFunctionResult` — aggregate result DTO for monitoring

### Infrastructure Layer
- `SqlTransactionTypeRepository`, `SqlTransactionCategoryRepository` — EF Core implementations
- `NordKreditDbContext` — TransactionTypes/TransactionCategories table configurations
- `SqlTransactionRepository.GetByDateRangeAsync` — date-range query implementation

### Test Coverage (21 new tests)
- Date range filtering (inclusive, processing timestamp not origination)
- Page totals every 20 lines (configurable page size)
- Account totals on card number change (including final group at EOF)
- Grand total = sum of all page totals
- Type/category enrichment formatting ("01-Purchase", "0001-Groceries")
- ABEND on type/category/XREF lookup failures
- Empty result, cancellation, field mapping, page count

## Testing
- [x] 362 unit tests pass
- [x] 39 BDD tests pass
- [x] 13 comparison tests pass
- [x] `dotnet build /warnaserror` — zero warnings
- [x] `dotnet format --verify-no-changes` — clean

## Regulatory Traceability
- **COBOL source**: CBTRN03C.cbl:159-373 (report generation)
- **Regulations**: FFFS 2014:5 Ch.7 (financial reporting), PSD2 Art.94 (accessibility), AML 2017:11 Para.3 (monitoring)

Closes #78

🤖 Generated with Claude Code