### PR TITLE
docs(#134): Extract and document key copybook data structures

### DIFF
--- a/docs-site/docs/data-structures/cocom01y-commarea.md
+++ b/docs-site/docs/data-structures/cocom01y-commarea.md
@@ -1,0 +1,101 @@
+---
+title: COCOM01Y — Application COMMAREA
+sidebar_position: 6
+---
+
+# COCOM01Y — Application COMMAREA
+
+## Overview
+
+| Attribute         | Value                                    |
+|-------------------|------------------------------------------|
+| **Copybook**      | COCOM01Y.cpy                             |
+| **Record Name**   | Application COMMAREA                     |
+| **Record Length**  | Up to 2,000 bytes (WS-COMMAREA PIC X(2000)) |
+| **VSAM File**     | N/A — CICS COMMAREA (inter-program communication) |
+| **Domain**        | Cross-cutting (CICS infrastructure)      |
+| **Status**        | Copybook not yet in repo (depends on #125) |
+
+## Purpose
+
+Defines the CICS Communication Area (COMMAREA) structure used for passing data between
+programs during pseudo-conversational transactions. Every CICS program in the CardDemo
+application includes this copybook to access shared context (calling program, transaction ID)
+and program-specific data appended after the common prefix.
+
+In the CICS model, COMMAREA is the primary mechanism for maintaining state across
+pseudo-conversational interactions (where the program ends after each screen display and
+restarts when the user responds).
+
+## Field Definitions
+
+The exact field layout of COCOM01Y is not yet available in the repository (tracked in #125).
+Based on usage in COCRDSLC.cbl and COCRDUPC.cbl, the common COMMAREA prefix includes:
+
+| # | Field Name          | PIC Clause   | Offset | Length | Description                              |
+|---|---------------------|--------------|--------|--------|------------------------------------------|
+| 1 | *(common prefix)*   |              | 0      | varies | Shared COMMAREA fields defined in COCOM01Y |
+
+Each program appends its own `WS-THIS-PROGCOMMAREA` after the common prefix:
+
+**COCRDSLC (Card Detail):**
+
+| # | Field Name          | PIC Clause   | Length | Description                              |
+|---|---------------------|--------------|--------|------------------------------------------|
+| 1 | CA-FROM-PROGRAM     | PIC X(08)    | 8      | Calling program name                     |
+| 2 | CA-FROM-TRANID      | PIC X(04)    | 4      | Calling transaction ID                   |
+
+**COCRDUPC (Card Update):**
+
+| # | Field Name             | PIC Clause   | Length | Description                              |
+|---|------------------------|--------------|--------|------------------------------------------|
+| 1 | CCUP-CHANGE-ACTION     | PIC X(1)     | 1      | Change state machine flag                |
+| 2 | CCUP-OLD-DETAILS       | (group)      | 80     | Original card data for comparison        |
+| 3 | CCUP-NEW-DETAILS       | (group)      | 80     | Modified card data from user input       |
+| 4 | CARD-UPDATE-RECORD     | (group)      | 150    | Complete card record for VSAM write      |
+
+The `WS-COMMAREA` field (`PIC X(2000)`) is the raw byte buffer into which the COMMAREA content is placed.
+
+## .NET Class Mapping
+
+The CICS COMMAREA pattern is replaced entirely in the .NET architecture:
+
+| COBOL COMMAREA Concept     | .NET Replacement                          |
+|----------------------------|-------------------------------------------|
+| COMMAREA byte buffer       | HTTP request/response bodies (JSON)       |
+| Pseudo-conversational state | Stateless REST API + client-side state   |
+| CA-FROM-PROGRAM            | HTTP `Referer` header / route context     |
+| CA-FROM-TRANID             | Correlation ID / `X-Request-ID` header    |
+| CCUP-CHANGE-ACTION         | HTTP method semantics (GET = view, PUT = update) |
+| CCUP-OLD/NEW-DETAILS       | Optimistic concurrency via `RowVersion`   |
+
+No direct .NET entity maps to COCOM01Y. The concepts are distributed across:
+- **Request DTOs** (e.g., `CardUpdateRequest`)
+- **Response DTOs** (e.g., `CardDetailResponse`)
+- **HTTP infrastructure** (ASP.NET Core middleware)
+
+## EBCDIC-to-Unicode Conversion Notes
+
+COMMAREA data is relevant during parallel-run if CICS transactions are intercepted and forwarded to the .NET system. All PIC X fields use `EbcdicConverter.ConvertToUnicode()` with IBM Code Page 1143.
+
+## Referencing Programs
+
+| Program     | Usage                                    |
+|-------------|------------------------------------------|
+| COCRDLIC    | Card list — receives/sends COMMAREA for pagination state |
+| COCRDSLC    | Card detail — receives card number in COMMAREA |
+| COCRDUPC    | Card update — maintains old/new card data in COMMAREA |
+| *(all CICS programs)* | Every CICS program in the system includes COCOM01Y |
+
+## Migration Notes
+
+The COMMAREA pattern represents one of the most significant architectural differences between
+the mainframe and .NET systems:
+
+1. **State management**: CICS programs are pseudo-conversational — they terminate after each
+   screen send and must reconstruct state from COMMAREA on restart. REST APIs are stateless
+   by design, so this concern disappears.
+2. **Data serialization**: COMMAREA uses fixed-length EBCDIC byte buffers. REST APIs use
+   variable-length JSON with UTF-8 encoding.
+3. **Program linkage**: `EXEC CICS XCTL` / `LINK` with COMMAREA becomes HTTP redirects or
+   service-to-service calls.

--- a/docs-site/docs/data-structures/csusr01y-user-data.md
+++ b/docs-site/docs/data-structures/csusr01y-user-data.md
@@ -1,0 +1,74 @@
+---
+title: CSUSR01Y — User Data
+sidebar_position: 7
+---
+
+# CSUSR01Y — User Data
+
+## Overview
+
+| Attribute         | Value                                    |
+|-------------------|------------------------------------------|
+| **Copybook**      | CSUSR01Y.cpy                             |
+| **Record Name**   | Signed-on User Data                      |
+| **Record Length**  | Variable (working storage)               |
+| **VSAM File**     | N/A — CICS security context              |
+| **Domain**        | User/Security (cross-cutting)            |
+| **Status**        | Copybook not yet in repo (depends on #125) |
+
+## Purpose
+
+Defines the signed-on user data structure used across all CICS programs for authentication
+and authorization context. Contains the current user's identity information as retrieved from
+the CICS security facility (RACF/Top Secret). Every program that performs user-specific
+operations includes this copybook.
+
+## Field Definitions
+
+The exact field layout of CSUSR01Y is not yet available in the repository (tracked in #125).
+Based on standard CardDemo patterns, the typical user data structure includes:
+
+| # | Field Name          | PIC Clause   | Offset | Length | Description                              |
+|---|---------------------|--------------|--------|--------|------------------------------------------|
+| 1 | USR-USERID          | PIC X(8)     | 0      | 8      | CICS user ID (from EIBUSERID)            |
+| 2 | USR-FIRST-NAME      | PIC X(20)    | 8      | 20     | User's first name                        |
+| 3 | USR-LAST-NAME       | PIC X(20)    | 28     | 20     | User's last name                         |
+| 4 | USR-TYPE            | PIC X(1)     | 48     | 1      | User type: 'A' = admin, 'U' = regular   |
+
+**Note:** Field definitions are approximate — verify against actual copybook when available in #125.
+
+## .NET Class Mapping
+
+The CICS user data pattern is replaced by Azure AD / Azure AD B2C identity:
+
+| COBOL Concept        | .NET Replacement                          |
+|----------------------|-------------------------------------------|
+| USR-USERID           | `ClaimsPrincipal.Identity.Name` / Azure AD `oid` claim |
+| USR-FIRST-NAME       | Azure AD `given_name` claim               |
+| USR-LAST-NAME        | Azure AD `family_name` claim              |
+| USR-TYPE             | Azure AD roles / app roles                |
+| RACF/Top Secret      | Azure AD B2C (customer) / Azure AD (internal) |
+
+No direct .NET entity maps to CSUSR01Y. User identity flows through ASP.NET Core's `ClaimsPrincipal` infrastructure.
+
+## EBCDIC-to-Unicode Conversion Notes
+
+User data fields contain names that may include Swedish characters (Å, Ä, Ö). Use `EbcdicConverter.ConvertToUnicode()` with IBM Code Page 1143 if extracting user data from CICS logs or audit trails during migration.
+
+## Referencing Programs
+
+| Program     | Usage                                    |
+|-------------|------------------------------------------|
+| COCRDLIC    | Card list — user context for authorization |
+| COCRDSLC    | Card detail — user context for audit trail |
+| COCRDUPC    | Card update — user context for change authorization |
+| *(all CICS programs)* | Every program that needs user identity |
+
+## Regulatory Traceability
+
+| Regulation          | Requirement                                |
+|---------------------|--------------------------------------------|
+| GDPR Art. 5(1)(c)  | Minimize user data stored in working storage |
+| GDPR Art. 5(1)(f)  | Secure handling of user identity data      |
+| PSD2 Art. 97       | SCA — user identity for strong authentication |
+| FFFS 2014:5 Ch.6   | Audit trail — user identity for all operations |

--- a/docs-site/docs/data-structures/cvact01y-account-master.md
+++ b/docs-site/docs/data-structures/cvact01y-account-master.md
@@ -1,0 +1,81 @@
+---
+title: CVACT01Y — Account Master Record
+sidebar_position: 2
+---
+
+# CVACT01Y — Account Master Record
+
+## Overview
+
+| Attribute         | Value                                    |
+|-------------------|------------------------------------------|
+| **Copybook**      | CVACT01Y.cpy                             |
+| **Record Name**   | ACCOUNT-RECORD                           |
+| **Record Length**  | 300 bytes                                |
+| **VSAM File**     | ACCTFILE (KSDS, key = ACCT-ID)           |
+| **Domain**        | Transactions / Account Management        |
+| **Status**        | Copybook not yet in repo (depends on #125) |
+
+## Purpose
+
+Defines the account master record used across transaction processing and account management.
+Contains account identifiers, balance fields, credit limits, and cycle accumulators.
+This is the central data structure for all balance-related operations on the mainframe.
+
+## Field Definitions
+
+| # | Field Name              | PIC Clause        | Offset | Length | Description                              |
+|---|-------------------------|--------------------|--------|--------|------------------------------------------|
+| 1 | ACCT-ID                | PIC 9(11)          | 0      | 11     | Account identifier (primary key)         |
+| 2 | ACCT-ACTIVE-STATUS     | PIC X(01)          | 11     | 1      | Active status: 'A' = active, 'D' = dormant |
+| 3 | ACCT-CURR-BAL          | PIC S9(10)V99      | 12     | 12     | Current balance (signed, 2 decimal places) |
+| 4 | ACCT-CREDIT-LIMIT      | PIC S9(10)V99      | 24     | 12     | Credit limit                             |
+| 5 | ACCT-CASH-CREDIT-LIMIT | PIC S9(10)V99      | 36     | 12     | Cash advance credit limit                |
+| 6 | ACCT-CURR-CYC-CREDIT   | PIC S9(10)V99      | 48     | 12     | Current cycle credit total               |
+| 7 | ACCT-CURR-CYC-DEBIT    | PIC S9(10)V99      | 60     | 12     | Current cycle debit total                |
+| 8 | ACCT-EXPIRAION-DATE    | PIC X(10)          | 72     | 10     | Expiration date (note: typo in COBOL source) |
+| 9 | FILLER                 | PIC X(218)         | 82     | 218    | Reserved / future use                    |
+
+**Note:** Offsets are approximate — the full copybook is not yet available in the repository (tracked in issue #125). Field definitions are reconstructed from the .NET domain model `Account.cs` and EF Core configuration in `NordKreditDbContext.cs`.
+
+## .NET Class Mapping
+
+**Target class:** `NordKredit.Domain.Transactions.Account`
+
+| COBOL Field            | C# Property        | C# Type      | SQL Column Type  | Notes                                |
+|------------------------|---------------------|-------------- |------------------|--------------------------------------|
+| ACCT-ID                | Id                  | `string`      | `nvarchar(11)`   | Primary key                          |
+| ACCT-ACTIVE-STATUS     | ActiveStatus        | `string`      | `nvarchar(1)`    | 'A' or 'D'                          |
+| ACCT-CURR-BAL          | CurrentBalance      | `decimal`     | `decimal(12,2)`  | Never use float/double               |
+| ACCT-CREDIT-LIMIT      | CreditLimit         | `decimal`     | `decimal(12,2)`  |                                      |
+| ACCT-CASH-CREDIT-LIMIT | CashCreditLimit     | `decimal`     | `decimal(12,2)`  |                                      |
+| ACCT-CURR-CYC-CREDIT   | CurrentCycleCredit  | `decimal`     | `decimal(12,2)`  |                                      |
+| ACCT-CURR-CYC-DEBIT    | CurrentCycleDebit   | `decimal`     | `decimal(12,2)`  |                                      |
+| ACCT-EXPIRAION-DATE    | ExpirationDate      | `DateTime?`   | `datetime2`      | Nullable — null means never expires  |
+
+## EBCDIC-to-Unicode Conversion Notes
+
+| Field Type        | Conversion Method                          | Notes                                    |
+|-------------------|--------------------------------------------|------------------------------------------|
+| PIC X (text)      | `EbcdicConverter.ConvertToUnicode()`       | IBM Code Page 1143 (Swedish/Finnish)     |
+| PIC S9 V99 (signed decimal) | `EbcdicConverter.ConvertZonedDecimal(scale: 2)` | Sign in last byte zone nibble |
+| PIC 9 (unsigned)  | `EbcdicConverter.ConvertZonedDecimal(scale: 0)` | Unsigned zoned decimal        |
+
+If the COBOL source uses `COMP-3` for any balance fields, use `EbcdicConverter.ConvertPackedDecimal()` instead. Verify against actual copybook when available.
+
+## Referencing Programs
+
+| Program     | Usage                                    |
+|-------------|------------------------------------------|
+| CBTRN02C    | Account expiration validation (lines 414–420), balance updates during transaction posting |
+| COCRDSLC    | Referenced (commented out `*COPY CVACT01Y`) for card detail context |
+| COCRDUPC    | Referenced (commented out `*COPY CVACT01Y`) for card update context |
+| CBTRN01C    | Account lookup during transaction verification |
+
+## Regulatory Traceability
+
+| Regulation            | Requirement                              |
+|-----------------------|------------------------------------------|
+| FFFS 2014:5 Ch.4 §3  | Credit limit enforcement for risk management |
+| PSD2 Art. 97          | Account validation during SCA flows      |
+| GDPR Art. 5(1)(d)    | Accuracy of balance data during migration |

--- a/docs-site/docs/data-structures/cvact02y-card-record.md
+++ b/docs-site/docs/data-structures/cvact02y-card-record.md
@@ -1,0 +1,82 @@
+---
+title: CVACT02Y — Card Record
+sidebar_position: 3
+---
+
+# CVACT02Y — Card Record
+
+## Overview
+
+| Attribute         | Value                                    |
+|-------------------|------------------------------------------|
+| **Copybook**      | CVACT02Y.cpy                             |
+| **Record Name**   | CARD-RECORD                              |
+| **Record Length**  | 150 bytes                                |
+| **VSAM File**     | CARDDAT (KSDS, key = CARD-NUM), CARDAIX (alternate index on CARD-ACCT-ID) |
+| **Domain**        | Card Management                          |
+| **Status**        | In repo (`docs/cobol-source/cpy/CVACT02Y.cpy`) |
+
+## Purpose
+
+Defines the card entity record stored in the CARDDAT VSAM file. Contains the card number,
+linked account, CVV, cardholder name, expiration date, and active status. This is the primary
+data structure for card lifecycle management (list, view, update operations).
+
+## Field Definitions
+
+| # | Field Name              | PIC Clause   | Offset | Length | Description                              |
+|---|-------------------------|--------------|--------|--------|------------------------------------------|
+| 1 | CARD-NUM               | PIC X(16)    | 0      | 16     | Card number (primary key)                |
+| 2 | CARD-ACCT-ID           | PIC 9(11)    | 16     | 11     | Account identifier (foreign key)         |
+| 3 | CARD-CVV-CD            | PIC 9(03)    | 27     | 3      | Card verification value                  |
+| 4 | CARD-EMBOSSED-NAME     | PIC X(50)    | 30     | 50     | Cardholder name as embossed on card      |
+| 5 | CARD-EXPIRAION-DATE    | PIC X(10)    | 80     | 10     | Expiration date (YYYY-MM-DD format)      |
+| 6 | CARD-ACTIVE-STATUS     | PIC X(01)    | 90     | 1      | Status: 'Y' = active, 'N' = inactive    |
+| 7 | FILLER                 | PIC X(59)    | 91     | 59     | Reserved / padding to 150 bytes          |
+
+## .NET Class Mapping
+
+**Target class:** `NordKredit.Domain.CardManagement.Card`
+
+| COBOL Field          | C# Property      | C# Type     | SQL Column Type  | Notes                                  |
+|----------------------|-------------------|-------------|------------------|----------------------------------------|
+| CARD-NUM             | CardNumber        | `string`    | `nvarchar(16)`   | Primary key                            |
+| CARD-ACCT-ID         | AccountId         | `string`    | `nvarchar(11)`   | Foreign key to Accounts table          |
+| CARD-CVV-CD          | CvvCode           | `string`    | `nvarchar(3)`    | PCI-DSS review required for storage    |
+| CARD-EMBOSSED-NAME   | EmbossedName      | `string`    | `nvarchar(50)`   | Supports Swedish characters (Å, Ä, Ö) |
+| CARD-EXPIRAION-DATE  | ExpirationDate    | `DateOnly`  | `date`           | Parsed from COBOL string format        |
+| CARD-ACTIVE-STATUS   | ActiveStatus      | `char`      | `nchar(1)`       | 'Y' or 'N'                            |
+| *(not in COBOL)*     | RowVersion        | `byte[]`    | `rowversion`     | Optimistic concurrency (replaces COBOL field comparison) |
+
+### Design Decisions
+
+- **CARD-ACCT-ID**: COBOL uses `PIC 9(11)` (numeric), but .NET maps to `string` to preserve leading zeros in the account identifier.
+- **CARD-CVV-CD**: Stored as `string` rather than `int` to preserve leading zeros. PCI-DSS compliance review is needed post-migration to determine whether CVV storage should continue.
+- **CARD-EXPIRAION-DATE**: The COBOL field name contains a typo (`EXPIRAION` instead of `EXPIRATION`). The .NET property uses the corrected spelling.
+- **RowVersion**: Added for optimistic concurrency control, replacing the COBOL pattern of reading/comparing all fields before update (see COCRDUPC.cbl).
+
+## EBCDIC-to-Unicode Conversion Notes
+
+| Field Type        | Conversion Method                          | Notes                                    |
+|-------------------|--------------------------------------------|------------------------------------------|
+| PIC X (text)      | `EbcdicConverter.ConvertToUnicode()`       | IBM Code Page 1143 (Swedish/Finnish)     |
+| PIC 9 (zoned)     | `EbcdicConverter.ConvertZonedDecimal(scale: 0)` | Unsigned integer via zoned decimal |
+
+**Special attention:** `CARD-EMBOSSED-NAME` contains Swedish characters (Å, Ä, Ö) which require IBM Code Page 1143 for correct conversion. The target column uses `nvarchar` to preserve Unicode.
+
+## Referencing Programs
+
+| Program     | Usage                                    |
+|-------------|------------------------------------------|
+| COCRDLIC    | Card list display — reads CARDDAT via STARTBR/READNEXT |
+| COCRDSLC    | Card detail display — reads individual card by CARD-NUM |
+| COCRDUPC    | Card update — reads, modifies, and rewrites CARD-RECORD |
+
+## Regulatory Traceability
+
+| Regulation          | Requirement                                |
+|---------------------|--------------------------------------------|
+| GDPR Art. 5(1)(c)  | Data minimization — only store necessary card fields |
+| GDPR Art. 5(1)(d)  | Accuracy — cardholder name must match embossed card |
+| PSD2 Art. 97       | Strong Customer Authentication for card operations |
+| PCI-DSS            | CVV storage review required post-migration  |

--- a/docs-site/docs/data-structures/cvact03y-card-cross-reference.md
+++ b/docs-site/docs/data-structures/cvact03y-card-cross-reference.md
@@ -1,0 +1,75 @@
+---
+title: CVACT03Y — Card Cross-Reference
+sidebar_position: 4
+---
+
+# CVACT03Y — Card Cross-Reference
+
+## Overview
+
+| Attribute         | Value                                    |
+|-------------------|------------------------------------------|
+| **Copybook**      | CVACT03Y.cpy                             |
+| **Record Name**   | CARD-XREF-RECORD                         |
+| **Record Length**  | 50 bytes                                 |
+| **VSAM File**     | CXREF (KSDS, key = XREF-CARD-NUM)       |
+| **Domain**        | Card Management / Transactions           |
+| **Status**        | In repo (`docs/cobol-source/cpy/CVACT03Y.cpy`) |
+
+## Purpose
+
+Establishes the three-way relationship between cards, customers, and accounts.
+This cross-reference is used during transaction verification (CBTRN01C) to resolve a card number
+to its owning account and customer. It is a lookup-only structure — updates are managed through
+card issuance processes.
+
+## Field Definitions
+
+| # | Field Name       | PIC Clause   | Offset | Length | Description                              |
+|---|------------------|--------------|--------|--------|------------------------------------------|
+| 1 | XREF-CARD-NUM   | PIC X(16)    | 0      | 16     | Card number (primary key, FK to CARDDAT) |
+| 2 | XREF-CUST-ID    | PIC 9(09)    | 16     | 9      | Customer identifier                      |
+| 3 | XREF-ACCT-ID    | PIC 9(11)    | 25     | 11     | Account identifier (FK to ACCTFILE)      |
+| 4 | FILLER          | PIC X(14)    | 36     | 14     | Reserved / padding to 50 bytes           |
+
+## .NET Class Mapping
+
+**Target classes:**
+- `NordKredit.Domain.CardManagement.CardCrossReference`
+- `NordKredit.Domain.Transactions.CardCrossReference`
+
+Both domains define their own cross-reference class with the same fields, following domain isolation principles.
+
+| COBOL Field    | C# Property  | C# Type   | SQL Column Type  | Notes                          |
+|----------------|---------------|-----------|------------------|--------------------------------|
+| XREF-CARD-NUM  | CardNumber   | `string`  | `nvarchar(16)`   | Primary key                    |
+| XREF-CUST-ID   | CustomerId   | `int`     | `int`            | Numeric customer ID            |
+| XREF-ACCT-ID   | AccountId    | `string`  | `nvarchar(11)`   | Preserves leading zeros        |
+
+### Design Decisions
+
+- **Dual domain classes**: Both `CardManagement` and `Transactions` domains have their own `CardCrossReference` entity to maintain bounded context isolation. They map to the same database table (`CardCrossReferences`).
+- **XREF-CUST-ID**: Mapped to `int` (not `string`) because customer IDs do not have meaningful leading zeros in this system.
+
+## EBCDIC-to-Unicode Conversion Notes
+
+| Field Type        | Conversion Method                          | Notes                                    |
+|-------------------|--------------------------------------------|------------------------------------------|
+| PIC X (text)      | `EbcdicConverter.ConvertToUnicode()`       | IBM Code Page 1143 (Swedish/Finnish)     |
+| PIC 9 (zoned)     | `EbcdicConverter.ConvertZonedDecimal(scale: 0)` | Unsigned integer via zoned decimal |
+
+## Referencing Programs
+
+| Program     | Usage                                    |
+|-------------|------------------------------------------|
+| CBTRN01C    | Card-to-account lookup during transaction verification |
+| CBTRN02C    | Account resolution for transaction posting |
+| COCRDSLC    | Referenced (commented out) for card detail context |
+| COCRDUPC    | Referenced (commented out) for card update context |
+
+## Regulatory Traceability
+
+| Regulation          | Requirement                                |
+|---------------------|--------------------------------------------|
+| GDPR Art. 5(1)(c)  | Data minimization — only card/customer/account linkage |
+| AML/KYC             | Card-to-customer linkage for suspicious activity monitoring |

--- a/docs-site/docs/data-structures/cvcrd01y-card-work-area.md
+++ b/docs-site/docs/data-structures/cvcrd01y-card-work-area.md
@@ -1,0 +1,86 @@
+---
+title: CVCRD01Y — Card Work Area
+sidebar_position: 5
+---
+
+# CVCRD01Y — Card Work Area
+
+## Overview
+
+| Attribute         | Value                                    |
+|-------------------|------------------------------------------|
+| **Copybook**      | CVCRD01Y.cpy                             |
+| **Record Name**   | CC-WORK-AREAS                            |
+| **Record Length**  | Variable (working storage, not a file record) |
+| **VSAM File**     | N/A — working storage only               |
+| **Domain**        | Card Management (CICS UI infrastructure) |
+| **Status**        | In repo (`docs/cobol-source/cpy/CVCRD01Y.cpy`) |
+
+## Purpose
+
+Defines common working storage areas shared across card management CICS programs.
+Contains the AID key handler (terminal keyboard input), navigation control fields
+(next program, next map), message buffers, and reusable account/card/customer ID fields.
+This copybook is UI infrastructure for the CICS terminal interface — it does not represent
+a persistent data record.
+
+## Field Definitions
+
+| # | Field Name          | PIC Clause   | Offset | Length | Description                              |
+|---|---------------------|--------------|--------|--------|------------------------------------------|
+| 1 | CCARD-AID           | PIC X(5)     | 0      | 5      | Terminal AID key value                   |
+|   | *88 CCARD-AID-ENTER*  |            |        |        | Value 'ENTER' — enter key pressed        |
+|   | *88 CCARD-AID-CLEAR*  |            |        |        | Value 'CLEAR' — clear key pressed        |
+|   | *88 CCARD-AID-PA1*    |            |        |        | Value 'PA1  ' — PA1 key                 |
+|   | *88 CCARD-AID-PA2*    |            |        |        | Value 'PA2  ' — PA2 key                 |
+|   | *88 CCARD-AID-PFK01–PFK12* |       |        |        | Values 'PFK01'–'PFK12' — function keys  |
+| 2 | CCARD-NEXT-PROG     | PIC X(8)     | 5      | 8      | Next program to invoke via XCTL          |
+| 3 | CCARD-NEXT-MAPSET   | PIC X(7)     | 13     | 7      | Next BMS mapset name                     |
+| 4 | CCARD-NEXT-MAP      | PIC X(7)     | 20     | 7      | Next BMS map name                        |
+| 5 | CCARD-ERROR-MSG     | PIC X(75)    | 27     | 75     | Error message buffer                     |
+| 6 | CCARD-RETURN-MSG    | PIC X(75)    | 102    | 75     | Return/status message buffer             |
+|   | *88 CCARD-RETURN-MSG-OFF* |        |        |        | Value LOW-VALUES — no message            |
+| 7 | CC-ACCT-ID          | PIC X(11)    | 177    | 11     | Account ID (alphanumeric form)           |
+|   | CC-ACCT-ID-N        | *REDEFINES* CC-ACCT-ID PIC 9(11) |  |  | Account ID (numeric form)          |
+| 8 | CC-CARD-NUM         | PIC X(16)    | 188    | 16     | Card number (alphanumeric form)          |
+|   | CC-CARD-NUM-N       | *REDEFINES* CC-CARD-NUM PIC 9(16) |  |  | Card number (numeric form)         |
+| 9 | CC-CUST-ID          | PIC X(09)    | 204    | 9      | Customer ID (alphanumeric form)          |
+|   | CC-CUST-ID-N        | *REDEFINES* CC-CUST-ID PIC 9(9)  |  |  | Customer ID (numeric form)         |
+
+## .NET Class Mapping
+
+This copybook does **not** map to a persistent .NET entity. It represents CICS terminal UI infrastructure
+that is replaced by the REST API layer (`NordKredit.Api`).
+
+| COBOL Concept           | .NET Replacement                          |
+|-------------------------|-------------------------------------------|
+| CCARD-AID (key handler) | HTTP request method + route               |
+| CCARD-NEXT-PROG (XCTL) | Controller action routing                 |
+| CCARD-NEXT-MAPSET/MAP   | Razor/Blazor views or SPA routing         |
+| CCARD-ERROR-MSG         | `ProblemDetails` error response            |
+| CCARD-RETURN-MSG        | HTTP response body / success message       |
+| CC-ACCT-ID / CC-CARD-NUM / CC-CUST-ID | Request DTO properties    |
+
+## EBCDIC-to-Unicode Conversion Notes
+
+Since this is working storage (not persisted data), EBCDIC conversion is only relevant if
+COMMAREA data is exchanged during parallel-run. All PIC X fields use `EbcdicConverter.ConvertToUnicode()`
+with IBM Code Page 1143.
+
+## Referencing Programs
+
+| Program     | Usage                                    |
+|-------------|------------------------------------------|
+| COCRDLIC    | Card list — AID key handling, navigation, card/account IDs |
+| COCRDSLC    | Card detail — AID key handling, card lookup parameters |
+| COCRDUPC    | Card update — AID key handling, card/account/customer context |
+
+## Migration Notes
+
+The 88-level condition names (e.g., `CCARD-AID-ENTER`) demonstrate COBOL's built-in pattern for
+named constants / enums. In .NET, equivalent patterns include:
+- `enum CicsAidKey { Enter, Clear, PA1, PA2, PFK01, ... }` for the AID keys
+- Constants or configuration for program names and mapset names
+
+Since the CICS UI is being replaced entirely by a REST API, this copybook's fields are not directly
+migrated. The concepts are absorbed into the API controller layer.

--- a/docs-site/docs/data-structures/cvtra01y-transaction-category-balance.md
+++ b/docs-site/docs/data-structures/cvtra01y-transaction-category-balance.md
@@ -1,0 +1,76 @@
+---
+title: CVTRA01Y — Transaction Category Balance
+sidebar_position: 8
+---
+
+# CVTRA01Y — Transaction Category Balance
+
+## Overview
+
+| Attribute         | Value                                    |
+|-------------------|------------------------------------------|
+| **Copybook**      | CVTRA01Y.cpy                             |
+| **Record Name**   | TRAN-CAT-BAL-RECORD                     |
+| **Record Length**  | 50 bytes                                 |
+| **VSAM File**     | TCATBALF (KSDS, composite key = TRAN-CAT-KEY) |
+| **Domain**        | Transactions                             |
+| **Status**        | Copybook not yet in repo (depends on #125) |
+
+## Purpose
+
+Tracks the accumulated balance for each account/transaction-type/category combination.
+Used by batch posting (CBTRN02C) to maintain running totals for transaction categorization
+and by reporting programs for category-level balance queries. The composite key structure
+enables efficient lookups by account and transaction classification.
+
+## Field Definitions
+
+| # | Field Name          | PIC Clause       | Offset | Length | Description                              |
+|---|---------------------|------------------|--------|--------|------------------------------------------|
+| 1 | TRANCAT-ACCT-ID    | PIC 9(11)        | 0      | 11     | Account identifier                       |
+| 2 | TRANCAT-TYPE-CD    | PIC X(02)        | 11     | 2      | Transaction type code (e.g., "DB", "CR") |
+| 3 | TRANCAT-CD         | PIC 9(04)        | 13     | 4      | Category code (e.g., 1001–9999)          |
+| 4 | TRAN-CAT-BAL       | PIC S9(09)V99    | 17     | 11     | Category balance (signed, 2 decimal places) |
+| 5 | FILLER             | PIC X(22)        | 28     | 22     | Reserved / padding to 50 bytes           |
+
+**Composite key:** `TRAN-CAT-KEY` = `TRANCAT-ACCT-ID` + `TRANCAT-TYPE-CD` + `TRANCAT-CD` (17 bytes)
+
+**Note:** Offsets are reconstructed from the .NET domain model. Verify against actual copybook when available.
+
+## .NET Class Mapping
+
+**Target class:** `NordKredit.Domain.Transactions.TransactionCategoryBalance`
+
+| COBOL Field        | C# Property  | C# Type   | SQL Column Type  | Notes                          |
+|--------------------|---------------|-----------|------------------|--------------------------------|
+| TRANCAT-ACCT-ID    | AccountId    | `string`  | `nvarchar(11)`   | Composite PK part 1           |
+| TRANCAT-TYPE-CD    | TypeCode     | `string`  | `nvarchar(2)`    | Composite PK part 2           |
+| TRANCAT-CD         | CategoryCode | `int`     | `int`            | Composite PK part 3           |
+| TRAN-CAT-BAL       | Balance      | `decimal` | `decimal(11,2)`  | Never use float/double         |
+
+### Design Decisions
+
+- **Composite key**: EF Core maps `HasKey(e => new { e.AccountId, e.TypeCode, e.CategoryCode })` — preserves the COBOL VSAM key structure exactly.
+- **TRAN-CAT-BAL**: Uses `decimal(11,2)` matching the COBOL `PIC S9(09)V99` precision (9 integer digits + 2 decimal).
+
+## EBCDIC-to-Unicode Conversion Notes
+
+| Field Type        | Conversion Method                          | Notes                                    |
+|-------------------|--------------------------------------------|------------------------------------------|
+| PIC X (text)      | `EbcdicConverter.ConvertToUnicode()`       | IBM Code Page 1143 (Swedish/Finnish)     |
+| PIC 9 (zoned)     | `EbcdicConverter.ConvertZonedDecimal(scale: 0)` | Unsigned integer                  |
+| PIC S9 V99        | `EbcdicConverter.ConvertZonedDecimal(scale: 2)` | Signed decimal with 2 places     |
+
+## Referencing Programs
+
+| Program     | Usage                                    |
+|-------------|------------------------------------------|
+| CBTRN02C    | Updates category balances during transaction posting |
+| CBTRN03C    | Reads category balances for transaction reporting |
+
+## Regulatory Traceability
+
+| Regulation          | Requirement                                |
+|---------------------|--------------------------------------------|
+| FSA FFFS 2014:5 Ch.7 | Financial reporting — accurate category-level balances |
+| PSD2 Art. 94        | Record keeping — transaction classification |

--- a/docs-site/docs/data-structures/cvtra03y-transaction-type.md
+++ b/docs-site/docs/data-structures/cvtra03y-transaction-type.md
@@ -1,0 +1,62 @@
+---
+title: CVTRA03Y — Transaction Type
+sidebar_position: 9
+---
+
+# CVTRA03Y — Transaction Type
+
+## Overview
+
+| Attribute         | Value                                    |
+|-------------------|------------------------------------------|
+| **Copybook**      | CVTRA03Y.cpy                             |
+| **Record Name**   | TRAN-TYPE-RECORD                         |
+| **Record Length**  | ~52 bytes                                |
+| **VSAM File**     | TRANTYPE (KSDS, key = TRAN-TYPE)         |
+| **Domain**        | Transactions                             |
+| **Status**        | Copybook not yet in repo (depends on #125) |
+
+## Purpose
+
+Lookup table mapping transaction type codes to human-readable descriptions.
+Used by reporting programs (CBTRN03C) to enrich transaction reports with type descriptions.
+Type codes such as "DB" (debit) and "CR" (credit) are the primary classification for all transactions.
+
+## Field Definitions
+
+| # | Field Name          | PIC Clause   | Offset | Length | Description                              |
+|---|---------------------|--------------|--------|--------|------------------------------------------|
+| 1 | TRAN-TYPE           | PIC X(02)    | 0      | 2      | Transaction type code (primary key)      |
+| 2 | TRAN-TYPE-DESC      | PIC X(50)    | 2      | 50     | Type description                         |
+
+**Note:** Field definitions are reconstructed from the .NET domain model. Verify against actual copybook when available.
+
+## .NET Class Mapping
+
+**Target class:** `NordKredit.Domain.Transactions.TransactionType`
+
+| COBOL Field      | C# Property  | C# Type   | SQL Column Type  | Notes                          |
+|------------------|---------------|-----------|------------------|--------------------------------|
+| TRAN-TYPE        | TypeCode     | `string`  | `nvarchar(2)`    | Primary key                    |
+| TRAN-TYPE-DESC   | Description  | `string`  | `nvarchar(50)`   |                                |
+
+## EBCDIC-to-Unicode Conversion Notes
+
+| Field Type        | Conversion Method                          | Notes                                    |
+|-------------------|--------------------------------------------|------------------------------------------|
+| PIC X (text)      | `EbcdicConverter.ConvertToUnicode()`       | IBM Code Page 1143 (Swedish/Finnish)     |
+
+Both fields are text — straightforward EBCDIC-to-Unicode conversion. Description field may contain Swedish characters in localized deployments.
+
+## Referencing Programs
+
+| Program     | Usage                                    |
+|-------------|------------------------------------------|
+| CBTRN03C    | Transaction detail report — enriches output with type descriptions |
+
+## Regulatory Traceability
+
+| Regulation            | Requirement                              |
+|-----------------------|------------------------------------------|
+| FSA FFFS 2014:5 Ch.7  | Financial reporting — clear transaction type classification |
+| PSD2 Art. 94          | Accessibility — human-readable transaction information |

--- a/docs-site/docs/data-structures/cvtra04y-transaction-category.md
+++ b/docs-site/docs/data-structures/cvtra04y-transaction-category.md
@@ -1,0 +1,70 @@
+---
+title: CVTRA04Y — Transaction Category
+sidebar_position: 10
+---
+
+# CVTRA04Y — Transaction Category
+
+## Overview
+
+| Attribute         | Value                                    |
+|-------------------|------------------------------------------|
+| **Copybook**      | CVTRA04Y.cpy                             |
+| **Record Name**   | TRAN-CAT-RECORD                          |
+| **Record Length**  | ~56 bytes                                |
+| **VSAM File**     | TRANCATG (KSDS, composite key = TRAN-TYPE + TRAN-CAT-CD) |
+| **Domain**        | Transactions                             |
+| **Status**        | Copybook not yet in repo (depends on #125) |
+
+## Purpose
+
+Lookup table mapping the combination of transaction type code and category code to
+a human-readable description. Provides finer-grained classification than the type code alone
+(e.g., type "DB" + category 1001 = "Retail Purchase"). Used by reporting programs for
+transaction enrichment.
+
+## Field Definitions
+
+| # | Field Name          | PIC Clause   | Offset | Length | Description                              |
+|---|---------------------|--------------|--------|--------|------------------------------------------|
+| 1 | TRAN-TYPE           | PIC X(02)    | 0      | 2      | Transaction type code (composite PK part 1) |
+| 2 | TRAN-CAT-CD         | PIC 9(04)    | 2      | 4      | Category code (composite PK part 2)      |
+| 3 | TRAN-CAT-DESC       | PIC X(50)    | 6      | 50     | Category description                     |
+
+**Composite key:** `TRAN-TYPE` + `TRAN-CAT-CD` (6 bytes)
+
+**Note:** Field definitions are reconstructed from the .NET domain model. Verify against actual copybook when available.
+
+## .NET Class Mapping
+
+**Target class:** `NordKredit.Domain.Transactions.TransactionCategory`
+
+| COBOL Field      | C# Property  | C# Type   | SQL Column Type  | Notes                          |
+|------------------|---------------|-----------|------------------|--------------------------------|
+| TRAN-TYPE        | TypeCode     | `string`  | `nvarchar(2)`    | Composite PK part 1           |
+| TRAN-CAT-CD      | CategoryCode | `int`     | `int`            | Composite PK part 2           |
+| TRAN-CAT-DESC    | Description  | `string`  | `nvarchar(50)`   |                                |
+
+### Design Decisions
+
+- **TRAN-CAT-CD**: Mapped from `PIC 9(04)` (4-digit numeric string) to `int` since category codes are pure numeric identifiers without meaningful leading zeros.
+
+## EBCDIC-to-Unicode Conversion Notes
+
+| Field Type        | Conversion Method                          | Notes                                    |
+|-------------------|--------------------------------------------|------------------------------------------|
+| PIC X (text)      | `EbcdicConverter.ConvertToUnicode()`       | IBM Code Page 1143 (Swedish/Finnish)     |
+| PIC 9 (zoned)     | `EbcdicConverter.ConvertZonedDecimal(scale: 0)` | Unsigned integer                  |
+
+## Referencing Programs
+
+| Program     | Usage                                    |
+|-------------|------------------------------------------|
+| CBTRN03C    | Transaction detail report — enriches output with category descriptions |
+
+## Regulatory Traceability
+
+| Regulation            | Requirement                              |
+|-----------------------|------------------------------------------|
+| FSA FFFS 2014:5 Ch.7  | Financial reporting — granular transaction classification |
+| PSD2 Art. 94          | Accessibility — detailed transaction categorization |

--- a/docs-site/docs/data-structures/cvtra05y-transaction-record.md
+++ b/docs-site/docs/data-structures/cvtra05y-transaction-record.md
@@ -1,0 +1,98 @@
+---
+title: CVTRA05Y — Transaction Record
+sidebar_position: 11
+---
+
+# CVTRA05Y — Transaction Record
+
+## Overview
+
+| Attribute         | Value                                    |
+|-------------------|------------------------------------------|
+| **Copybook**      | CVTRA05Y.cpy                             |
+| **Record Name**   | TRAN-RECORD                              |
+| **Record Length**  | 350 bytes                                |
+| **VSAM File**     | TRANSACT (KSDS, key = TRAN-ID)           |
+| **Domain**        | Transactions                             |
+| **Status**        | Copybook not yet in repo (depends on #125) |
+
+## Purpose
+
+Defines the posted transaction record — the final, committed state of a transaction after
+it passes all validation checks. Contains transaction identifiers, classification codes,
+monetary amount, merchant information, card linkage, and timestamps. This is the primary
+transaction data structure and the target of the daily batch posting process (CBTRN02C).
+
+## Field Definitions
+
+| # | Field Name            | PIC Clause       | Offset | Length | Description                              |
+|---|-----------------------|------------------|--------|--------|------------------------------------------|
+| 1 | TRAN-ID              | PIC X(16)        | 0      | 16     | Transaction ID (primary key)             |
+| 2 | TRAN-TYPE-CD         | PIC X(02)        | 16     | 2      | Type code (FK to TRANTYPE: "DB", "CR")   |
+| 3 | TRAN-CAT-CD          | PIC 9(04)        | 18     | 4      | Category code (FK to TRANCATG: 1001–9999)|
+| 4 | TRAN-SOURCE          | PIC X(10)        | 22     | 10     | Source system ("ONLINE", "BATCH")        |
+| 5 | TRAN-DESC            | PIC X(100)       | 32     | 100    | Transaction description                  |
+| 6 | TRAN-AMT             | PIC S9(09)V99    | 132    | 11     | Amount (signed, 2 decimal places)        |
+| 7 | TRAN-MERCHANT-ID     | PIC 9(09)        | 143    | 9      | Merchant identifier                      |
+| 8 | TRAN-MERCHANT-NAME   | PIC X(50)        | 152    | 50     | Merchant name                            |
+| 9 | TRAN-MERCHANT-CITY   | PIC X(50)        | 202    | 50     | Merchant city                            |
+| 10| TRAN-MERCHANT-ZIP    | PIC X(10)        | 252    | 10     | Merchant postal code                     |
+| 11| TRAN-CARD-NUM        | PIC X(16)        | 262    | 16     | Card number (FK to CARDDAT)              |
+| 12| TRAN-ORIG-TS         | PIC X(26)        | 278    | 26     | Origination timestamp                    |
+| 13| TRAN-PROC-TS         | PIC X(26)        | 304    | 26     | Processing timestamp                     |
+| 14| FILLER               | PIC X(20)        | 330    | 20     | Reserved / padding to 350 bytes          |
+
+**Note:** Offsets are reconstructed from field lengths. Verify against actual copybook when available.
+
+## .NET Class Mapping
+
+**Target class:** `NordKredit.Domain.Transactions.Transaction`
+
+| COBOL Field          | C# Property            | C# Type      | SQL Column Type  | Notes                              |
+|----------------------|-------------------------|--------------|------------------|------------------------------------|
+| TRAN-ID              | Id                     | `string`     | `nvarchar(16)`   | Primary key                        |
+| TRAN-TYPE-CD         | TypeCode               | `string`     | `nvarchar(2)`    |                                    |
+| TRAN-CAT-CD          | CategoryCode           | `int`        | `int`            |                                    |
+| TRAN-SOURCE          | Source                 | `string`     | `nvarchar(10)`   |                                    |
+| TRAN-DESC            | Description            | `string`     | `nvarchar(100)`  |                                    |
+| TRAN-AMT             | Amount                 | `decimal`    | `decimal(11,2)`  | Never use float/double             |
+| TRAN-MERCHANT-ID     | MerchantId             | `int`        | `int`            |                                    |
+| TRAN-MERCHANT-NAME   | MerchantName           | `string`     | `nvarchar(50)`   |                                    |
+| TRAN-MERCHANT-CITY   | MerchantCity           | `string`     | `nvarchar(50)`   |                                    |
+| TRAN-MERCHANT-ZIP    | MerchantZip            | `string`     | `nvarchar(10)`   |                                    |
+| TRAN-CARD-NUM        | CardNumber             | `string`     | `nvarchar(16)`   | Indexed for card-based queries     |
+| TRAN-ORIG-TS         | OriginationTimestamp   | `DateTime`   | `datetime2`      | Parsed from COBOL PIC X(26)        |
+| TRAN-PROC-TS         | ProcessingTimestamp    | `DateTime`   | `datetime2`      | Parsed from COBOL PIC X(26)        |
+
+### Design Decisions
+
+- **Timestamps**: COBOL stores timestamps as `PIC X(26)` strings (format: `YYYY-MM-DD-HH.MM.SS.FFFFFF`). .NET maps to `DateTime` with parsing during data migration.
+- **TRAN-AMT**: `decimal(11,2)` exactly matches `PIC S9(09)V99` — 9 integer digits + 2 implied decimal places.
+- **CardNumber index**: An index on `CardNumber` replaces the VSAM alternate index for transaction lookups by card.
+
+## EBCDIC-to-Unicode Conversion Notes
+
+| Field Type        | Conversion Method                          | Notes                                    |
+|-------------------|--------------------------------------------|------------------------------------------|
+| PIC X (text)      | `EbcdicConverter.ConvertToUnicode()`       | IBM Code Page 1143 (Swedish/Finnish)     |
+| PIC 9 (zoned)     | `EbcdicConverter.ConvertZonedDecimal(scale: 0)` | Unsigned integer                  |
+| PIC S9 V99        | `EbcdicConverter.ConvertZonedDecimal(scale: 2)` | Signed decimal with 2 places     |
+| PIC X(26) timestamp | `EbcdicConverter.ConvertToUnicode()` then `DateTime.ParseExact()` | Two-step conversion |
+
+**Special attention:** Merchant names and descriptions may contain Swedish characters (Å, Ä, Ö) and must use Code Page 1143 for correct conversion.
+
+## Referencing Programs
+
+| Program     | Usage                                    |
+|-------------|------------------------------------------|
+| CBTRN02C    | Transaction posting — writes TRAN-RECORD to TRANSACT file |
+| CBTRN03C    | Transaction reporting — reads and enriches with type/category descriptions |
+
+## Regulatory Traceability
+
+| Regulation            | Requirement                              |
+|-----------------------|------------------------------------------|
+| PSD2 Art. 94          | Record keeping — complete transaction audit trail |
+| FSA FFFS 2014:5 Ch.7  | Financial reporting — accurate transaction records |
+| AML/KYC               | Transaction monitoring — merchant and amount data |
+| GDPR Art. 5(1)(d)    | Data accuracy during migration            |

--- a/docs-site/docs/data-structures/cvtra06y-daily-transaction.md
+++ b/docs-site/docs/data-structures/cvtra06y-daily-transaction.md
@@ -1,0 +1,98 @@
+---
+title: CVTRA06Y — Daily Transaction
+sidebar_position: 12
+---
+
+# CVTRA06Y — Daily Transaction
+
+## Overview
+
+| Attribute         | Value                                    |
+|-------------------|------------------------------------------|
+| **Copybook**      | CVTRA06Y.cpy                             |
+| **Record Name**   | DALYTRAN-RECORD                          |
+| **Record Length**  | 350 bytes                                |
+| **VSAM File**     | DALYTRAN (sequential daily input file)   |
+| **Domain**        | Transactions (batch processing)          |
+| **Status**        | Copybook not yet in repo (depends on #125) |
+
+## Purpose
+
+Defines the daily transaction input record — unposted transactions received from external
+systems (card networks, online banking) for batch processing. Has the same field layout as
+the posted Transaction record (CVTRA05Y) but is sourced from a sequential daily input file
+rather than the VSAM transaction store. Processed by the nightly batch cycle: verified by
+CBTRN01C, then posted by CBTRN02C (or rejected to DailyRejects).
+
+## Field Definitions
+
+| # | Field Name              | PIC Clause       | Offset | Length | Description                              |
+|---|-------------------------|------------------|--------|--------|------------------------------------------|
+| 1 | DALYTRAN-ID            | PIC X(16)        | 0      | 16     | Transaction ID                           |
+| 2 | DALYTRAN-TYPE-CD       | PIC X(02)        | 16     | 2      | Type code ("DB", "CR")                   |
+| 3 | DALYTRAN-CAT-CD        | PIC 9(04)        | 18     | 4      | Category code (1001–9999)                |
+| 4 | DALYTRAN-SOURCE        | PIC X(10)        | 22     | 10     | Source system                            |
+| 5 | DALYTRAN-DESC          | PIC X(100)       | 32     | 100    | Transaction description                  |
+| 6 | DALYTRAN-AMT           | PIC S9(09)V99    | 132    | 11     | Amount (signed, 2 decimal places)        |
+| 7 | DALYTRAN-MERCHANT-ID   | PIC 9(09)        | 143    | 9      | Merchant identifier                      |
+| 8 | DALYTRAN-MERCHANT-NAME | PIC X(50)        | 152    | 50     | Merchant name                            |
+| 9 | DALYTRAN-MERCHANT-CITY | PIC X(50)        | 202    | 50     | Merchant city                            |
+| 10| DALYTRAN-MERCHANT-ZIP  | PIC X(10)        | 252    | 10     | Merchant postal code                     |
+| 11| DALYTRAN-CARD-NUM      | PIC X(16)        | 262    | 16     | Card number                              |
+| 12| DALYTRAN-ORIG-TS       | PIC X(26)        | 278    | 26     | Origination timestamp                    |
+| 13| DALYTRAN-PROC-TS       | PIC X(26)        | 304    | 26     | Processing timestamp                     |
+| 14| FILLER                 | PIC X(20)        | 330    | 20     | Reserved / padding to 350 bytes          |
+
+**Note:** Field layout mirrors CVTRA05Y (TRAN-RECORD) with `DALYTRAN-` prefix instead of `TRAN-`.
+
+## .NET Class Mapping
+
+**Target class:** `NordKredit.Domain.Transactions.DailyTransaction`
+
+| COBOL Field             | C# Property            | C# Type      | SQL Column Type  | Notes                              |
+|-------------------------|-------------------------|--------------|------------------|------------------------------------|
+| DALYTRAN-ID             | Id                     | `string`     | `nvarchar(16)`   | Primary key                        |
+| DALYTRAN-TYPE-CD        | TypeCode               | `string`     | `nvarchar(2)`    |                                    |
+| DALYTRAN-CAT-CD         | CategoryCode           | `int`        | `int`            |                                    |
+| DALYTRAN-SOURCE         | Source                 | `string`     | `nvarchar(10)`   |                                    |
+| DALYTRAN-DESC           | Description            | `string`     | `nvarchar(100)`  |                                    |
+| DALYTRAN-AMT            | Amount                 | `decimal`    | `decimal(11,2)`  | Never use float/double             |
+| DALYTRAN-MERCHANT-ID    | MerchantId             | `int`        | `int`            |                                    |
+| DALYTRAN-MERCHANT-NAME  | MerchantName           | `string`     | `nvarchar(50)`   |                                    |
+| DALYTRAN-MERCHANT-CITY  | MerchantCity           | `string`     | `nvarchar(50)`   |                                    |
+| DALYTRAN-MERCHANT-ZIP   | MerchantZip            | `string`     | `nvarchar(10)`   |                                    |
+| DALYTRAN-CARD-NUM       | CardNumber             | `string`     | `nvarchar(16)`   | Indexed for card-based queries     |
+| DALYTRAN-ORIG-TS        | OriginationTimestamp   | `DateTime`   | `datetime2`      |                                    |
+| DALYTRAN-PROC-TS        | ProcessingTimestamp    | `DateTime`   | `datetime2`      |                                    |
+
+### Design Decisions
+
+- **Same schema as Transaction**: The DailyTransaction table mirrors the Transaction table schema. In COBOL, both copybooks share the same layout with different field prefixes. In .NET, both classes have identical properties but are separate entities for domain clarity.
+- **Batch lifecycle**: Daily transactions are input → verified (CBTRN01C) → posted as Transactions (CBTRN02C) or rejected as DailyRejects. In .NET, this maps to an Azure Function timer trigger processing the DailyTransactions table.
+
+## EBCDIC-to-Unicode Conversion Notes
+
+Same conversion rules as CVTRA05Y (Transaction Record):
+
+| Field Type        | Conversion Method                          | Notes                                    |
+|-------------------|--------------------------------------------|------------------------------------------|
+| PIC X (text)      | `EbcdicConverter.ConvertToUnicode()`       | IBM Code Page 1143 (Swedish/Finnish)     |
+| PIC 9 (zoned)     | `EbcdicConverter.ConvertZonedDecimal(scale: 0)` | Unsigned integer                  |
+| PIC S9 V99        | `EbcdicConverter.ConvertZonedDecimal(scale: 2)` | Signed decimal with 2 places     |
+| PIC X(26) timestamp | `EbcdicConverter.ConvertToUnicode()` then `DateTime.ParseExact()` | Two-step conversion |
+
+## Referencing Programs
+
+| Program     | Usage                                    |
+|-------------|------------------------------------------|
+| CBTRN01C    | Verification — validates card, cross-reference, account for each daily transaction |
+| CBTRN02C    | Posting — reads verified daily transactions, posts to TRANSACT file, rejects invalid ones |
+
+## Regulatory Traceability
+
+| Regulation            | Requirement                              |
+|-----------------------|------------------------------------------|
+| PSD2 Art. 97          | SCA validation during transaction verification |
+| FFFS 2014:5 Ch.4 §3   | Credit risk checks before posting        |
+| EBA Guidelines        | Creditworthiness assessment during posting |
+| GDPR Art. 5(1)(d)    | Data accuracy of incoming transaction data |

--- a/docs-site/docs/data-structures/index.md
+++ b/docs-site/docs/data-structures/index.md
@@ -5,16 +5,78 @@ sidebar_position: 1
 
 # Data Structures
 
-COBOL copybook definitions and their mapped .NET equivalents.
+COBOL copybook definitions and their mapped .NET equivalents for the NordKredit core banking migration.
 
-## Status
+## Overview
 
-No data structures have been documented yet. Copybook mappings will be added as each domain is analyzed.
+The NordKredit mainframe system uses approximately 300 COBOL copybooks to define data contracts
+across all domains. This section documents the key copybooks that define the primary data structures
+for the domains currently in scope (Card Management, Transactions, Account Management).
 
-## Expected Coverage
+Each copybook document includes:
+- **Field definitions** — COBOL PIC clauses, offsets, and lengths
+- **.NET class mapping** — target C# types and SQL column types
+- **EBCDIC-to-Unicode conversion** — field-specific conversion methods using `EbcdicConverter`
+- **Referencing programs** — COBOL programs that include each copybook
+- **Regulatory traceability** — applicable FSA, PSD2, GDPR, and AML/KYC requirements
 
-- COBOL copybook field definitions
-- .NET class/record mappings
-- EBCDIC-to-Unicode conversion rules
-- Field-level validation constraints
-- Db2-to-Azure SQL schema mappings
+## Copybook Index
+
+### Account Domain
+
+| Copybook   | Record Name         | Length | VSAM File | .NET Class | Status |
+|------------|---------------------|--------|-----------|------------|--------|
+| [CVACT01Y](./cvact01y-account-master) | ACCOUNT-RECORD | 300 bytes | ACCTFILE | `Account` | Reconstructed from .NET model |
+
+### Card Management Domain
+
+| Copybook   | Record Name         | Length | VSAM File | .NET Class | Status |
+|------------|---------------------|--------|-----------|------------|--------|
+| [CVACT02Y](./cvact02y-card-record) | CARD-RECORD | 150 bytes | CARDDAT | `Card` | In repo |
+| [CVACT03Y](./cvact03y-card-cross-reference) | CARD-XREF-RECORD | 50 bytes | CXREF | `CardCrossReference` | In repo |
+| [CVCRD01Y](./cvcrd01y-card-work-area) | CC-WORK-AREAS | Variable | N/A (working storage) | *(no direct mapping)* | In repo |
+
+### Transaction Domain
+
+| Copybook   | Record Name         | Length | VSAM File | .NET Class | Status |
+|------------|---------------------|--------|-----------|------------|--------|
+| [CVTRA01Y](./cvtra01y-transaction-category-balance) | TRAN-CAT-BAL-RECORD | 50 bytes | TCATBALF | `TransactionCategoryBalance` | Reconstructed from .NET model |
+| [CVTRA03Y](./cvtra03y-transaction-type) | TRAN-TYPE-RECORD | ~52 bytes | TRANTYPE | `TransactionType` | Reconstructed from .NET model |
+| [CVTRA04Y](./cvtra04y-transaction-category) | TRAN-CAT-RECORD | ~56 bytes | TRANCATG | `TransactionCategory` | Reconstructed from .NET model |
+| [CVTRA05Y](./cvtra05y-transaction-record) | TRAN-RECORD | 350 bytes | TRANSACT | `Transaction` | Reconstructed from .NET model |
+| [CVTRA06Y](./cvtra06y-daily-transaction) | DALYTRAN-RECORD | 350 bytes | DALYTRAN | `DailyTransaction` | Reconstructed from .NET model |
+
+### Infrastructure (CICS)
+
+| Copybook   | Record Name         | Length | VSAM File | .NET Class | Status |
+|------------|---------------------|--------|-----------|------------|--------|
+| [COCOM01Y](./cocom01y-commarea) | Application COMMAREA | Up to 2,000 bytes | N/A (CICS COMMAREA) | *(REST API layer)* | Reconstructed from program references |
+| [CSUSR01Y](./csusr01y-user-data) | Signed-on User Data | Variable | N/A (CICS security) | *(Azure AD claims)* | Reconstructed from program references |
+
+## COBOL PIC Clause Quick Reference
+
+| PIC Clause        | Meaning                  | .NET Type   | SQL Type         | Conversion Method                    |
+|-------------------|--------------------------|-------------|------------------|--------------------------------------|
+| PIC X(n)          | Alphanumeric, n chars    | `string`    | `nvarchar(n)`    | `EbcdicConverter.ConvertToUnicode()` |
+| PIC 9(n)          | Unsigned numeric, n digits | `int`/`long` | `int`/`bigint` | `EbcdicConverter.ConvertZonedDecimal(scale: 0)` |
+| PIC S9(n)V99      | Signed decimal, 2 places | `decimal`   | `decimal(n+2,2)` | `EbcdicConverter.ConvertZonedDecimal(scale: 2)` |
+| PIC S9(n) COMP-3  | Packed decimal (BCD)     | `decimal`   | `decimal`        | `EbcdicConverter.ConvertPackedDecimal()` |
+| PIC S9(n) COMP    | Binary integer           | `int`/`long`| `int`/`bigint`   | Direct binary interpretation         |
+
+## EBCDIC Conversion
+
+All text fields use IBM Code Page 1143 (Swedish/Finnish EBCDIC variant) for conversion.
+The `EbcdicConverter` utility class in `NordKredit.Infrastructure.DataMigration` handles:
+
+- **Text fields** (`PIC X`) — `ConvertToUnicode()` / `ConvertToEbcdic()` for bidirectional conversion
+- **Packed decimal** (`COMP-3`) — `ConvertPackedDecimal(scale)` with nibble-pair digit extraction
+- **Zoned decimal** (`PIC 9`, `PIC S9`) — `ConvertZonedDecimal(scale)` with zone/digit nibble separation
+
+Swedish characters (Å, Ä, Ö) require Code Page 1143 specifically — generic EBCDIC code pages will produce incorrect mappings.
+
+## Coverage Status
+
+- **Documented**: 11 copybooks (key data structures for Card Management, Transactions, Account, and CICS infrastructure)
+- **In repo**: 3 copybooks (CVACT02Y, CVACT03Y, CVCRD01Y) with full field-level documentation from source
+- **Reconstructed**: 8 copybooks documented from .NET domain models and EF Core configuration
+- **Pending**: Remaining ~289 copybooks (tracked in issue #125 for copybook acquisition)


### PR DESCRIPTION
## Summary
- Document 11 key COBOL copybooks covering Account, Card Management, Transaction, and CICS infrastructure domains
- Each copybook document includes: field definitions with PIC clauses/offsets/lengths, .NET class mappings with C# types and SQL column types, EBCDIC-to-Unicode conversion notes, referencing programs, and regulatory traceability
- Update `docs-site/docs/data-structures/index.md` from placeholder to comprehensive index with copybook tables, PIC clause reference, and EBCDIC conversion guide

## Changes
- **11 new files** in `docs-site/docs/data-structures/`:
  - `cvact01y-account-master.md` — Account master record (300 bytes, ACCTFILE)
  - `cvact02y-card-record.md` — Card entity record (150 bytes, CARDDAT)
  - `cvact03y-card-cross-reference.md` — Card-customer-account cross-reference (50 bytes, CXREF)
  - `cvcrd01y-card-work-area.md` — CICS card working storage areas
  - `cocom01y-commarea.md` — Application COMMAREA (CICS inter-program communication)
  - `csusr01y-user-data.md` — Signed-on user data (CICS security context)
  - `cvtra01y-transaction-category-balance.md` — Category balance record (50 bytes, TCATBALF)
  - `cvtra03y-transaction-type.md` — Transaction type lookup (TRANTYPE)
  - `cvtra04y-transaction-category.md` — Transaction category lookup (TRANCATG)
  - `cvtra05y-transaction-record.md` — Posted transaction record (350 bytes, TRANSACT)
  - `cvtra06y-daily-transaction.md` — Daily batch transaction input (350 bytes, DALYTRAN)
- **1 updated file**: `docs-site/docs/data-structures/index.md` — comprehensive copybook index

## Testing
- [x] Docs-site builds successfully (`npm run build`)
- [x] .NET build passes with zero warnings (`dotnet build /warnaserror`)
- [x] All 548 tests pass (`dotnet test`)

Closes #134

🤖 Generated with Claude Code