### PR TITLE
feat(#140): Add Azure AD B2C authentication for customer APIs

### DIFF
--- a/src/NordKredit.Api/Controllers/CardsController.cs
+++ b/src/NordKredit.Api/Controllers/CardsController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NordKredit.Domain.CardManagement;
 
@@ -9,9 +10,11 @@ namespace NordKredit.Api.Controllers;
 /// COBOL source: COCRDLIC.cbl:1123-1411 (pagination/filtering), COCRDSLC.cbl:608-812 (detail),
 ///               COCRDUPC.cbl:275-1523 (card update with state machine and concurrency).
 /// Regulations: PSD2 Art. 97 (SCA), GDPR Art. 15 (right of access), FFFS 2014:5 Ch. 8 §4.
+/// SEC-BR-001: Internal only — requires OperatorAccess (Azure AD). Maps to COBOL CDEMO-USRTYP-ADMIN role.
 /// </summary>
 [ApiController]
 [Route("api/cards")]
+[Authorize(Policy = "OperatorAccess")]
 public class CardsController : ControllerBase
 {
     private readonly CardDetailService _detailService;

--- a/src/NordKredit.Api/Controllers/TransactionsController.cs
+++ b/src/NordKredit.Api/Controllers/TransactionsController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NordKredit.Domain.Transactions;
 
@@ -7,9 +8,11 @@ namespace NordKredit.Api.Controllers;
 /// REST API for transaction operations.
 /// Replaces COBOL CICS online transaction screens COTRN00C (list), COTRN01C (detail), and COTRN02C (add).
 /// Regulations: FFFS 2014:5 Ch.8 (accurate records), PSD2 Art.94 (transaction retention).
+/// SEC-BR-005: Requires CustomerAccess or OperatorAccess authentication (replaces CICS CESN).
 /// </summary>
 [ApiController]
 [Route("api/transactions")]
+[Authorize(Policy = "CustomerAccess")]
 public class TransactionsController : ControllerBase
 {
     private readonly TransactionAddService _addService;

--- a/src/NordKredit.Api/NordKredit.Api.csproj
+++ b/src/NordKredit.Api/NordKredit.Api.csproj
@@ -5,4 +5,8 @@
     <ProjectReference Include="..\NordKredit.Infrastructure\NordKredit.Infrastructure.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.14.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/NordKredit.Api/appsettings.json
+++ b/src/NordKredit.Api/appsettings.json
@@ -5,5 +5,18 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AzureAdB2C": {
+    "Instance": "https://{tenant-name}.b2clogin.com",
+    "Domain": "{tenant-name}.onmicrosoft.com",
+    "TenantId": "{b2c-tenant-id}",
+    "ClientId": "{b2c-client-id}",
+    "SignUpSignInPolicyId": "B2C_1_SignUpSignIn",
+    "CallbackPath": "/signin-oidc"
+  },
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "{azure-ad-tenant-id}",
+    "ClientId": "{azure-ad-client-id}"
+  }
 }

--- a/tests/NordKredit.UnitTests/Auth/AuthenticationTests.cs
+++ b/tests/NordKredit.UnitTests/Auth/AuthenticationTests.cs
@@ -1,0 +1,303 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NordKredit.Infrastructure;
+
+namespace NordKredit.UnitTests.Auth;
+
+/// <summary>
+/// Integration tests for Azure AD B2C / Azure AD authentication and authorization.
+/// SEC-BR-005: Verifies CICS CESN → Azure AD B2C/AD authentication replacement.
+/// PSD2 Art. 97: Validates that unauthenticated requests are rejected (SCA enforcement).
+/// DORA Art. 9: Confirms protection and prevention via strong authentication.
+/// </summary>
+public class AuthenticationTests : IClassFixture<AuthenticationTests.NordKreditWebApplicationFactory>
+{
+    private readonly NordKreditWebApplicationFactory _factory;
+
+    public AuthenticationTests(NordKreditWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    // =================================================================
+    // Health endpoint — must remain unauthenticated (infrastructure probe)
+    // =================================================================
+
+    [Fact]
+    public async Task Health_NoAuth_Returns200()
+    {
+        var client = _factory.CreateUnauthenticatedClient();
+
+        var response = await client.GetAsync("/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    // =================================================================
+    // TransactionsController — requires CustomerAccess policy
+    // SEC-BR-005: Unauthenticated requests must be rejected.
+    // =================================================================
+
+    [Fact]
+    public async Task Transactions_NoAuth_Returns401()
+    {
+        var client = _factory.CreateUnauthenticatedClient();
+
+        var response = await client.GetAsync("/api/transactions");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TransactionDetail_NoAuth_Returns401()
+    {
+        var client = _factory.CreateUnauthenticatedClient();
+
+        var response = await client.GetAsync("/api/transactions/0000000000000001");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TransactionPost_NoAuth_Returns401()
+    {
+        var client = _factory.CreateUnauthenticatedClient();
+
+        var response = await client.PostAsync("/api/transactions",
+            new StringContent("{}", System.Text.Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TransactionLast_NoAuth_Returns401()
+    {
+        var client = _factory.CreateUnauthenticatedClient();
+
+        var response = await client.GetAsync("/api/transactions/last");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Transactions_WithB2CAuth_IsNotUnauthorized()
+    {
+        var client = _factory.CreateB2CAuthenticatedClient();
+
+        var response = await client.GetAsync("/api/transactions");
+
+        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Transactions_WithAzureAdAuth_IsNotUnauthorized()
+    {
+        var client = _factory.CreateAzureAdAuthenticatedClient();
+
+        var response = await client.GetAsync("/api/transactions");
+
+        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // =================================================================
+    // CardsController — requires OperatorAccess policy (Azure AD only)
+    // SEC-BR-001: Card operations restricted to admin/operator role.
+    // =================================================================
+
+    [Fact]
+    public async Task Cards_NoAuth_Returns401()
+    {
+        var client = _factory.CreateUnauthenticatedClient();
+
+        var response = await client.GetAsync("/api/cards");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CardDetail_NoAuth_Returns401()
+    {
+        var client = _factory.CreateUnauthenticatedClient();
+
+        var response = await client.GetAsync("/api/cards/4000123456789010");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CardUpdate_NoAuth_Returns401()
+    {
+        var client = _factory.CreateUnauthenticatedClient();
+
+        var response = await client.PutAsync("/api/cards/4000123456789010",
+            new StringContent("{}", System.Text.Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Cards_WithB2CAuth_Returns401Unauthorized()
+    {
+        // B2C tokens are not listed in the OperatorAccess policy authentication schemes,
+        // so the policy challenges only the AzureAd scheme, which returns NoResult for B2C tokens.
+        // This results in 401 (no authenticated identity from policy schemes), not 403.
+        var client = _factory.CreateB2CAuthenticatedClient();
+
+        var response = await client.GetAsync("/api/cards");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Cards_WithAzureAdAuth_IsNotUnauthorized()
+    {
+        var client = _factory.CreateAzureAdAuthenticatedClient();
+
+        var response = await client.GetAsync("/api/cards");
+
+        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Cards_WithAzureAdAuth_IsNotForbidden()
+    {
+        var client = _factory.CreateAzureAdAuthenticatedClient();
+
+        var response = await client.GetAsync("/api/cards");
+
+        Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    // =================================================================
+    // Test infrastructure
+    // =================================================================
+
+    public class NordKreditWebApplicationFactory : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+            builder.ConfigureTestServices(services =>
+            {
+                // Replace real DbContext with InMemory for auth tests.
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<NordKreditDbContext>));
+                if (descriptor != null)
+                {
+                    services.Remove(descriptor);
+                }
+
+                services.AddDbContext<NordKreditDbContext>(options =>
+                    options.UseInMemoryDatabase("AuthTests"));
+
+                // Replace real Azure AD B2C and Azure AD auth with test schemes.
+                // This allows testing auth policies without real identity providers.
+                services.AddAuthentication("TestB2C")
+                    .AddScheme<AuthenticationSchemeOptions, TestB2CAuthHandler>("TestB2C", _ => { })
+                    .AddScheme<AuthenticationSchemeOptions, TestAzureAdAuthHandler>("TestAzureAd", _ => { });
+
+                // Reconfigure authorization policies to use test schemes.
+                services.AddAuthorizationBuilder()
+                    .AddPolicy("CustomerAccess", policy =>
+                    {
+                        policy.AuthenticationSchemes.Clear();
+                        policy.AuthenticationSchemes.Add("TestB2C");
+                        policy.AuthenticationSchemes.Add("TestAzureAd");
+                        policy.RequireAuthenticatedUser();
+                    })
+                    .AddPolicy("OperatorAccess", policy =>
+                    {
+                        policy.AuthenticationSchemes.Clear();
+                        policy.AuthenticationSchemes.Add("TestAzureAd");
+                        policy.RequireAuthenticatedUser();
+                    });
+            });
+        }
+
+        public HttpClient CreateUnauthenticatedClient() =>
+            CreateClient();
+
+        public HttpClient CreateB2CAuthenticatedClient()
+        {
+            var client = CreateClient();
+            client.DefaultRequestHeaders.Add("X-Test-Auth-Scheme", "TestB2C");
+            return client;
+        }
+
+        public HttpClient CreateAzureAdAuthenticatedClient()
+        {
+            var client = CreateClient();
+            client.DefaultRequestHeaders.Add("X-Test-Auth-Scheme", "TestAzureAd");
+            return client;
+        }
+    }
+
+    private sealed class TestB2CAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public TestB2CAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue("X-Test-Auth-Scheme", out var scheme) ||
+                scheme != "TestB2C")
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "test-customer-001"),
+                new Claim(ClaimTypes.Name, "Test Customer"),
+            };
+            var identity = new ClaimsIdentity(claims, "TestB2C");
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, "TestB2C");
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+
+    private sealed class TestAzureAdAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public TestAzureAdAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue("X-Test-Auth-Scheme", out var scheme) ||
+                scheme != "TestAzureAd")
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "test-operator-001"),
+                new Claim(ClaimTypes.Name, "Test Operator"),
+            };
+            var identity = new ClaimsIdentity(claims, "TestAzureAd");
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, "TestAzureAd");
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}

--- a/tests/NordKredit.UnitTests/NordKredit.UnitTests.csproj
+++ b/tests/NordKredit.UnitTests/NordKredit.UnitTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />


### PR DESCRIPTION
## Summary
- Implements Azure AD B2C authentication for customer-facing APIs and Azure AD authentication for internal operator endpoints
- Adds `Microsoft.Identity.Web` 3.14.1 with dual JWT bearer token validation schemes
- Configures authorization policies: `CustomerAccess` (B2C + AD) for transactions, `OperatorAccess` (AD only) for cards

## Changes
- `src/NordKredit.Api/NordKredit.Api.csproj` — Added `Microsoft.Identity.Web` 3.14.1 package reference
- `src/NordKredit.Api/Program.cs` — Added authentication middleware, dual JWT schemes, authorization policies, `UseAuthentication()`/`UseAuthorization()` pipeline
- `src/NordKredit.Api/appsettings.json` — Added `AzureAdB2C` and `AzureAd` configuration sections with placeholder values
- `src/NordKredit.Api/Controllers/TransactionsController.cs` — Added `[Authorize(Policy = "CustomerAccess")]`
- `src/NordKredit.Api/Controllers/CardsController.cs` — Added `[Authorize(Policy = "OperatorAccess")]`
- `tests/NordKredit.UnitTests/Auth/AuthenticationTests.cs` — 13 integration tests using `WebApplicationFactory` with test auth handlers
- `tests/NordKredit.UnitTests/NordKredit.UnitTests.csproj` — Added `Microsoft.AspNetCore.Mvc.Testing` 8.0.11

## Regulatory Traceability
- **SEC-BR-005**: CICS CESN sign-on → Azure AD B2C (customer) / Azure AD (operator)
- **SEC-BR-001**: Role-based access control — cards restricted to operators (CDEMO-USRTYP-ADMIN)
- **PSD2 Art. 97**: Strong Customer Authentication — B2C supports MFA via conditional access
- **DORA Art. 9**: Protection and prevention — strong authentication mechanisms
- **FFFS 2014:5 Ch. 8 §4**: IT security and internal controls

## Testing
- [x] 13 new integration tests pass (401/403 for all endpoint/auth combinations)
- [x] All 427 existing tests pass
- [x] `dotnet build /warnaserror` — zero warnings
- [x] `dotnet format --verify-no-changes` — clean

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)