### PR TITLE
feat(#138): Implement EBCDIC-to-Unicode conversion utilities

### DIFF
--- a/src/NordKredit.Infrastructure/DataMigration/EbcdicConverter.cs
+++ b/src/NordKredit.Infrastructure/DataMigration/EbcdicConverter.cs
@@ -1,0 +1,133 @@
+using System.Text;
+
+namespace NordKredit.Infrastructure.DataMigration;
+
+/// <summary>
+/// Converts EBCDIC-encoded data from the IBM mainframe to Unicode/UTF-8.
+/// Handles IBM Code Page 1143 (Swedish/Finnish EBCDIC variant) for text fields,
+/// packed decimal (COMP-3) for numeric fields, and zoned decimal fields.
+/// COBOL source: All copybook text/numeric field conversions during Db2 → Azure SQL migration.
+/// Regulation: GDPR Art. 5(1)(d) — accuracy of personal data during migration.
+/// </summary>
+public static class EbcdicConverter
+{
+    private static readonly Encoding _ebcdicEncoding;
+
+    static EbcdicConverter()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        _ebcdicEncoding = Encoding.GetEncoding(1143);
+    }
+
+    /// <summary>
+    /// Converts EBCDIC bytes (IBM Code Page 1143) to a Unicode string.
+    /// </summary>
+    /// <param name="ebcdicBytes">The EBCDIC-encoded byte array.</param>
+    /// <returns>The decoded Unicode string.</returns>
+    public static string ConvertToUnicode(byte[] ebcdicBytes) =>
+        _ebcdicEncoding.GetString(ebcdicBytes);
+
+    /// <summary>
+    /// Converts a Unicode string to EBCDIC bytes (IBM Code Page 1143).
+    /// Used for parallel-run comparison where data must be sent back to mainframe format.
+    /// </summary>
+    /// <param name="unicodeString">The Unicode string to encode.</param>
+    /// <returns>The EBCDIC-encoded byte array.</returns>
+    public static byte[] ConvertToEbcdic(string unicodeString) =>
+        _ebcdicEncoding.GetBytes(unicodeString);
+
+    /// <summary>
+    /// Converts a COBOL COMP-3 (packed decimal) byte array to a .NET decimal value.
+    /// Each byte stores two digits (one per nibble), with the last nibble as sign
+    /// (0xC = positive, 0xD = negative, 0xF = unsigned positive).
+    /// </summary>
+    /// <param name="packedBytes">The packed decimal byte array.</param>
+    /// <param name="scale">Number of implied decimal places (e.g., PIC 9(5)V99 COMP-3 → scale=2).</param>
+    /// <returns>The decimal value.</returns>
+    public static decimal ConvertPackedDecimal(byte[] packedBytes, int scale = 0)
+    {
+        if (packedBytes.Length == 0)
+        {
+            throw new ArgumentException("Packed decimal byte array cannot be empty.", nameof(packedBytes));
+        }
+
+        long value = 0;
+
+        // Process all bytes: each byte has two nibbles (digits),
+        // except the last nibble of the last byte which is the sign.
+        for (var i = 0; i < packedBytes.Length; i++)
+        {
+            var highNibble = (packedBytes[i] >> 4) & 0x0F;
+            var lowNibble = packedBytes[i] & 0x0F;
+
+            if (i < packedBytes.Length - 1)
+            {
+                // Both nibbles are digits
+                value = (value * 10) + highNibble;
+                value = (value * 10) + lowNibble;
+            }
+            else
+            {
+                // Last byte: high nibble is digit, low nibble is sign
+                value = (value * 10) + highNibble;
+            }
+        }
+
+        // Determine sign from last nibble of last byte
+        var signNibble = packedBytes[^1] & 0x0F;
+        var isNegative = signNibble == 0x0D;
+
+        if (isNegative)
+        {
+            value = -value;
+        }
+
+        // Apply scale (implied decimal places)
+        if (scale > 0)
+        {
+            return value / (decimal)Math.Pow(10, scale);
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Converts a COBOL zoned decimal byte array to a .NET decimal value.
+    /// Each byte stores one digit in the low nibble; the zone (high nibble) of the
+    /// last byte indicates the sign (0xC/0xF = positive, 0xD = negative).
+    /// </summary>
+    /// <param name="zonedBytes">The zoned decimal byte array.</param>
+    /// <param name="scale">Number of implied decimal places.</param>
+    /// <returns>The decimal value.</returns>
+    public static decimal ConvertZonedDecimal(byte[] zonedBytes, int scale = 0)
+    {
+        if (zonedBytes.Length == 0)
+        {
+            throw new ArgumentException("Zoned decimal byte array cannot be empty.", nameof(zonedBytes));
+        }
+
+        long value = 0;
+
+        for (var i = 0; i < zonedBytes.Length; i++)
+        {
+            var digit = zonedBytes[i] & 0x0F;
+            value = (value * 10) + digit;
+        }
+
+        // Sign is in the high nibble of the last byte
+        var signNibble = (zonedBytes[^1] >> 4) & 0x0F;
+        var isNegative = signNibble == 0x0D;
+
+        if (isNegative)
+        {
+            value = -value;
+        }
+
+        if (scale > 0)
+        {
+            return value / (decimal)Math.Pow(10, scale);
+        }
+
+        return value;
+    }
+}

--- a/src/NordKredit.Infrastructure/NordKredit.Infrastructure.csproj
+++ b/src/NordKredit.Infrastructure/NordKredit.Infrastructure.csproj
@@ -10,6 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/NordKredit.UnitTests/Infrastructure/EbcdicConverterTests.cs
+++ b/tests/NordKredit.UnitTests/Infrastructure/EbcdicConverterTests.cs
@@ -1,0 +1,275 @@
+using NordKredit.Infrastructure.DataMigration;
+
+namespace NordKredit.UnitTests.Infrastructure;
+
+/// <summary>
+/// Tests for <see cref="EbcdicConverter"/>.
+/// Verifies EBCDIC (IBM Code Page 1143) to Unicode conversion,
+/// packed decimal (COMP-3), and zoned decimal conversions.
+/// COBOL source: All copybook field conversions during Db2 → Azure SQL migration.
+/// </summary>
+public class EbcdicConverterTests
+{
+    // ──────────────────────────────────────────────
+    // EBCDIC ↔ Unicode text conversion tests
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void ConvertToUnicode_AsciiLetters_ReturnsCorrectString()
+    {
+        // EBCDIC Code Page 1143: 'A' = 0xC1, 'B' = 0xC2, 'C' = 0xC3
+        byte[] ebcdic = [0xC1, 0xC2, 0xC3];
+
+        var result = EbcdicConverter.ConvertToUnicode(ebcdic);
+
+        Assert.Equal("ABC", result);
+    }
+
+    [Fact]
+    public void ConvertToUnicode_SwedishCharacters_ReturnsCorrectString()
+    {
+        // IBM Code Page 1143 Swedish EBCDIC:
+        // We test round-trip to ensure the encoding handles Swedish chars properly
+        var swedishText = "ÅÄÖåäö";
+
+        var ebcdicBytes = EbcdicConverter.ConvertToEbcdic(swedishText);
+        var roundTripped = EbcdicConverter.ConvertToUnicode(ebcdicBytes);
+
+        Assert.Equal(swedishText, roundTripped);
+    }
+
+    [Fact]
+    public void ConvertToUnicode_Digits_ReturnsCorrectString()
+    {
+        // EBCDIC digits: '0' = 0xF0, '1' = 0xF1, ... '9' = 0xF9
+        byte[] ebcdic = [0xF1, 0xF2, 0xF3];
+
+        var result = EbcdicConverter.ConvertToUnicode(ebcdic);
+
+        Assert.Equal("123", result);
+    }
+
+    [Fact]
+    public void ConvertToUnicode_EmptyArray_ReturnsEmptyString()
+    {
+        var result = EbcdicConverter.ConvertToUnicode([]);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void ConvertToEbcdic_EmptyString_ReturnsEmptyArray()
+    {
+        var result = EbcdicConverter.ConvertToEbcdic(string.Empty);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ConvertRoundTrip_MixedSwedishAndAscii_PreservesContent()
+    {
+        // Simulate a typical customer name field from COBOL copybook
+        var customerName = "Göran Ström";
+
+        var ebcdicBytes = EbcdicConverter.ConvertToEbcdic(customerName);
+        var roundTripped = EbcdicConverter.ConvertToUnicode(ebcdicBytes);
+
+        Assert.Equal(customerName, roundTripped);
+    }
+
+    [Fact]
+    public void ConvertRoundTrip_SpacePaddedField_PreservesContent()
+    {
+        // COBOL fields are typically space-padded (EBCDIC space = 0x40)
+        var paddedName = "Erik   ";
+
+        var ebcdicBytes = EbcdicConverter.ConvertToEbcdic(paddedName);
+        var roundTripped = EbcdicConverter.ConvertToUnicode(ebcdicBytes);
+
+        Assert.Equal(paddedName, roundTripped);
+    }
+
+    // ──────────────────────────────────────────────
+    // Packed decimal (COMP-3) conversion tests
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void ConvertPackedDecimal_PositiveInteger_ReturnsCorrectValue()
+    {
+        // COMP-3: 12345+ → 3 bytes: 0x12, 0x34, 0x5C
+        // Each nibble = one digit, last nibble 0xC = positive
+        byte[] packed = [0x12, 0x34, 0x5C];
+
+        var result = EbcdicConverter.ConvertPackedDecimal(packed);
+
+        Assert.Equal(12345m, result);
+    }
+
+    [Fact]
+    public void ConvertPackedDecimal_NegativeInteger_ReturnsCorrectValue()
+    {
+        // COMP-3: -12345 → 3 bytes: 0x12, 0x34, 0x5D
+        // Last nibble 0xD = negative
+        byte[] packed = [0x12, 0x34, 0x5D];
+
+        var result = EbcdicConverter.ConvertPackedDecimal(packed);
+
+        Assert.Equal(-12345m, result);
+    }
+
+    [Fact]
+    public void ConvertPackedDecimal_WithScale_ReturnsCorrectDecimalValue()
+    {
+        // PIC 9(5)V99 COMP-3: value 12345.67 → stored integer 1234567
+        // 7 digits + 1 sign nibble = 8 nibbles = 4 bytes: 0x12, 0x34, 0x56, 0x7C
+        // scale=2 means last 2 digits are after decimal point
+        byte[] packed = [0x12, 0x34, 0x56, 0x7C];
+
+        var result = EbcdicConverter.ConvertPackedDecimal(packed, scale: 2);
+
+        Assert.Equal(12345.67m, result);
+    }
+
+    [Fact]
+    public void ConvertPackedDecimal_Zero_ReturnsZero()
+    {
+        // Zero: 0x00, 0x0C (positive zero)
+        byte[] packed = [0x00, 0x0C];
+
+        var result = EbcdicConverter.ConvertPackedDecimal(packed);
+
+        Assert.Equal(0m, result);
+    }
+
+    [Fact]
+    public void ConvertPackedDecimal_UnsignedPositive_ReturnsCorrectValue()
+    {
+        // 0xF = unsigned/positive (common in COBOL display fields converted to COMP-3)
+        byte[] packed = [0x99, 0x9F];
+
+        var result = EbcdicConverter.ConvertPackedDecimal(packed);
+
+        Assert.Equal(999m, result);
+    }
+
+    [Fact]
+    public void ConvertPackedDecimal_SingleByte_ReturnsCorrectValue()
+    {
+        // Single digit packed: 5+ stored as 0x5C
+        byte[] packed = [0x5C];
+
+        var result = EbcdicConverter.ConvertPackedDecimal(packed);
+
+        Assert.Equal(5m, result);
+    }
+
+    [Fact]
+    public void ConvertPackedDecimal_LargeValue_ReturnsCorrectValue()
+    {
+        // Typical account balance: PIC 9(9)V99 COMP-3
+        // Value: 123456789.12 → stored integer 12345678912 (11 digits)
+        // 11 digits + 1 sign = 12 nibbles = 6 bytes: 0x12, 0x34, 0x56, 0x78, 0x91, 0x2C
+        byte[] packed = [0x12, 0x34, 0x56, 0x78, 0x91, 0x2C];
+
+        var result = EbcdicConverter.ConvertPackedDecimal(packed, scale: 2);
+
+        Assert.Equal(123456789.12m, result);
+    }
+
+    [Fact]
+    public void ConvertPackedDecimal_NegativeWithScale_ReturnsCorrectValue()
+    {
+        // Negative amount: -100.50 → PIC S9(5)V99 COMP-3
+        // Stored integer: 10050 (5 digits + 1 sign = 6 nibbles = 3 bytes)
+        // Packed: 0x10, 0x05, 0x0D
+        byte[] packed = [0x10, 0x05, 0x0D];
+
+        var result = EbcdicConverter.ConvertPackedDecimal(packed, scale: 2);
+
+        Assert.Equal(-100.50m, result);
+    }
+
+    [Fact]
+    public void ConvertPackedDecimal_EmptyArray_ThrowsArgumentException() =>
+        Assert.Throws<ArgumentException>(() => EbcdicConverter.ConvertPackedDecimal([]));
+
+    // ──────────────────────────────────────────────
+    // Zoned decimal conversion tests
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void ConvertZonedDecimal_PositiveInteger_ReturnsCorrectValue()
+    {
+        // Zoned decimal: 12345 positive
+        // Each byte: zone nibble (0xF) + digit nibble
+        // Last byte: sign nibble (0xC for positive) + digit nibble
+        // '1'=0xF1, '2'=0xF2, '3'=0xF3, '4'=0xF4, '5'=0xC5
+        byte[] zoned = [0xF1, 0xF2, 0xF3, 0xF4, 0xC5];
+
+        var result = EbcdicConverter.ConvertZonedDecimal(zoned);
+
+        Assert.Equal(12345m, result);
+    }
+
+    [Fact]
+    public void ConvertZonedDecimal_NegativeInteger_ReturnsCorrectValue()
+    {
+        // Zoned decimal: -12345
+        // Last byte sign nibble 0xD = negative
+        // '1'=0xF1, '2'=0xF2, '3'=0xF3, '4'=0xF4, '5'=0xD5
+        byte[] zoned = [0xF1, 0xF2, 0xF3, 0xF4, 0xD5];
+
+        var result = EbcdicConverter.ConvertZonedDecimal(zoned);
+
+        Assert.Equal(-12345m, result);
+    }
+
+    [Fact]
+    public void ConvertZonedDecimal_WithScale_ReturnsCorrectDecimalValue()
+    {
+        // PIC 9(3)V99: value 123.45
+        // Stored as 5 zoned bytes: 0xF1, 0xF2, 0xF3, 0xF4, 0xC5
+        byte[] zoned = [0xF1, 0xF2, 0xF3, 0xF4, 0xC5];
+
+        var result = EbcdicConverter.ConvertZonedDecimal(zoned, scale: 2);
+
+        Assert.Equal(123.45m, result);
+    }
+
+    [Fact]
+    public void ConvertZonedDecimal_UnsignedPositive_ReturnsCorrectValue()
+    {
+        // Unsigned: all bytes have 0xF zone including last byte
+        // '1'=0xF1, '2'=0xF2, '3'=0xF3
+        byte[] zoned = [0xF1, 0xF2, 0xF3];
+
+        var result = EbcdicConverter.ConvertZonedDecimal(zoned);
+
+        Assert.Equal(123m, result);
+    }
+
+    [Fact]
+    public void ConvertZonedDecimal_Zero_ReturnsZero()
+    {
+        byte[] zoned = [0xF0, 0xF0, 0xC0];
+
+        var result = EbcdicConverter.ConvertZonedDecimal(zoned);
+
+        Assert.Equal(0m, result);
+    }
+
+    [Fact]
+    public void ConvertZonedDecimal_EmptyArray_ThrowsArgumentException() =>
+        Assert.Throws<ArgumentException>(() => EbcdicConverter.ConvertZonedDecimal([]));
+
+    [Fact]
+    public void ConvertZonedDecimal_SingleDigit_ReturnsCorrectValue()
+    {
+        // Single digit: 7 positive → 0xC7
+        byte[] zoned = [0xC7];
+
+        var result = EbcdicConverter.ConvertZonedDecimal(zoned);
+
+        Assert.Equal(7m, result);
+    }
+}

--- a/tests/NordKredit.UnitTests/NordKredit.UnitTests.csproj
+++ b/tests/NordKredit.UnitTests/NordKredit.UnitTests.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\..\src\NordKredit.Api\NordKredit.Api.csproj" />
     <ProjectReference Include="..\..\src\NordKredit.Domain\NordKredit.Domain.csproj" />
     <ProjectReference Include="..\..\src\NordKredit.Functions\NordKredit.Functions.csproj" />
+    <ProjectReference Include="..\..\src\NordKredit.Infrastructure\NordKredit.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Add `EbcdicConverter` static class for converting EBCDIC-encoded mainframe data to Unicode/UTF-8
- Support IBM Code Page 1143 (Swedish/Finnish EBCDIC variant with Å, Ä, Ö, å, ä, ö)
- Support COMP-3 packed decimal and zoned decimal numeric field conversions

## Changes
- `src/NordKredit.Infrastructure/DataMigration/EbcdicConverter.cs` — New converter class with 4 public methods: `ConvertToUnicode`, `ConvertToEbcdic`, `ConvertPackedDecimal`, `ConvertZonedDecimal`
- `src/NordKredit.Infrastructure/NordKredit.Infrastructure.csproj` — Added `System.Text.Encoding.CodePages` 8.0.0 NuGet package
- `tests/NordKredit.UnitTests/Infrastructure/EbcdicConverterTests.cs` — 23 unit tests covering text round-trip, Swedish characters, packed decimals (positive/negative/scaled/edge cases), and zoned decimals
- `tests/NordKredit.UnitTests/NordKredit.UnitTests.csproj` — Added project reference to Infrastructure

## Testing
- [x] 23 new unit tests all passing
- [x] Full test suite (548 tests) passing
- [x] `dotnet build /warnaserror` — zero warnings
- [x] `dotnet format --verify-no-changes` — clean

Closes #138

🤖 Generated with Claude Code