### PR TITLE
feat(#156): Implement data migration pipeline (Db2 to Azure SQL)

### DIFF
--- a/docs/Architecture/ADR-004-data-migration-pipeline.md
+++ b/docs/Architecture/ADR-004-data-migration-pipeline.md
@@ -1,0 +1,139 @@
+# ADR-004: Data Migration Pipeline (Db2 to Azure SQL)
+
+**Date:** 2026-02-17
+
+**Status:** Accepted
+
+**Deciders:** Engineering team
+
+**Tags:** architecture, backend, infrastructure, data-migration, compliance
+
+---
+
+## Context
+
+**What is the issue we're trying to solve?**
+
+The core banking migration requires an incremental data sync pipeline that operates during the parallel-run period. Data must flow from Db2 for z/OS to Azure SQL Database, with EBCDIC-to-Unicode conversion, referential integrity validation, rollback capability, and GDPR/DORA-compliant audit logging. The pipeline must support changed-record-only sync (not full table scans) and maintain EU data residency.
+
+**What forces are at play?**
+
+- Parallel-run requires continuous data synchronization between mainframe and Azure.
+- EBCDIC conversion utilities (#138) and schema mapping (#143) are already available.
+- Incremental sync must detect changed records via timestamp-based delta detection.
+- Rollback capability must allow reverting to a previous sync state.
+- GDPR Art.17 requires preserving right-to-erasure capability across migrated data.
+- DORA Art.11 requires full audit trail of data changes during migration.
+- All data must remain in EU/Sweden Central (data residency).
+- Pipeline must handle all 9 mapped tables from the schema mapping document.
+
+---
+
+## Decision
+
+**What did we decide?**
+
+Implement the data migration pipeline as domain-layer orchestration with infrastructure abstractions, following the established patterns from the parallel-run framework (#155):
+
+1. **`MigrationPipeline`** — Orchestrates incremental sync: reads changed records from source, applies field conversions, writes to target, validates referential integrity, and logs all changes. Lives in `NordKredit.Domain/DataMigration/`.
+
+2. **`ISourceDataReader`** — Interface for reading changed records from Db2. Returns raw row data with metadata (table, change type, timestamp). Infrastructure implements with Db2 connectivity.
+
+3. **`ITargetDataWriter`** — Interface for writing converted records to Azure SQL. Supports batch writes with transactional semantics. Infrastructure implements with EF Core.
+
+4. **`IMigrationAuditLog`** — Persists audit records of all data changes for GDPR/DORA compliance. Every record migration is logged with source, target, and conversion details.
+
+5. **`FieldConverter`** — Applies EBCDIC-to-Unicode, packed decimal, and zoned decimal conversions using the existing `EbcdicConverter`. Maps COBOL field types to .NET types per the schema mapping document.
+
+6. **`ReferentialIntegrityValidator`** — Post-sync validation that checks foreign key relationships, record counts, and data completeness across all migrated tables.
+
+7. **`MigrationSyncState`** — Tracks sync checkpoints (last sync timestamp per table) for incremental sync and rollback. Each sync batch creates a checkpoint that can be reverted.
+
+**Incremental sync strategy:** Timestamp-based delta detection. Each table's sync state tracks the last processed timestamp. On each run, only records with a modified timestamp after the checkpoint are processed. This avoids full table scans while being simpler than CDC (which requires Db2 log access that may not be available from Azure).
+
+**Rollback strategy:** Each sync batch is wrapped in a transaction. Sync state checkpoints are versioned. Rolling back means restoring the previous checkpoint and deleting records written in the failed batch.
+
+---
+
+## Alternatives Considered
+
+### Alternative 1: Change Data Capture (CDC) from Db2
+
+**Description:** Use Db2 native CDC to stream changes.
+
+**Pros:**
+- Real-time change streaming
+- No timestamp column requirement
+
+**Cons:**
+- Requires Db2 log reader access (may not be available from Azure)
+- Complex infrastructure setup
+- Vendor-specific coupling
+
+**Why rejected:** Timestamp-based delta is simpler, works over standard SQL connectivity, and meets the incremental sync requirement. CDC can be adopted later if needed.
+
+### Alternative 2: Azure Data Factory
+
+**Description:** Use Azure Data Factory for ETL pipeline.
+
+**Pros:**
+- Managed service, visual pipeline designer
+- Built-in connectors
+
+**Cons:**
+- No EBCDIC-to-Unicode conversion support
+- Cannot apply domain-specific validation rules
+- Limited rollback capability
+- Additional Azure cost
+
+**Why rejected:** Custom conversion logic (COMP-3, zoned decimal, Swedish EBCDIC) requires code-level control. Domain validation rules need business context.
+
+---
+
+## Consequences
+
+### Positive
+- Follows existing domain-layer patterns (interfaces, DI, async)
+- Reuses proven EbcdicConverter utilities
+- Full audit trail for GDPR/DORA compliance
+- Testable with unit tests using stub implementations
+- Incremental sync minimizes data transfer volume
+- Rollback capability provides safety net during parallel-run
+
+### Negative
+- Timestamp-based sync requires reliable timestamp columns in Db2
+- Custom pipeline requires more implementation effort than managed ETL
+
+### Risks
+- Large batch sizes could cause memory pressure
+  - **Mitigation:** Configurable batch size with streaming reads
+- Network latency to Db2 could slow sync
+  - **Mitigation:** Parallel table sync, configurable timeouts
+
+---
+
+## Implementation Notes
+
+- Domain models: `src/NordKredit.Domain/DataMigration/`
+- Infrastructure: `src/NordKredit.Infrastructure/DataMigration/`
+- Unit tests: `tests/NordKredit.UnitTests/DataMigration/`
+- Reuses: `EbcdicConverter` from `NordKredit.Infrastructure.DataMigration`
+- Schema mapping reference: `docs-site/docs/data-structures/db2-to-azure-sql-schema-mapping.md`
+
+---
+
+## References
+
+- Issue #156: Implement data migration pipeline
+- Issue #155: Parallel-run orchestration framework (dependency)
+- Issue #138: EBCDIC converter utilities
+- Issue #143: Db2-to-Azure SQL schema mapping
+- GDPR Art.5(1)(d) — Accuracy during migration
+- GDPR Art.17 — Right to erasure
+- DORA Art.11 — ICT system testing
+- FFFS 2014:5 — FSA operational risk
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/src/NordKredit.Domain/DataMigration/ConvertedRecord.cs
+++ b/src/NordKredit.Domain/DataMigration/ConvertedRecord.cs
@@ -1,0 +1,27 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// A source record after EBCDIC-to-Unicode conversion and type mapping.
+/// Field values are .NET types (string, decimal, DateTime, etc.) ready for Azure SQL.
+/// Regulation: GDPR Art. 5(1)(d) — accuracy of personal data during migration.
+/// </summary>
+public class ConvertedRecord
+{
+    /// <summary>Target Azure SQL table name (e.g., "Accounts", "Cards").</summary>
+    public required string TargetTable { get; init; }
+
+    /// <summary>The type of change to apply.</summary>
+    public required ChangeType ChangeType { get; init; }
+
+    /// <summary>Primary key value(s) as a string.</summary>
+    public required string PrimaryKey { get; init; }
+
+    /// <summary>
+    /// Converted field values keyed by Azure SQL column name.
+    /// Values are .NET types: string, decimal, int, DateTime, DateOnly, etc.
+    /// </summary>
+    public required IReadOnlyDictionary<string, object?> Fields { get; init; }
+
+    /// <summary>Timestamp of the change in the source system.</summary>
+    public required DateTimeOffset SourceTimestamp { get; init; }
+}

--- a/src/NordKredit.Domain/DataMigration/FieldConverter.cs
+++ b/src/NordKredit.Domain/DataMigration/FieldConverter.cs
@@ -1,0 +1,100 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Converts raw EBCDIC field values from Db2 source records to .NET types
+/// using the EBCDIC converter and schema mapping field type definitions.
+/// COBOL source: All copybook field conversions per schema mapping (#143).
+/// Regulation: GDPR Art. 5(1)(d) — accuracy of personal data during migration.
+/// </summary>
+public class FieldConverter
+{
+    private readonly IEbcdicConverter _ebcdicConverter;
+
+    public FieldConverter(IEbcdicConverter ebcdicConverter)
+    {
+        _ebcdicConverter = ebcdicConverter;
+    }
+
+    /// <summary>
+    /// Converts a source record's raw fields to .NET types based on the table mapping.
+    /// Returns a ConvertedRecord with Azure SQL column names and typed values.
+    /// </summary>
+    public ConvertedRecord Convert(SourceRecord source, TableMapping mapping)
+    {
+        var convertedFields = new Dictionary<string, object?>();
+
+        foreach (var fieldMapping in mapping.Fields)
+        {
+            if (!source.Fields.TryGetValue(fieldMapping.SourceField, out var rawValue))
+            {
+                convertedFields[fieldMapping.TargetColumn] = null;
+                continue;
+            }
+
+            convertedFields[fieldMapping.TargetColumn] = ConvertField(rawValue, fieldMapping);
+        }
+
+        return new ConvertedRecord
+        {
+            TargetTable = mapping.TargetTable,
+            ChangeType = source.ChangeType,
+            PrimaryKey = source.PrimaryKey,
+            Fields = convertedFields,
+            SourceTimestamp = source.SourceTimestamp
+        };
+    }
+
+    private object? ConvertField(object rawValue, FieldMapping fieldMapping)
+    {
+        if (rawValue is byte[] bytes)
+        {
+            return fieldMapping.FieldType switch
+            {
+                CobolFieldType.Alphanumeric => _ebcdicConverter.ConvertToUnicode(bytes).TrimEnd(),
+                CobolFieldType.ZonedDecimal => _ebcdicConverter.ConvertZonedDecimal(bytes, fieldMapping.Scale),
+                CobolFieldType.SignedZonedDecimal => _ebcdicConverter.ConvertZonedDecimal(bytes, fieldMapping.Scale),
+                CobolFieldType.PackedDecimal => _ebcdicConverter.ConvertPackedDecimal(bytes, fieldMapping.Scale),
+                CobolFieldType.NumericString => _ebcdicConverter.ConvertToUnicode(bytes).Trim(),
+                CobolFieldType.Date => ParseDate(_ebcdicConverter.ConvertToUnicode(bytes).Trim()),
+                CobolFieldType.Timestamp => ParseTimestamp(_ebcdicConverter.ConvertToUnicode(bytes).Trim()),
+                _ => throw new ArgumentException($"Unknown field type: {fieldMapping.FieldType}")
+            };
+        }
+
+        // Already a converted value (e.g., string passed through)
+        return rawValue;
+    }
+
+    private static DateOnly? ParseDate(string dateString)
+    {
+        if (string.IsNullOrWhiteSpace(dateString))
+        {
+            return null;
+        }
+
+        // COBOL date format: YYYY-MM-DD
+        if (DateOnly.TryParseExact(dateString, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var date))
+        {
+            return date;
+        }
+
+        return null;
+    }
+
+    private static DateTime? ParseTimestamp(string timestampString)
+    {
+        if (string.IsNullOrWhiteSpace(timestampString))
+        {
+            return null;
+        }
+
+        // COBOL timestamp format: YYYY-MM-DD-HH.MM.SS.FFFFFF
+        if (DateTime.TryParseExact(timestampString, "yyyy-MM-dd-HH.mm.ss.ffffff",
+            null, System.Globalization.DateTimeStyles.None, out var timestamp))
+        {
+            return timestamp;
+        }
+
+        return null;
+    }
+}

--- a/src/NordKredit.Domain/DataMigration/IEbcdicConverter.cs
+++ b/src/NordKredit.Domain/DataMigration/IEbcdicConverter.cs
@@ -1,0 +1,18 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Domain interface for EBCDIC conversion operations.
+/// Infrastructure layer implements this using the concrete EbcdicConverter.
+/// Keeps the domain layer free of infrastructure dependencies (CodePages encoding).
+/// </summary>
+public interface IEbcdicConverter
+{
+    /// <summary>Converts EBCDIC bytes (IBM Code Page 1143) to a Unicode string.</summary>
+    string ConvertToUnicode(byte[] ebcdicBytes);
+
+    /// <summary>Converts a COBOL COMP-3 packed decimal to a .NET decimal.</summary>
+    decimal ConvertPackedDecimal(byte[] packedBytes, int scale = 0);
+
+    /// <summary>Converts a COBOL zoned decimal to a .NET decimal.</summary>
+    decimal ConvertZonedDecimal(byte[] zonedBytes, int scale = 0);
+}

--- a/src/NordKredit.Domain/DataMigration/IMigrationAuditLog.cs
+++ b/src/NordKredit.Domain/DataMigration/IMigrationAuditLog.cs
@@ -1,0 +1,15 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Persists audit entries for all data migration operations.
+/// Required for GDPR Art.17 (right to erasure traceability) and DORA Art.11 (audit trail).
+/// </summary>
+public interface IMigrationAuditLog
+{
+    /// <summary>
+    /// Logs a batch of audit entries for migrated records.
+    /// </summary>
+    Task LogBatchAsync(
+        IReadOnlyList<MigrationAuditEntry> entries,
+        CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/DataMigration/IMigrationStateStore.cs
+++ b/src/NordKredit.Domain/DataMigration/IMigrationStateStore.cs
@@ -1,0 +1,32 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Persists and retrieves sync state checkpoints for incremental migration.
+/// Supports rollback by tracking versioned checkpoints per table.
+/// Regulation: DORA Art.11 — ICT system testing documentation.
+/// </summary>
+public interface IMigrationStateStore
+{
+    /// <summary>
+    /// Gets the latest non-rolled-back sync state for a table.
+    /// Returns null if no sync has occurred for this table.
+    /// </summary>
+    Task<MigrationSyncState?> GetLatestAsync(
+        string tableName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Saves a new sync state checkpoint.
+    /// </summary>
+    Task SaveAsync(
+        MigrationSyncState state,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks a sync state as rolled back and restores the previous version.
+    /// Returns the restored state, or null if no previous version exists.
+    /// </summary>
+    Task<MigrationSyncState?> RollbackAsync(
+        string tableName,
+        CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/DataMigration/IReferentialIntegrityChecker.cs
+++ b/src/NordKredit.Domain/DataMigration/IReferentialIntegrityChecker.cs
@@ -1,0 +1,18 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Checks referential integrity by verifying that foreign key values exist in referenced tables.
+/// Infrastructure implements with Azure SQL queries.
+/// </summary>
+public interface IReferentialIntegrityChecker
+{
+    /// <summary>
+    /// Finds which of the given key values do NOT exist in the referenced table/column.
+    /// Returns the set of missing keys.
+    /// </summary>
+    Task<IReadOnlyList<string>> FindMissingKeysAsync(
+        string tableName,
+        string columnName,
+        IReadOnlyCollection<string> keyValues,
+        CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/DataMigration/ISourceDataReader.cs
+++ b/src/NordKredit.Domain/DataMigration/ISourceDataReader.cs
@@ -1,0 +1,24 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Reads changed records from the Db2 source system for incremental migration.
+/// Infrastructure implements with Db2 connectivity.
+/// COBOL source: All VSAM file structures (ACCTFILE, CARDDAT, CXREF, TRANSACT, etc.).
+/// Regulation: GDPR Art. 5(1)(d) — accuracy of personal data during migration.
+/// </summary>
+public interface ISourceDataReader
+{
+    /// <summary>
+    /// Reads records from the source table that have changed since the given timestamp.
+    /// Returns records ordered by source timestamp ascending.
+    /// </summary>
+    /// <param name="tableName">The source table name.</param>
+    /// <param name="sinceTimestamp">Only return records changed after this timestamp.</param>
+    /// <param name="batchSize">Maximum number of records to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<SourceRecord>> ReadChangedRecordsAsync(
+        string tableName,
+        DateTimeOffset sinceTimestamp,
+        int batchSize,
+        CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/DataMigration/ITargetDataWriter.cs
+++ b/src/NordKredit.Domain/DataMigration/ITargetDataWriter.cs
@@ -1,0 +1,26 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Writes converted records to the Azure SQL target database.
+/// Supports batch writes with transactional semantics for rollback.
+/// Regulation: GDPR Art.17 — right to erasure must be preservable after migration.
+/// </summary>
+public interface ITargetDataWriter
+{
+    /// <summary>
+    /// Writes a batch of converted records to the target table within a transaction.
+    /// Returns the number of records successfully written.
+    /// </summary>
+    Task<int> WriteBatchAsync(
+        IReadOnlyList<ConvertedRecord> records,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Rolls back records written in a specific batch (identified by primary keys and table).
+    /// Used when a sync batch fails validation.
+    /// </summary>
+    Task RollbackBatchAsync(
+        string tableName,
+        IReadOnlyList<string> primaryKeys,
+        CancellationToken cancellationToken = default);
+}

--- a/src/NordKredit.Domain/DataMigration/MigrationAuditEntry.cs
+++ b/src/NordKredit.Domain/DataMigration/MigrationAuditEntry.cs
@@ -1,0 +1,39 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Audit log entry for a single record migration, tracking the full lifecycle
+/// from source read through conversion to target write.
+/// Regulation: GDPR Art.17 (right to erasure traceability), DORA Art.11 (audit trail).
+/// </summary>
+public class MigrationAuditEntry
+{
+    /// <summary>Unique identifier for this audit entry.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Correlation ID for the batch this record belongs to.</summary>
+    public required string BatchCorrelationId { get; init; }
+
+    /// <summary>Source table name.</summary>
+    public required string SourceTable { get; init; }
+
+    /// <summary>Target table name.</summary>
+    public required string TargetTable { get; init; }
+
+    /// <summary>Primary key of the record.</summary>
+    public required string PrimaryKey { get; init; }
+
+    /// <summary>Type of change applied.</summary>
+    public required ChangeType ChangeType { get; init; }
+
+    /// <summary>Whether the migration succeeded.</summary>
+    public required bool Success { get; init; }
+
+    /// <summary>Error message if the migration failed.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Data residency region (must be EU/Sweden Central).</summary>
+    public required string DataRegion { get; init; }
+
+    /// <summary>When this audit entry was created.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+}

--- a/src/NordKredit.Domain/DataMigration/MigrationBatchResult.cs
+++ b/src/NordKredit.Domain/DataMigration/MigrationBatchResult.cs
@@ -1,0 +1,35 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Result of a single migration batch execution.
+/// Contains counts, timing, and validation results.
+/// </summary>
+public class MigrationBatchResult
+{
+    /// <summary>Correlation ID for this batch.</summary>
+    public required string BatchCorrelationId { get; init; }
+
+    /// <summary>Table that was synced.</summary>
+    public required string TableName { get; init; }
+
+    /// <summary>Number of records read from source.</summary>
+    public required int RecordsRead { get; init; }
+
+    /// <summary>Number of records successfully written to target.</summary>
+    public required int RecordsWritten { get; init; }
+
+    /// <summary>Number of records that failed conversion or write.</summary>
+    public required int RecordsFailed { get; init; }
+
+    /// <summary>Whether post-sync validation passed.</summary>
+    public required bool ValidationPassed { get; init; }
+
+    /// <summary>Validation errors, if any.</summary>
+    public IReadOnlyList<string> ValidationErrors { get; init; } = [];
+
+    /// <summary>Duration of the batch execution.</summary>
+    public required TimeSpan Duration { get; init; }
+
+    /// <summary>Whether the batch completed successfully (all records written, validation passed).</summary>
+    public bool IsSuccess => RecordsFailed == 0 && ValidationPassed;
+}

--- a/src/NordKredit.Domain/DataMigration/MigrationPipeline.cs
+++ b/src/NordKredit.Domain/DataMigration/MigrationPipeline.cs
@@ -1,0 +1,297 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Orchestrates incremental data migration from Db2 to Azure SQL.
+/// Reads changed records, applies EBCDIC-to-Unicode conversion, writes to target,
+/// validates referential integrity, and maintains audit trail.
+/// COBOL source: All copybook structures during Db2 → Azure SQL migration.
+/// Regulations: GDPR Art. 5(1)(d) (accuracy), GDPR Art.17 (erasure), DORA Art.11 (audit).
+/// </summary>
+public partial class MigrationPipeline
+{
+    private readonly ISourceDataReader _sourceReader;
+    private readonly ITargetDataWriter _targetWriter;
+    private readonly IMigrationAuditLog _auditLog;
+    private readonly IMigrationStateStore _stateStore;
+    private readonly FieldConverter _fieldConverter;
+    private readonly ReferentialIntegrityValidator _integrityValidator;
+    private readonly MigrationPipelineConfiguration _config;
+    private readonly ILogger<MigrationPipeline> _logger;
+
+    public MigrationPipeline(
+        ISourceDataReader sourceReader,
+        ITargetDataWriter targetWriter,
+        IMigrationAuditLog auditLog,
+        IMigrationStateStore stateStore,
+        FieldConverter fieldConverter,
+        ReferentialIntegrityValidator integrityValidator,
+        MigrationPipelineConfiguration config,
+        ILogger<MigrationPipeline> logger)
+    {
+        _sourceReader = sourceReader;
+        _targetWriter = targetWriter;
+        _auditLog = auditLog;
+        _stateStore = stateStore;
+        _fieldConverter = fieldConverter;
+        _integrityValidator = integrityValidator;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Executes an incremental sync for a single table.
+    /// Reads changed records since last checkpoint, converts, writes, validates, and logs.
+    /// </summary>
+    public async Task<MigrationBatchResult> SyncTableAsync(
+        string sourceTable,
+        CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var batchCorrelationId = Guid.NewGuid().ToString();
+
+        if (!_config.TableMappings.TryGetValue(sourceTable, out var mapping))
+        {
+            throw new ArgumentException($"No table mapping found for source table: {sourceTable}");
+        }
+
+        LogSyncStarted(_logger, sourceTable, mapping.TargetTable, batchCorrelationId);
+
+        // Get last sync checkpoint (or start from epoch)
+        var lastState = await _stateStore.GetLatestAsync(mapping.TargetTable, cancellationToken);
+        var sinceTimestamp = lastState?.LastSyncTimestamp ?? DateTimeOffset.MinValue;
+
+        LogReadingChanges(_logger, sourceTable, sinceTimestamp, _config.BatchSize);
+
+        // Read changed records from source
+        var sourceRecords = await _sourceReader.ReadChangedRecordsAsync(
+            sourceTable, sinceTimestamp, _config.BatchSize, cancellationToken);
+
+        if (sourceRecords.Count == 0)
+        {
+            LogNoChanges(_logger, sourceTable);
+            stopwatch.Stop();
+            return new MigrationBatchResult
+            {
+                BatchCorrelationId = batchCorrelationId,
+                TableName = mapping.TargetTable,
+                RecordsRead = 0,
+                RecordsWritten = 0,
+                RecordsFailed = 0,
+                ValidationPassed = true,
+                Duration = stopwatch.Elapsed
+            };
+        }
+
+        // Convert all records
+        var convertedRecords = new List<ConvertedRecord>();
+        var failedRecords = new List<(SourceRecord Record, string Error)>();
+
+        foreach (var source in sourceRecords)
+        {
+            try
+            {
+                var converted = _fieldConverter.Convert(source, mapping);
+                convertedRecords.Add(converted);
+            }
+            catch (Exception ex)
+            {
+                failedRecords.Add((source, ex.Message));
+                LogConversionFailed(_logger, sourceTable, source.PrimaryKey, ex.Message);
+            }
+        }
+
+        // Write converted records to target
+        int recordsWritten = 0;
+        if (convertedRecords.Count > 0)
+        {
+            recordsWritten = await _targetWriter.WriteBatchAsync(convertedRecords, cancellationToken);
+        }
+
+        // Validate referential integrity
+        var validationErrors = await _integrityValidator.ValidateAsync(
+            convertedRecords, mapping, cancellationToken);
+
+        bool validationPassed = validationErrors.Count == 0;
+
+        if (!validationPassed)
+        {
+            LogValidationFailed(_logger, sourceTable, validationErrors.Count);
+
+            // Rollback the batch
+            List<string> writtenKeys = [.. convertedRecords.Select(r => r.PrimaryKey)];
+            await _targetWriter.RollbackBatchAsync(mapping.TargetTable, writtenKeys, cancellationToken);
+            recordsWritten = 0;
+        }
+
+        // Update sync state checkpoint
+        if (validationPassed && recordsWritten > 0)
+        {
+            var latestTimestamp = sourceRecords.Max(r => r.SourceTimestamp);
+            var newVersion = (lastState?.Version ?? 0) + 1;
+
+            var newState = new MigrationSyncState
+            {
+                Id = Guid.NewGuid().ToString(),
+                TableName = mapping.TargetTable,
+                LastSyncTimestamp = latestTimestamp,
+                Version = newVersion,
+                RecordCount = recordsWritten,
+                CreatedAt = DateTimeOffset.UtcNow
+            };
+
+            await _stateStore.SaveAsync(newState, cancellationToken);
+        }
+
+        // Write audit log entries
+        var auditEntries = CreateAuditEntries(
+            batchCorrelationId, convertedRecords, failedRecords, mapping, validationPassed);
+        await _auditLog.LogBatchAsync(auditEntries, cancellationToken);
+
+        stopwatch.Stop();
+        LogSyncCompleted(_logger, sourceTable, sourceRecords.Count, recordsWritten, failedRecords.Count, stopwatch.Elapsed.TotalSeconds);
+
+        return new MigrationBatchResult
+        {
+            BatchCorrelationId = batchCorrelationId,
+            TableName = mapping.TargetTable,
+            RecordsRead = sourceRecords.Count,
+            RecordsWritten = recordsWritten,
+            RecordsFailed = failedRecords.Count,
+            ValidationPassed = validationPassed,
+            ValidationErrors = validationErrors,
+            Duration = stopwatch.Elapsed
+        };
+    }
+
+    /// <summary>
+    /// Rolls back the last sync batch for a table, restoring the previous checkpoint.
+    /// </summary>
+    public async Task<MigrationSyncState?> RollbackTableAsync(
+        string targetTable,
+        CancellationToken cancellationToken = default)
+    {
+        LogRollbackStarted(_logger, targetTable);
+        var restoredState = await _stateStore.RollbackAsync(targetTable, cancellationToken);
+
+        if (restoredState is not null)
+        {
+            LogRollbackCompleted(_logger, targetTable, restoredState.Version);
+        }
+        else
+        {
+            LogRollbackNoState(_logger, targetTable);
+        }
+
+        return restoredState;
+    }
+
+    private List<MigrationAuditEntry> CreateAuditEntries(
+        string batchCorrelationId,
+        List<ConvertedRecord> convertedRecords,
+        List<(SourceRecord Record, string Error)> failedRecords,
+        TableMapping mapping,
+        bool validationPassed)
+    {
+        var entries = new List<MigrationAuditEntry>();
+        var now = DateTimeOffset.UtcNow;
+
+        // Successful conversions (only if validation passed)
+        if (validationPassed)
+        {
+            foreach (var record in convertedRecords)
+            {
+                entries.Add(new MigrationAuditEntry
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    BatchCorrelationId = batchCorrelationId,
+                    SourceTable = mapping.SourceTable,
+                    TargetTable = mapping.TargetTable,
+                    PrimaryKey = record.PrimaryKey,
+                    ChangeType = record.ChangeType,
+                    Success = true,
+                    DataRegion = _config.DataRegion,
+                    CreatedAt = now
+                });
+            }
+        }
+        else
+        {
+            // Validation failed — mark all as failed
+            foreach (var record in convertedRecords)
+            {
+                entries.Add(new MigrationAuditEntry
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    BatchCorrelationId = batchCorrelationId,
+                    SourceTable = mapping.SourceTable,
+                    TargetTable = mapping.TargetTable,
+                    PrimaryKey = record.PrimaryKey,
+                    ChangeType = record.ChangeType,
+                    Success = false,
+                    ErrorMessage = "Referential integrity validation failed",
+                    DataRegion = _config.DataRegion,
+                    CreatedAt = now
+                });
+            }
+        }
+
+        // Conversion failures
+        foreach (var (record, error) in failedRecords)
+        {
+            entries.Add(new MigrationAuditEntry
+            {
+                Id = Guid.NewGuid().ToString(),
+                BatchCorrelationId = batchCorrelationId,
+                SourceTable = mapping.SourceTable,
+                TargetTable = mapping.TargetTable,
+                PrimaryKey = record.PrimaryKey,
+                ChangeType = record.ChangeType,
+                Success = false,
+                ErrorMessage = $"Conversion failed: {error}",
+                DataRegion = _config.DataRegion,
+                CreatedAt = now
+            });
+        }
+
+        return entries;
+    }
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Migration sync started: {SourceTable} → {TargetTable} (batch: {BatchCorrelationId})")]
+    private static partial void LogSyncStarted(ILogger logger, string sourceTable, string targetTable, string batchCorrelationId);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Reading changes from {SourceTable} since {SinceTimestamp} (batch size: {BatchSize})")]
+    private static partial void LogReadingChanges(ILogger logger, string sourceTable, DateTimeOffset sinceTimestamp, int batchSize);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "No changes found in {SourceTable} since last sync")]
+    private static partial void LogNoChanges(ILogger logger, string sourceTable);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Conversion failed for {SourceTable} record {PrimaryKey}: {ErrorMessage}")]
+    private static partial void LogConversionFailed(ILogger logger, string sourceTable, string primaryKey, string errorMessage);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Referential integrity validation failed for {SourceTable}: {ErrorCount} errors")]
+    private static partial void LogValidationFailed(ILogger logger, string sourceTable, int errorCount);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Migration sync completed: {SourceTable} — read: {RecordsRead}, written: {RecordsWritten}, failed: {RecordsFailed}, duration: {DurationSeconds:F2}s")]
+    private static partial void LogSyncCompleted(ILogger logger, string sourceTable, int recordsRead, int recordsWritten, int recordsFailed, double durationSeconds);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Rollback started for table {TargetTable}")]
+    private static partial void LogRollbackStarted(ILogger logger, string targetTable);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Rollback completed for table {TargetTable}, restored to version {Version}")]
+    private static partial void LogRollbackCompleted(ILogger logger, string targetTable, int version);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Rollback for table {TargetTable}: no previous state to restore")]
+    private static partial void LogRollbackNoState(ILogger logger, string targetTable);
+}

--- a/src/NordKredit.Domain/DataMigration/MigrationPipelineConfiguration.cs
+++ b/src/NordKredit.Domain/DataMigration/MigrationPipelineConfiguration.cs
@@ -1,0 +1,24 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Configuration for the data migration pipeline.
+/// Controls batch sizes, data residency, and enabled tables.
+/// </summary>
+public class MigrationPipelineConfiguration
+{
+    /// <summary>Maximum number of records per sync batch. Default: 1000.</summary>
+    public int BatchSize { get; init; } = 1000;
+
+    /// <summary>
+    /// Data residency region. Must be EU/Sweden Central for GDPR compliance.
+    /// Used in audit log entries.
+    /// </summary>
+    public string DataRegion { get; init; } = "Sweden Central";
+
+    /// <summary>
+    /// Table mappings defining source→target field conversions.
+    /// Keyed by source table name.
+    /// </summary>
+    public IReadOnlyDictionary<string, TableMapping> TableMappings { get; init; } =
+        new Dictionary<string, TableMapping>();
+}

--- a/src/NordKredit.Domain/DataMigration/MigrationSyncState.cs
+++ b/src/NordKredit.Domain/DataMigration/MigrationSyncState.cs
@@ -1,0 +1,30 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Tracks the sync checkpoint for a single table during incremental migration.
+/// Each sync batch creates a new checkpoint version enabling rollback.
+/// Regulation: DORA Art.11 — ICT system testing documentation.
+/// </summary>
+public class MigrationSyncState
+{
+    /// <summary>Unique identifier for this sync state record.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The table being synced (Azure SQL target table name).</summary>
+    public required string TableName { get; init; }
+
+    /// <summary>The last successfully synced source timestamp for this table.</summary>
+    public required DateTimeOffset LastSyncTimestamp { get; set; }
+
+    /// <summary>Auto-incrementing version for rollback support.</summary>
+    public required int Version { get; set; }
+
+    /// <summary>Number of records synced in this batch.</summary>
+    public required int RecordCount { get; set; }
+
+    /// <summary>When this checkpoint was created.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>Whether this checkpoint has been rolled back.</summary>
+    public bool IsRolledBack { get; set; }
+}

--- a/src/NordKredit.Domain/DataMigration/ReferentialIntegrityValidator.cs
+++ b/src/NordKredit.Domain/DataMigration/ReferentialIntegrityValidator.cs
@@ -1,0 +1,69 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Validates referential integrity after a sync batch by checking that
+/// all foreign key references in the migrated records point to existing records.
+/// COBOL source: VSAM alternate index relationships (e.g., CARDDAT→ACCTFILE).
+/// Regulation: FFFS 2014:5 Ch.4 §3 — operational risk (data integrity).
+/// </summary>
+public class ReferentialIntegrityValidator
+{
+    private readonly IReferentialIntegrityChecker _checker;
+
+    public ReferentialIntegrityValidator(IReferentialIntegrityChecker checker)
+    {
+        _checker = checker;
+    }
+
+    /// <summary>
+    /// Validates referential integrity for a batch of converted records against the table mapping.
+    /// Returns a list of validation error messages (empty if all valid).
+    /// </summary>
+    public async Task<IReadOnlyList<string>> ValidateAsync(
+        IReadOnlyList<ConvertedRecord> records,
+        TableMapping mapping,
+        CancellationToken cancellationToken = default)
+    {
+        var errors = new List<string>();
+
+        if (mapping.ForeignKeys.Count == 0)
+        {
+            return errors;
+        }
+
+        foreach (var fk in mapping.ForeignKeys)
+        {
+            // Collect all distinct FK values from the batch
+            var fkValues = new HashSet<string>();
+            foreach (var record in records)
+            {
+                if (record.ChangeType == ChangeType.Delete)
+                {
+                    continue;
+                }
+
+                if (record.Fields.TryGetValue(fk.Column, out var value) && value is not null)
+                {
+                    fkValues.Add(value.ToString()!);
+                }
+            }
+
+            if (fkValues.Count == 0)
+            {
+                continue;
+            }
+
+            var missingKeys = await _checker.FindMissingKeysAsync(
+                fk.ReferencedTable, fk.ReferencedColumn, fkValues, cancellationToken);
+
+            foreach (var missingKey in missingKeys)
+            {
+                errors.Add(
+                    $"Referential integrity violation: {mapping.TargetTable}.{fk.Column} " +
+                    $"value '{missingKey}' not found in {fk.ReferencedTable}.{fk.ReferencedColumn}");
+            }
+        }
+
+        return errors;
+    }
+}

--- a/src/NordKredit.Domain/DataMigration/SourceRecord.cs
+++ b/src/NordKredit.Domain/DataMigration/SourceRecord.cs
@@ -1,0 +1,39 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Represents a single record read from the Db2 source system during migration.
+/// Contains raw field data (EBCDIC bytes) and metadata about the change.
+/// COBOL source: All copybook structures referenced in schema mapping document.
+/// Regulation: GDPR Art. 5(1)(d) — accuracy of personal data during migration.
+/// </summary>
+public class SourceRecord
+{
+    /// <summary>The source table name (e.g., "ACCTFILE", "CARDDAT").</summary>
+    public required string TableName { get; init; }
+
+    /// <summary>The type of change detected.</summary>
+    public required ChangeType ChangeType { get; init; }
+
+    /// <summary>Primary key value(s) as a string (composite keys joined with '|').</summary>
+    public required string PrimaryKey { get; init; }
+
+    /// <summary>
+    /// Raw field values keyed by COBOL field name.
+    /// Values are byte arrays (EBCDIC-encoded) for text/numeric fields,
+    /// or pre-converted strings for already-processed fields.
+    /// </summary>
+    public required IReadOnlyDictionary<string, object> Fields { get; init; }
+
+    /// <summary>Timestamp of the change in the source system.</summary>
+    public required DateTimeOffset SourceTimestamp { get; init; }
+}
+
+/// <summary>
+/// The type of change detected in the source system.
+/// </summary>
+public enum ChangeType
+{
+    Insert,
+    Update,
+    Delete
+}

--- a/src/NordKredit.Domain/DataMigration/TableMapping.cs
+++ b/src/NordKredit.Domain/DataMigration/TableMapping.cs
@@ -1,0 +1,85 @@
+namespace NordKredit.Domain.DataMigration;
+
+/// <summary>
+/// Defines the field-level mapping between a Db2 source table and an Azure SQL target table.
+/// Based on schema mapping from #143.
+/// COBOL source: Copybook structures (CVACT01Y, CVACT02Y, CVACT03Y, CVTRA05Y, etc.).
+/// </summary>
+public class TableMapping
+{
+    /// <summary>Source Db2/VSAM table name.</summary>
+    public required string SourceTable { get; init; }
+
+    /// <summary>Target Azure SQL table name.</summary>
+    public required string TargetTable { get; init; }
+
+    /// <summary>Primary key column name(s) in the target table.</summary>
+    public required IReadOnlyList<string> PrimaryKeyColumns { get; init; }
+
+    /// <summary>Field-level mappings from source to target.</summary>
+    public required IReadOnlyList<FieldMapping> Fields { get; init; }
+
+    /// <summary>Foreign key relationships for referential integrity validation.</summary>
+    public IReadOnlyList<ForeignKeyMapping> ForeignKeys { get; init; } = [];
+}
+
+/// <summary>
+/// Maps a single field from COBOL/Db2 source to Azure SQL target.
+/// </summary>
+public class FieldMapping
+{
+    /// <summary>Source COBOL field name.</summary>
+    public required string SourceField { get; init; }
+
+    /// <summary>Target Azure SQL column name.</summary>
+    public required string TargetColumn { get; init; }
+
+    /// <summary>The COBOL data type for conversion.</summary>
+    public required CobolFieldType FieldType { get; init; }
+
+    /// <summary>Decimal scale for numeric fields (e.g., 2 for PIC 9(5)V99).</summary>
+    public int Scale { get; init; }
+}
+
+/// <summary>
+/// Defines a foreign key relationship for referential integrity validation.
+/// </summary>
+public class ForeignKeyMapping
+{
+    /// <summary>Column in this table that references another table.</summary>
+    public required string Column { get; init; }
+
+    /// <summary>Referenced table name.</summary>
+    public required string ReferencedTable { get; init; }
+
+    /// <summary>Referenced column name.</summary>
+    public required string ReferencedColumn { get; init; }
+}
+
+/// <summary>
+/// COBOL field types that require different conversion strategies.
+/// Based on the schema mapping document from #143.
+/// </summary>
+public enum CobolFieldType
+{
+    /// <summary>PIC X(n) — alphanumeric text, convert via EbcdicConverter.ConvertToUnicode.</summary>
+    Alphanumeric,
+
+    /// <summary>PIC 9(n) — unsigned numeric, convert via EbcdicConverter.ConvertZonedDecimal.</summary>
+    ZonedDecimal,
+
+    /// <summary>PIC S9(n)Vnn — signed numeric with implied decimal, convert via EbcdicConverter.ConvertZonedDecimal.</summary>
+    SignedZonedDecimal,
+
+    /// <summary>COMP-3 — packed decimal, convert via EbcdicConverter.ConvertPackedDecimal.</summary>
+    PackedDecimal,
+
+    /// <summary>PIC X(n) containing a date string — convert to DateOnly after EBCDIC decode.</summary>
+    Date,
+
+    /// <summary>PIC X(n) containing a timestamp — convert to DateTime after EBCDIC decode.</summary>
+    Timestamp,
+
+    /// <summary>PIC 9(n) — numeric stored as string to preserve leading zeros (e.g., AccountId).</summary>
+    NumericString
+}

--- a/tests/NordKredit.UnitTests/DataMigration/FieldConverterTests.cs
+++ b/tests/NordKredit.UnitTests/DataMigration/FieldConverterTests.cs
@@ -1,0 +1,334 @@
+using NordKredit.Domain.DataMigration;
+
+namespace NordKredit.UnitTests.DataMigration;
+
+/// <summary>
+/// Unit tests for FieldConverter — converts EBCDIC source fields to .NET types.
+/// Validates EBCDIC text, packed decimal, zoned decimal, date, and timestamp conversions.
+/// COBOL source: All copybook field conversions during Db2 → Azure SQL migration.
+/// Regulation: GDPR Art. 5(1)(d) — accuracy of personal data during migration.
+/// </summary>
+public class FieldConverterTests
+{
+    private readonly StubEbcdicConverter _ebcdicConverter = new();
+    private readonly FieldConverter _converter;
+
+    public FieldConverterTests()
+    {
+        _converter = new FieldConverter(_ebcdicConverter);
+    }
+
+    // ===================================================================
+    // AC: EBCDIC-to-Unicode conversion is applied to all text fields
+    // Alphanumeric (PIC X) fields are converted and trimmed
+    // ===================================================================
+
+    [Fact]
+    public void Convert_AlphanumericField_ConvertsAndTrims()
+    {
+        var mapping = CreateMapping("Accounts", fields:
+        [
+            new FieldMapping { SourceField = "ACCT-ACTIVE-STATUS", TargetColumn = "ActiveStatus", FieldType = CobolFieldType.Alphanumeric }
+        ]);
+        byte[] ebcdicBytes = [0xC1]; // 'A' in EBCDIC
+        var source = CreateSourceRecord("ACCTFILE", fields: new()
+        {
+            ["ACCT-ACTIVE-STATUS"] = ebcdicBytes
+        });
+        _ebcdicConverter.UnicodeResult = "A   "; // With trailing spaces
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Equal("A", result.Fields["ActiveStatus"]);
+    }
+
+    // ===================================================================
+    // AC: EBCDIC-to-Unicode conversion handles Swedish characters (Å, Ä, Ö)
+    // ===================================================================
+
+    [Fact]
+    public void Convert_SwedishCharacters_PreservesCorrectly()
+    {
+        var mapping = CreateMapping("Cards", fields:
+        [
+            new FieldMapping { SourceField = "CARD-EMBOSSED-NAME", TargetColumn = "EmbossedName", FieldType = CobolFieldType.Alphanumeric }
+        ]);
+        byte[] ebcdicBytes = [0x01];
+        var source = CreateSourceRecord("CARDDAT", fields: new()
+        {
+            ["CARD-EMBOSSED-NAME"] = ebcdicBytes
+        });
+        _ebcdicConverter.UnicodeResult = "Björk Ström";
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Equal("Björk Ström", result.Fields["EmbossedName"]);
+    }
+
+    // ===================================================================
+    // AC: Packed decimal (COMP-3) conversion for numeric fields
+    // ===================================================================
+
+    [Fact]
+    public void Convert_PackedDecimalField_ConvertsWithScale()
+    {
+        var mapping = CreateMapping("Accounts", fields:
+        [
+            new FieldMapping { SourceField = "ACCT-CURR-BAL", TargetColumn = "CurrentBalance", FieldType = CobolFieldType.PackedDecimal, Scale = 2 }
+        ]);
+        byte[] packed = [0x12, 0x34, 0x5C]; // 123.45
+        var source = CreateSourceRecord("ACCTFILE", fields: new()
+        {
+            ["ACCT-CURR-BAL"] = packed
+        });
+        _ebcdicConverter.PackedDecimalResult = 123.45m;
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Equal(123.45m, result.Fields["CurrentBalance"]);
+    }
+
+    // ===================================================================
+    // AC: Zoned decimal conversion for signed numeric fields
+    // ===================================================================
+
+    [Fact]
+    public void Convert_SignedZonedDecimalField_ConvertsWithScale()
+    {
+        var mapping = CreateMapping("Transactions", fields:
+        [
+            new FieldMapping { SourceField = "TRAN-AMT", TargetColumn = "Amount", FieldType = CobolFieldType.SignedZonedDecimal, Scale = 2 }
+        ]);
+        byte[] zoned = [0xF1, 0xF0, 0xF0, 0xD0];
+        var source = CreateSourceRecord("TRANSACT", fields: new()
+        {
+            ["TRAN-AMT"] = zoned
+        });
+        _ebcdicConverter.ZonedDecimalResult = -100.00m;
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Equal(-100.00m, result.Fields["Amount"]);
+    }
+
+    // ===================================================================
+    // AC: NumericString preserves leading zeros (e.g., AccountId PIC 9(11))
+    // ===================================================================
+
+    [Fact]
+    public void Convert_NumericStringField_PreservesLeadingZeros()
+    {
+        var mapping = CreateMapping("Accounts", fields:
+        [
+            new FieldMapping { SourceField = "ACCT-ID", TargetColumn = "Id", FieldType = CobolFieldType.NumericString }
+        ]);
+        byte[] ebcdicBytes = [0x01];
+        var source = CreateSourceRecord("ACCTFILE", fields: new()
+        {
+            ["ACCT-ID"] = ebcdicBytes
+        });
+        _ebcdicConverter.UnicodeResult = "00012345678";
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Equal("00012345678", result.Fields["Id"]);
+    }
+
+    // ===================================================================
+    // AC: Date fields convert from COBOL date format to DateOnly
+    // ===================================================================
+
+    [Fact]
+    public void Convert_DateField_ParsesCobolFormat()
+    {
+        var mapping = CreateMapping("Cards", fields:
+        [
+            new FieldMapping { SourceField = "CARD-EXPIRY-DATE", TargetColumn = "ExpirationDate", FieldType = CobolFieldType.Date }
+        ]);
+        byte[] ebcdicBytes = [0x01];
+        var source = CreateSourceRecord("CARDDAT", fields: new()
+        {
+            ["CARD-EXPIRY-DATE"] = ebcdicBytes
+        });
+        _ebcdicConverter.UnicodeResult = "2027-03-15";
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Equal(new DateOnly(2027, 3, 15), result.Fields["ExpirationDate"]);
+    }
+
+    // ===================================================================
+    // AC: Timestamp fields convert from COBOL timestamp to DateTime
+    // ===================================================================
+
+    [Fact]
+    public void Convert_TimestampField_ParsesCobolFormat()
+    {
+        var mapping = CreateMapping("Transactions", fields:
+        [
+            new FieldMapping { SourceField = "TRAN-ORIG-TS", TargetColumn = "OriginationTimestamp", FieldType = CobolFieldType.Timestamp }
+        ]);
+        byte[] ebcdicBytes = [0x01];
+        var source = CreateSourceRecord("TRANSACT", fields: new()
+        {
+            ["TRAN-ORIG-TS"] = ebcdicBytes
+        });
+        _ebcdicConverter.UnicodeResult = "2026-02-17-14.30.00.000000";
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Equal(new DateTime(2026, 2, 17, 14, 30, 0), result.Fields["OriginationTimestamp"]);
+    }
+
+    // ===================================================================
+    // Missing source field → null in output
+    // ===================================================================
+
+    [Fact]
+    public void Convert_MissingField_ReturnsNull()
+    {
+        var mapping = CreateMapping("Accounts", fields:
+        [
+            new FieldMapping { SourceField = "MISSING-FIELD", TargetColumn = "MissingColumn", FieldType = CobolFieldType.Alphanumeric }
+        ]);
+        var source = CreateSourceRecord("ACCTFILE");
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Null(result.Fields["MissingColumn"]);
+    }
+
+    // ===================================================================
+    // Change type and primary key are preserved in converted record
+    // ===================================================================
+
+    [Fact]
+    public void Convert_PreservesChangeTypeAndPrimaryKey()
+    {
+        var mapping = CreateMapping("Accounts", fields: []);
+        var source = CreateSourceRecord("ACCTFILE", changeType: ChangeType.Update, primaryKey: "00012345678");
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Equal(ChangeType.Update, result.ChangeType);
+        Assert.Equal("00012345678", result.PrimaryKey);
+        Assert.Equal("Accounts", result.TargetTable);
+    }
+
+    // ===================================================================
+    // Empty date string → null
+    // ===================================================================
+
+    [Fact]
+    public void Convert_EmptyDateField_ReturnsNull()
+    {
+        var mapping = CreateMapping("Cards", fields:
+        [
+            new FieldMapping { SourceField = "DATE-FIELD", TargetColumn = "SomeDate", FieldType = CobolFieldType.Date }
+        ]);
+        byte[] ebcdicBytes = [0x01];
+        var source = CreateSourceRecord("CARDDAT", fields: new()
+        {
+            ["DATE-FIELD"] = ebcdicBytes
+        });
+        _ebcdicConverter.UnicodeResult = "          "; // Spaces
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Null(result.Fields["SomeDate"]);
+    }
+
+    // ===================================================================
+    // Multiple fields in one record are all converted
+    // ===================================================================
+
+    [Fact]
+    public void Convert_MultipleFields_AllConverted()
+    {
+        var mapping = CreateMapping("Accounts", fields:
+        [
+            new FieldMapping { SourceField = "ACCT-ID", TargetColumn = "Id", FieldType = CobolFieldType.NumericString },
+            new FieldMapping { SourceField = "ACCT-STATUS", TargetColumn = "ActiveStatus", FieldType = CobolFieldType.Alphanumeric },
+            new FieldMapping { SourceField = "ACCT-BAL", TargetColumn = "CurrentBalance", FieldType = CobolFieldType.PackedDecimal, Scale = 2 }
+        ]);
+        byte[] b1 = [0x01];
+        byte[] b2 = [0x02];
+        byte[] b3 = [0x03];
+        var source = CreateSourceRecord("ACCTFILE", fields: new()
+        {
+            ["ACCT-ID"] = b1,
+            ["ACCT-STATUS"] = b2,
+            ["ACCT-BAL"] = b3
+        });
+        _ebcdicConverter.UnicodeResult = "00012345678";
+        _ebcdicConverter.PackedDecimalResult = 500.00m;
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Equal(3, result.Fields.Count);
+    }
+
+    // ===================================================================
+    // Pre-converted string values pass through
+    // ===================================================================
+
+    [Fact]
+    public void Convert_PreConvertedStringValue_PassesThrough()
+    {
+        var mapping = CreateMapping("Accounts", fields:
+        [
+            new FieldMapping { SourceField = "ALREADY-STRING", TargetColumn = "StringCol", FieldType = CobolFieldType.Alphanumeric }
+        ]);
+        var source = CreateSourceRecord("ACCTFILE", fields: new()
+        {
+            ["ALREADY-STRING"] = "Already a string"
+        });
+
+        var result = _converter.Convert(source, mapping);
+
+        Assert.Equal("Already a string", result.Fields["StringCol"]);
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    private static TableMapping CreateMapping(string targetTable, IReadOnlyList<FieldMapping>? fields = null) =>
+        new()
+        {
+            SourceTable = "SOURCE",
+            TargetTable = targetTable,
+            PrimaryKeyColumns = ["Id"],
+            Fields = fields ?? [],
+            ForeignKeys = []
+        };
+
+    private static SourceRecord CreateSourceRecord(
+        string tableName,
+        Dictionary<string, object>? fields = null,
+        ChangeType changeType = ChangeType.Insert,
+        string primaryKey = "PK001") =>
+        new()
+        {
+            TableName = tableName,
+            ChangeType = changeType,
+            PrimaryKey = primaryKey,
+            Fields = fields ?? [],
+            SourceTimestamp = DateTimeOffset.UtcNow
+        };
+}
+
+// ===================================================================
+// Test doubles
+// ===================================================================
+
+internal sealed class StubEbcdicConverter : IEbcdicConverter
+{
+    public string UnicodeResult { get; set; } = "";
+    public decimal PackedDecimalResult { get; set; }
+    public decimal ZonedDecimalResult { get; set; }
+
+    public string ConvertToUnicode(byte[] ebcdicBytes) => UnicodeResult;
+    public decimal ConvertPackedDecimal(byte[] packedBytes, int scale = 0) => PackedDecimalResult;
+    public decimal ConvertZonedDecimal(byte[] zonedBytes, int scale = 0) => ZonedDecimalResult;
+}

--- a/tests/NordKredit.UnitTests/DataMigration/MigrationPipelineTests.cs
+++ b/tests/NordKredit.UnitTests/DataMigration/MigrationPipelineTests.cs
@@ -1,0 +1,561 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NordKredit.Domain.DataMigration;
+
+namespace NordKredit.UnitTests.DataMigration;
+
+/// <summary>
+/// Unit tests for MigrationPipeline — orchestrates incremental Db2 → Azure SQL sync.
+/// Validates incremental sync, conversion, validation, rollback, and audit logging.
+/// Regulations: GDPR Art. 5(1)(d) (accuracy), GDPR Art.17 (erasure), DORA Art.11 (audit).
+/// </summary>
+public class MigrationPipelineTests
+{
+    private static readonly byte[] _testBytes = [0x01];
+    private static readonly byte[] _testBytes2 = [0x02];
+    private static readonly byte[] _badBytes = [0xFF];
+
+    private readonly StubSourceDataReader _sourceReader = new();
+    private readonly StubTargetDataWriter _targetWriter = new();
+    private readonly StubMigrationAuditLog _auditLog = new();
+    private readonly StubMigrationStateStore _stateStore = new();
+    private readonly StubEbcdicConverterForPipeline _ebcdicConverter = new();
+    private readonly StubReferentialIntegrityCheckerForPipeline _integrityChecker = new();
+
+    // ===================================================================
+    // AC: Pipeline incrementally syncs data (changed records only)
+    // No changes since last sync → no records written
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_NoChanges_ReturnsZeroRecords()
+    {
+        _sourceReader.Records = [];
+        var pipeline = CreatePipeline();
+
+        var result = await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.Equal(0, result.RecordsRead);
+        Assert.Equal(0, result.RecordsWritten);
+        Assert.True(result.IsSuccess);
+    }
+
+    // ===================================================================
+    // AC: Pipeline reads changed records and writes to target
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_WithChanges_ReadsConvertsAndWrites()
+    {
+        var sourceRecords = new List<SourceRecord>
+        {
+            CreateSourceRecord("ACCTFILE", "PK001", new() { ["ACCT-ID"] = _testBytes }),
+            CreateSourceRecord("ACCTFILE", "PK002", new() { ["ACCT-ID"] = _testBytes2 })
+        };
+        _sourceReader.Records = sourceRecords;
+        _targetWriter.WrittenCount = 2;
+        _ebcdicConverter.UnicodeResult = "00012345678";
+        var pipeline = CreatePipeline();
+
+        var result = await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.Equal(2, result.RecordsRead);
+        Assert.Equal(2, result.RecordsWritten);
+        Assert.True(result.IsSuccess);
+    }
+
+    // ===================================================================
+    // AC: Pipeline supports incremental sync (uses last checkpoint)
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_WithExistingCheckpoint_ReadsSinceLastSync()
+    {
+        var lastSync = new DateTimeOffset(2026, 2, 16, 12, 0, 0, TimeSpan.Zero);
+        _stateStore.LatestState = new MigrationSyncState
+        {
+            Id = "state-1",
+            TableName = "Accounts",
+            LastSyncTimestamp = lastSync,
+            Version = 1,
+            RecordCount = 100,
+            CreatedAt = lastSync
+        };
+        _sourceReader.Records = [];
+        var pipeline = CreatePipeline();
+
+        await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.Equal(lastSync, _sourceReader.LastSinceTimestamp);
+    }
+
+    // ===================================================================
+    // AC: First sync starts from beginning of time
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_NoCheckpoint_StartFromMinValue()
+    {
+        _stateStore.LatestState = null;
+        _sourceReader.Records = [];
+        var pipeline = CreatePipeline();
+
+        await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.Equal(DateTimeOffset.MinValue, _sourceReader.LastSinceTimestamp);
+    }
+
+    // ===================================================================
+    // AC: Sync state checkpoint is saved after successful sync
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_Success_SavesCheckpoint()
+    {
+        var sourceTimestamp = new DateTimeOffset(2026, 2, 17, 10, 0, 0, TimeSpan.Zero);
+        _sourceReader.Records =
+        [
+            CreateSourceRecord("ACCTFILE", "PK001", timestamp: sourceTimestamp)
+        ];
+        _targetWriter.WrittenCount = 1;
+        _ebcdicConverter.UnicodeResult = "test";
+        var pipeline = CreatePipeline();
+
+        await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.NotNull(_stateStore.LastSavedState);
+        Assert.Equal("Accounts", _stateStore.LastSavedState.TableName);
+        Assert.Equal(sourceTimestamp, _stateStore.LastSavedState.LastSyncTimestamp);
+        Assert.Equal(1, _stateStore.LastSavedState.Version);
+    }
+
+    // ===================================================================
+    // AC: Checkpoint version increments on each sync
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_ExistingCheckpoint_IncrementsVersion()
+    {
+        _stateStore.LatestState = new MigrationSyncState
+        {
+            Id = "state-1",
+            TableName = "Accounts",
+            LastSyncTimestamp = DateTimeOffset.UtcNow.AddHours(-1),
+            Version = 3,
+            RecordCount = 50,
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-1)
+        };
+        _sourceReader.Records = [CreateSourceRecord("ACCTFILE", "PK001")];
+        _targetWriter.WrittenCount = 1;
+        _ebcdicConverter.UnicodeResult = "test";
+        var pipeline = CreatePipeline();
+
+        await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.Equal(4, _stateStore.LastSavedState!.Version);
+    }
+
+    // ===================================================================
+    // AC: Conversion failures are counted but don't stop the batch
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_ConversionFailure_ContinuesWithOtherRecords()
+    {
+        _sourceReader.Records =
+        [
+            CreateSourceRecord("ACCTFILE", "PK001", new() { ["BAD-FIELD"] = _badBytes }),
+            CreateSourceRecord("ACCTFILE", "PK002", new() { ["ACCT-ID"] = _testBytes })
+        ];
+        _targetWriter.WrittenCount = 1;
+        _ebcdicConverter.UnicodeResult = "test";
+        _ebcdicConverter.ThrowOnFieldName = "BAD-FIELD";
+        var pipeline = CreatePipeline(fields:
+        [
+            new FieldMapping { SourceField = "BAD-FIELD", TargetColumn = "BadCol", FieldType = CobolFieldType.PackedDecimal },
+            new FieldMapping { SourceField = "ACCT-ID", TargetColumn = "Id", FieldType = CobolFieldType.NumericString }
+        ]);
+
+        var result = await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.Equal(2, result.RecordsRead);
+        Assert.Equal(1, result.RecordsWritten);
+        Assert.Equal(1, result.RecordsFailed);
+    }
+
+    // ===================================================================
+    // AC: Referential integrity validation runs post-sync
+    // Validation failure triggers rollback
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_ValidationFails_RollsBackBatch()
+    {
+        _sourceReader.Records = [CreateSourceRecord("ACCTFILE", "PK001")];
+        _targetWriter.WrittenCount = 1;
+        _ebcdicConverter.UnicodeResult = "test";
+        _integrityChecker.MissingKeys = ["MISSING001"];
+        var pipeline = CreatePipeline(foreignKeys:
+        [
+            new ForeignKeyMapping { Column = "Id", ReferencedTable = "OtherTable", ReferencedColumn = "Id" }
+        ]);
+
+        var result = await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.False(result.ValidationPassed);
+        Assert.Equal(0, result.RecordsWritten); // Rolled back
+        Assert.True(_targetWriter.RollbackCalled);
+    }
+
+    // ===================================================================
+    // AC: Validation failure does not save checkpoint
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_ValidationFails_DoesNotSaveCheckpoint()
+    {
+        _sourceReader.Records = [CreateSourceRecord("ACCTFILE", "PK001")];
+        _targetWriter.WrittenCount = 1;
+        _ebcdicConverter.UnicodeResult = "test";
+        _integrityChecker.MissingKeys = ["MISSING001"];
+        var pipeline = CreatePipeline(foreignKeys:
+        [
+            new ForeignKeyMapping { Column = "Id", ReferencedTable = "OtherTable", ReferencedColumn = "Id" }
+        ]);
+
+        await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.Null(_stateStore.LastSavedState);
+    }
+
+    // ===================================================================
+    // AC: Audit logging tracks all data changes (GDPR/DORA)
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_Success_LogsAuditEntries()
+    {
+        _sourceReader.Records =
+        [
+            CreateSourceRecord("ACCTFILE", "PK001"),
+            CreateSourceRecord("ACCTFILE", "PK002")
+        ];
+        _targetWriter.WrittenCount = 2;
+        _ebcdicConverter.UnicodeResult = "test";
+        var pipeline = CreatePipeline();
+
+        await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.Equal(2, _auditLog.LoggedEntries.Count);
+        Assert.All(_auditLog.LoggedEntries, e =>
+        {
+            Assert.True(e.Success);
+            Assert.Equal("Sweden Central", e.DataRegion);
+            Assert.Equal("ACCTFILE", e.SourceTable);
+            Assert.Equal("Accounts", e.TargetTable);
+        });
+    }
+
+    // ===================================================================
+    // AC: Data residency is maintained (EU/Sweden Central)
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_AuditEntries_HaveCorrectDataRegion()
+    {
+        _sourceReader.Records = [CreateSourceRecord("ACCTFILE", "PK001")];
+        _targetWriter.WrittenCount = 1;
+        _ebcdicConverter.UnicodeResult = "test";
+        var pipeline = CreatePipeline();
+
+        await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.All(_auditLog.LoggedEntries, e => Assert.Equal("Sweden Central", e.DataRegion));
+    }
+
+    // ===================================================================
+    // AC: Failed records are logged with error details
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_FailedConversion_LogsErrorInAudit()
+    {
+        _sourceReader.Records =
+        [
+            CreateSourceRecord("ACCTFILE", "PK001", new() { ["BAD-FIELD"] = _badBytes })
+        ];
+        _ebcdicConverter.ThrowOnFieldName = "BAD-FIELD";
+        var pipeline = CreatePipeline(fields:
+        [
+            new FieldMapping { SourceField = "BAD-FIELD", TargetColumn = "BadCol", FieldType = CobolFieldType.PackedDecimal }
+        ]);
+
+        await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.Single(_auditLog.LoggedEntries);
+        Assert.False(_auditLog.LoggedEntries[0].Success);
+        Assert.Contains("Conversion failed", _auditLog.LoggedEntries[0].ErrorMessage!);
+    }
+
+    // ===================================================================
+    // AC: Rollback capability exists (revert to previous sync state)
+    // ===================================================================
+
+    [Fact]
+    public async Task RollbackTable_RestoresPreviousState()
+    {
+        var previousState = new MigrationSyncState
+        {
+            Id = "state-1",
+            TableName = "Accounts",
+            LastSyncTimestamp = DateTimeOffset.UtcNow.AddHours(-2),
+            Version = 1,
+            RecordCount = 50,
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-2)
+        };
+        _stateStore.RollbackResult = previousState;
+        var pipeline = CreatePipeline();
+
+        var result = await pipeline.RollbackTableAsync("Accounts");
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Version);
+        Assert.True(_stateStore.RollbackCalled);
+    }
+
+    // ===================================================================
+    // AC: Rollback with no previous state returns null
+    // ===================================================================
+
+    [Fact]
+    public async Task RollbackTable_NoPreviousState_ReturnsNull()
+    {
+        _stateStore.RollbackResult = null;
+        var pipeline = CreatePipeline();
+
+        var result = await pipeline.RollbackTableAsync("Accounts");
+
+        Assert.Null(result);
+    }
+
+    // ===================================================================
+    // Unknown table mapping throws
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_UnknownTable_ThrowsArgumentException()
+    {
+        var pipeline = CreatePipeline();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => pipeline.SyncTableAsync("UNKNOWN_TABLE"));
+    }
+
+    // ===================================================================
+    // AC: Batch correlation ID links all audit entries
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_AllAuditEntries_HaveSameBatchCorrelationId()
+    {
+        _sourceReader.Records =
+        [
+            CreateSourceRecord("ACCTFILE", "PK001"),
+            CreateSourceRecord("ACCTFILE", "PK002")
+        ];
+        _targetWriter.WrittenCount = 2;
+        _ebcdicConverter.UnicodeResult = "test";
+        var pipeline = CreatePipeline();
+
+        var result = await pipeline.SyncTableAsync("ACCTFILE");
+
+        var batchId = result.BatchCorrelationId;
+        Assert.All(_auditLog.LoggedEntries, e => Assert.Equal(batchId, e.BatchCorrelationId));
+    }
+
+    // ===================================================================
+    // AC: Validation failure audit entries record failure reason
+    // ===================================================================
+
+    [Fact]
+    public async Task SyncTable_ValidationFails_AuditEntriesMarkAsFailedWithReason()
+    {
+        _sourceReader.Records = [CreateSourceRecord("ACCTFILE", "PK001")];
+        _targetWriter.WrittenCount = 1;
+        _ebcdicConverter.UnicodeResult = "test";
+        _integrityChecker.MissingKeys = ["MISSING001"];
+        var pipeline = CreatePipeline(foreignKeys:
+        [
+            new ForeignKeyMapping { Column = "Id", ReferencedTable = "OtherTable", ReferencedColumn = "Id" }
+        ]);
+
+        await pipeline.SyncTableAsync("ACCTFILE");
+
+        Assert.Single(_auditLog.LoggedEntries);
+        Assert.False(_auditLog.LoggedEntries[0].Success);
+        Assert.Contains("Referential integrity", _auditLog.LoggedEntries[0].ErrorMessage!);
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    private MigrationPipeline CreatePipeline(
+        IReadOnlyList<FieldMapping>? fields = null,
+        IReadOnlyList<ForeignKeyMapping>? foreignKeys = null)
+    {
+        var mapping = new TableMapping
+        {
+            SourceTable = "ACCTFILE",
+            TargetTable = "Accounts",
+            PrimaryKeyColumns = ["Id"],
+            Fields = fields ??
+            [
+                new FieldMapping { SourceField = "ACCT-ID", TargetColumn = "Id", FieldType = CobolFieldType.NumericString }
+            ],
+            ForeignKeys = foreignKeys ?? []
+        };
+
+        var config = new MigrationPipelineConfiguration
+        {
+            BatchSize = 1000,
+            DataRegion = "Sweden Central",
+            TableMappings = new Dictionary<string, TableMapping> { ["ACCTFILE"] = mapping }
+        };
+
+        var fieldConverter = new FieldConverter(_ebcdicConverter);
+        var integrityValidator = new ReferentialIntegrityValidator(_integrityChecker);
+
+        return new MigrationPipeline(
+            _sourceReader,
+            _targetWriter,
+            _auditLog,
+            _stateStore,
+            fieldConverter,
+            integrityValidator,
+            config,
+            NullLogger<MigrationPipeline>.Instance);
+    }
+
+    private static SourceRecord CreateSourceRecord(
+        string tableName,
+        string primaryKey,
+        Dictionary<string, object>? fields = null,
+        DateTimeOffset? timestamp = null) =>
+        new()
+        {
+            TableName = tableName,
+            ChangeType = ChangeType.Insert,
+            PrimaryKey = primaryKey,
+            Fields = fields ?? new Dictionary<string, object> { ["ACCT-ID"] = _testBytes },
+            SourceTimestamp = timestamp ?? DateTimeOffset.UtcNow
+        };
+}
+
+// ===================================================================
+// Test doubles for MigrationPipeline
+// ===================================================================
+
+internal sealed class StubSourceDataReader : ISourceDataReader
+{
+    public IReadOnlyList<SourceRecord> Records { get; set; } = [];
+    public DateTimeOffset LastSinceTimestamp { get; private set; }
+
+    public Task<IReadOnlyList<SourceRecord>> ReadChangedRecordsAsync(
+        string tableName, DateTimeOffset sinceTimestamp, int batchSize,
+        CancellationToken cancellationToken = default)
+    {
+        LastSinceTimestamp = sinceTimestamp;
+        return Task.FromResult(Records);
+    }
+}
+
+internal sealed class StubTargetDataWriter : ITargetDataWriter
+{
+    public int WrittenCount { get; set; }
+    public bool RollbackCalled { get; private set; }
+
+    public Task<int> WriteBatchAsync(
+        IReadOnlyList<ConvertedRecord> records,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(WrittenCount);
+
+    public Task RollbackBatchAsync(
+        string tableName, IReadOnlyList<string> primaryKeys,
+        CancellationToken cancellationToken = default)
+    {
+        RollbackCalled = true;
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class StubMigrationAuditLog : IMigrationAuditLog
+{
+    public List<MigrationAuditEntry> LoggedEntries { get; } = [];
+
+    public Task LogBatchAsync(
+        IReadOnlyList<MigrationAuditEntry> entries,
+        CancellationToken cancellationToken = default)
+    {
+        LoggedEntries.AddRange(entries);
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class StubMigrationStateStore : IMigrationStateStore
+{
+    public MigrationSyncState? LatestState { get; set; }
+    public MigrationSyncState? LastSavedState { get; private set; }
+    public MigrationSyncState? RollbackResult { get; set; }
+    public bool RollbackCalled { get; private set; }
+
+    public Task<MigrationSyncState?> GetLatestAsync(
+        string tableName, CancellationToken cancellationToken = default) =>
+        Task.FromResult(LatestState);
+
+    public Task SaveAsync(
+        MigrationSyncState state, CancellationToken cancellationToken = default)
+    {
+        LastSavedState = state;
+        return Task.CompletedTask;
+    }
+
+    public Task<MigrationSyncState?> RollbackAsync(
+        string tableName, CancellationToken cancellationToken = default)
+    {
+        RollbackCalled = true;
+        return Task.FromResult(RollbackResult);
+    }
+}
+
+internal sealed class StubEbcdicConverterForPipeline : IEbcdicConverter
+{
+    public string UnicodeResult { get; set; } = "";
+    public decimal PackedDecimalResult { get; set; }
+    public decimal ZonedDecimalResult { get; set; }
+    public string? ThrowOnFieldName { get; set; }
+
+    public string ConvertToUnicode(byte[] ebcdicBytes) => UnicodeResult;
+
+    public decimal ConvertPackedDecimal(byte[] packedBytes, int scale = 0)
+    {
+        if (ThrowOnFieldName is not null)
+        {
+            throw new InvalidOperationException("Invalid packed decimal data");
+        }
+
+        return PackedDecimalResult;
+    }
+
+    public decimal ConvertZonedDecimal(byte[] zonedBytes, int scale = 0) => ZonedDecimalResult;
+}
+
+internal sealed class StubReferentialIntegrityCheckerForPipeline : IReferentialIntegrityChecker
+{
+    public IReadOnlyList<string> MissingKeys { get; set; } = [];
+
+    public Task<IReadOnlyList<string>> FindMissingKeysAsync(
+        string tableName, string columnName,
+        IReadOnlyCollection<string> keyValues,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(MissingKeys);
+}

--- a/tests/NordKredit.UnitTests/DataMigration/ReferentialIntegrityValidatorTests.cs
+++ b/tests/NordKredit.UnitTests/DataMigration/ReferentialIntegrityValidatorTests.cs
@@ -1,0 +1,225 @@
+using NordKredit.Domain.DataMigration;
+
+namespace NordKredit.UnitTests.DataMigration;
+
+/// <summary>
+/// Unit tests for ReferentialIntegrityValidator — validates foreign key relationships
+/// after a sync batch.
+/// COBOL source: VSAM alternate index relationships (CARDDAT→ACCTFILE, TRANSACT→CARDDAT).
+/// Regulation: FFFS 2014:5 Ch.4 §3 — operational risk (data integrity).
+/// </summary>
+public class ReferentialIntegrityValidatorTests
+{
+    private readonly StubReferentialIntegrityChecker _checker = new();
+    private readonly ReferentialIntegrityValidator _validator;
+
+    public ReferentialIntegrityValidatorTests()
+    {
+        _validator = new ReferentialIntegrityValidator(_checker);
+    }
+
+    // ===================================================================
+    // AC: Referential integrity validation runs post-sync
+    // No FK constraints → no errors
+    // ===================================================================
+
+    [Fact]
+    public async Task Validate_NoForeignKeys_ReturnsEmpty()
+    {
+        var mapping = CreateMapping(foreignKeys: []);
+        var records = new List<ConvertedRecord> { CreateConvertedRecord() };
+
+        var errors = await _validator.ValidateAsync(records, mapping);
+
+        Assert.Empty(errors);
+    }
+
+    // ===================================================================
+    // AC: All FK references exist → validation passes
+    // ===================================================================
+
+    [Fact]
+    public async Task Validate_AllReferencesExist_ReturnsEmpty()
+    {
+        var mapping = CreateMapping(foreignKeys:
+        [
+            new ForeignKeyMapping { Column = "AccountId", ReferencedTable = "Accounts", ReferencedColumn = "Id" }
+        ]);
+        var records = new List<ConvertedRecord>
+        {
+            CreateConvertedRecord(fields: new() { ["AccountId"] = "00012345678" })
+        };
+        _checker.MissingKeys = [];
+
+        var errors = await _validator.ValidateAsync(records, mapping);
+
+        Assert.Empty(errors);
+    }
+
+    // ===================================================================
+    // AC: Missing FK reference → returns validation error
+    // ===================================================================
+
+    [Fact]
+    public async Task Validate_MissingReference_ReturnsError()
+    {
+        var mapping = CreateMapping(
+            targetTable: "Cards",
+            foreignKeys:
+            [
+                new ForeignKeyMapping { Column = "AccountId", ReferencedTable = "Accounts", ReferencedColumn = "Id" }
+            ]);
+        var records = new List<ConvertedRecord>
+        {
+            CreateConvertedRecord(fields: new() { ["AccountId"] = "MISSING001" })
+        };
+        _checker.MissingKeys = ["MISSING001"];
+
+        var errors = await _validator.ValidateAsync(records, mapping);
+
+        Assert.Single(errors);
+        Assert.Contains("MISSING001", errors[0]);
+        Assert.Contains("Accounts", errors[0]);
+    }
+
+    // ===================================================================
+    // AC: Delete records are skipped during FK validation
+    // ===================================================================
+
+    [Fact]
+    public async Task Validate_DeleteRecord_SkipsValidation()
+    {
+        var mapping = CreateMapping(foreignKeys:
+        [
+            new ForeignKeyMapping { Column = "AccountId", ReferencedTable = "Accounts", ReferencedColumn = "Id" }
+        ]);
+        var records = new List<ConvertedRecord>
+        {
+            CreateConvertedRecord(changeType: ChangeType.Delete, fields: new() { ["AccountId"] = "00012345678" })
+        };
+
+        var errors = await _validator.ValidateAsync(records, mapping);
+
+        Assert.Empty(errors);
+        Assert.False(_checker.WasCalled);
+    }
+
+    // ===================================================================
+    // AC: Null FK value is skipped
+    // ===================================================================
+
+    [Fact]
+    public async Task Validate_NullFkValue_SkipsValidation()
+    {
+        var mapping = CreateMapping(foreignKeys:
+        [
+            new ForeignKeyMapping { Column = "AccountId", ReferencedTable = "Accounts", ReferencedColumn = "Id" }
+        ]);
+        var records = new List<ConvertedRecord>
+        {
+            CreateConvertedRecord(fields: new() { ["AccountId"] = null })
+        };
+
+        var errors = await _validator.ValidateAsync(records, mapping);
+
+        Assert.Empty(errors);
+    }
+
+    // ===================================================================
+    // AC: Multiple FK violations reported
+    // ===================================================================
+
+    [Fact]
+    public async Task Validate_MultipleMissingReferences_ReturnsAllErrors()
+    {
+        var mapping = CreateMapping(
+            targetTable: "Transactions",
+            foreignKeys:
+            [
+                new ForeignKeyMapping { Column = "CardNumber", ReferencedTable = "Cards", ReferencedColumn = "CardNumber" }
+            ]);
+        var records = new List<ConvertedRecord>
+        {
+            CreateConvertedRecord(fields: new() { ["CardNumber"] = "CARD001" }),
+            CreateConvertedRecord(fields: new() { ["CardNumber"] = "CARD002" })
+        };
+        _checker.MissingKeys = ["CARD001", "CARD002"];
+
+        var errors = await _validator.ValidateAsync(records, mapping);
+
+        Assert.Equal(2, errors.Count);
+    }
+
+    // ===================================================================
+    // AC: Deduplicates FK values before checking
+    // ===================================================================
+
+    [Fact]
+    public async Task Validate_DuplicateFkValues_DeduplicatesBeforeCheck()
+    {
+        var mapping = CreateMapping(foreignKeys:
+        [
+            new ForeignKeyMapping { Column = "AccountId", ReferencedTable = "Accounts", ReferencedColumn = "Id" }
+        ]);
+        var records = new List<ConvertedRecord>
+        {
+            CreateConvertedRecord(fields: new() { ["AccountId"] = "ACCT001" }),
+            CreateConvertedRecord(fields: new() { ["AccountId"] = "ACCT001" })
+        };
+        _checker.MissingKeys = [];
+
+        await _validator.ValidateAsync(records, mapping);
+
+        // Checker should have received deduplicated set
+        Assert.Single(_checker.LastCheckedValues!);
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    private static TableMapping CreateMapping(
+        string targetTable = "TestTable",
+        IReadOnlyList<ForeignKeyMapping>? foreignKeys = null) =>
+        new()
+        {
+            SourceTable = "SOURCE",
+            TargetTable = targetTable,
+            PrimaryKeyColumns = ["Id"],
+            Fields = [],
+            ForeignKeys = foreignKeys ?? []
+        };
+
+    private static ConvertedRecord CreateConvertedRecord(
+        ChangeType changeType = ChangeType.Insert,
+        Dictionary<string, object?>? fields = null) =>
+        new()
+        {
+            TargetTable = "TestTable",
+            ChangeType = changeType,
+            PrimaryKey = "PK001",
+            Fields = fields ?? [],
+            SourceTimestamp = DateTimeOffset.UtcNow
+        };
+}
+
+// ===================================================================
+// Test doubles
+// ===================================================================
+
+internal sealed class StubReferentialIntegrityChecker : IReferentialIntegrityChecker
+{
+    public IReadOnlyList<string> MissingKeys { get; set; } = [];
+    public bool WasCalled { get; private set; }
+    public IReadOnlyCollection<string>? LastCheckedValues { get; private set; }
+
+    public Task<IReadOnlyList<string>> FindMissingKeysAsync(
+        string tableName, string columnName,
+        IReadOnlyCollection<string> keyValues,
+        CancellationToken cancellationToken = default)
+    {
+        WasCalled = true;
+        LastCheckedValues = keyValues;
+        return Task.FromResult(MissingKeys);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements incremental data migration pipeline from Db2 to Azure SQL with timestamp-based change detection
- Adds EBCDIC-to-Unicode field conversion (alphanumeric, packed decimal, zoned decimal, date, timestamp)
- Includes post-sync referential integrity validation with automatic rollback on FK violations
- Full GDPR/DORA audit trail with Sweden Central data residency

## Changes
- **Domain layer** (17 files): `MigrationPipeline` orchestrator, `FieldConverter`, `ReferentialIntegrityValidator`, domain interfaces (`ISourceDataReader`, `ITargetDataWriter`, `IMigrationAuditLog`, `IMigrationStateStore`, `IReferentialIntegrityChecker`, `IEbcdicConverter`), and data models (`SourceRecord`, `ConvertedRecord`, `TableMapping`, `MigrationSyncState`, `MigrationAuditEntry`, `MigrationBatchResult`, `MigrationPipelineConfiguration`)
- **Tests** (3 files, 36 tests): `MigrationPipelineTests`, `FieldConverterTests`, `ReferentialIntegrityValidatorTests` — covering incremental sync, conversion, validation, rollback, audit logging
- **ADR-004**: Documents timestamp-based CDC decision, rollback strategy, audit requirements

## Regulatory Traceability
- GDPR Art. 5(1)(d) — Data accuracy during migration (field conversion validation)
- GDPR Art. 17 — Right to erasure traceability (audit entries per record)
- DORA Art. 11 — ICT system audit trail (batch correlation IDs, sync state versioning)
- FFFS 2014:5 Ch.4 §3 — Operational risk (referential integrity validation)

## Testing
- [x] Unit tests pass (36 new + 495 existing = 531 total)
- [x] All tests pass (665 total across all projects)
- [x] Build passes with `/warnaserror` (0 warnings)
- [x] `dotnet format --verify-no-changes` passes

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)