### PR TITLE
feat(#141): Add Application Insights telemetry and Azure Monitor integration

### DIFF
--- a/src/NordKredit.Api/NordKredit.Api.csproj
+++ b/src/NordKredit.Api/NordKredit.Api.csproj
@@ -6,6 +6,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="3.14.1" />
   </ItemGroup>
 

--- a/src/NordKredit.Api/Telemetry/NordKreditTelemetryInitializer.cs
+++ b/src/NordKredit.Api/Telemetry/NordKreditTelemetryInitializer.cs
@@ -1,0 +1,58 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace NordKredit.Api.Telemetry;
+
+/// <summary>
+/// Custom telemetry initializer that tags all requests with the NordKredit domain.
+/// Maps API endpoint paths to business domains for monitoring and alerting.
+/// DORA Art.11: ICT risk monitoring — domain-level observability.
+/// </summary>
+public class NordKreditTelemetryInitializer : ITelemetryInitializer
+{
+    internal const string DomainPropertyKey = "nordkredit.domain";
+
+    public void Initialize(ITelemetry telemetry)
+    {
+        var domain = ResolveDomain(telemetry);
+
+        if (telemetry is ISupportProperties supportProperties)
+        {
+            supportProperties.Properties[DomainPropertyKey] = domain;
+        }
+    }
+
+    private static string ResolveDomain(ITelemetry telemetry)
+    {
+        if (telemetry is not RequestTelemetry request)
+        {
+            return "general";
+        }
+
+        var url = request.Url;
+        if (url is null)
+        {
+            return "general";
+        }
+
+        var path = url.AbsolutePath.ToLowerInvariant();
+
+        if (path.StartsWith("/api/transactions", StringComparison.Ordinal))
+        {
+            return "payments";
+        }
+
+        if (path.StartsWith("/api/cards", StringComparison.Ordinal))
+        {
+            return "card-management";
+        }
+
+        if (path.StartsWith("/health", StringComparison.Ordinal))
+        {
+            return "infrastructure";
+        }
+
+        return "general";
+    }
+}

--- a/src/NordKredit.Api/appsettings.json
+++ b/src/NordKredit.Api/appsettings.json
@@ -6,6 +6,9 @@
     }
   },
   "AllowedHosts": "*",
+  "ApplicationInsights": {
+    "ConnectionString": ""
+  },
   "AzureAdB2C": {
     "Instance": "https://{tenant-name}.b2clogin.com",
     "Domain": "{tenant-name}.onmicrosoft.com",

--- a/src/NordKredit.Functions/NordKredit.Functions.csproj
+++ b/src/NordKredit.Functions/NordKredit.Functions.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
   </ItemGroup>
 

--- a/src/NordKredit.Functions/Program.cs
+++ b/src/NordKredit.Functions/Program.cs
@@ -2,10 +2,17 @@ using Microsoft.EntityFrameworkCore;
 using NordKredit.Domain.Transactions;
 using NordKredit.Functions;
 using NordKredit.Functions.Batch;
+using NordKredit.Functions.Telemetry;
 using NordKredit.Infrastructure;
 using NordKredit.Infrastructure.Transactions;
 
 var builder = Host.CreateApplicationBuilder(args);
+
+// Application Insights telemetry for worker service — DORA Art.11: ICT risk monitoring.
+builder.Services.AddApplicationInsightsTelemetryWorkerService();
+
+// Batch SLA custom metrics — tracks duration, posted, and rejected transaction counts.
+builder.Services.AddSingleton<BatchMetricsService>();
 
 builder.Services.AddDbContext<NordKreditDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("NordKreditDb")));

--- a/src/NordKredit.Functions/Telemetry/BatchMetricsService.cs
+++ b/src/NordKredit.Functions/Telemetry/BatchMetricsService.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics.Metrics;
+
+namespace NordKredit.Functions.Telemetry;
+
+/// <summary>
+/// Custom metrics for batch SLA monitoring.
+/// Tracks pipeline duration, posted transaction count, and rejected transaction count.
+/// DORA Art.11: ICT risk monitoring — batch SLA compliance metrics.
+/// Regulations: FFFS 2014:5 Ch.4 §3 (operational risk).
+/// </summary>
+public sealed class BatchMetricsService : IDisposable
+{
+    public const string MeterName = "NordKredit.Batch";
+
+    private readonly Meter _meter;
+
+    public BatchMetricsService(IMeterFactory meterFactory)
+    {
+        _meter = meterFactory.Create(MeterName);
+        BatchDuration = _meter.CreateHistogram<double>(
+            "batch.duration",
+            unit: "s",
+            description: "Duration of the daily batch pipeline in seconds");
+        TransactionsPosted = _meter.CreateCounter<long>(
+            "batch.transactions.posted",
+            unit: "{transactions}",
+            description: "Number of transactions successfully posted");
+        TransactionsRejected = _meter.CreateCounter<long>(
+            "batch.transactions.rejected",
+            unit: "{transactions}",
+            description: "Number of transactions rejected during validation");
+    }
+
+    public Histogram<double> BatchDuration { get; }
+    public Counter<long> TransactionsPosted { get; }
+    public Counter<long> TransactionsRejected { get; }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/src/NordKredit.Functions/appsettings.json
+++ b/src/NordKredit.Functions/appsettings.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "ApplicationInsights": {
+    "ConnectionString": ""
   }
 }

--- a/tests/NordKredit.UnitTests/Auth/AuthenticationTests.cs
+++ b/tests/NordKredit.UnitTests/Auth/AuthenticationTests.cs
@@ -33,11 +33,21 @@ public class AuthenticationTests : IClassFixture<AuthenticationTests.NordKreditW
     // =================================================================
 
     [Fact]
-    public async Task Health_NoAuth_Returns200()
+    public async Task HealthLive_NoAuth_Returns200()
     {
         var client = _factory.CreateUnauthenticatedClient();
 
-        var response = await client.GetAsync("/health");
+        var response = await client.GetAsync("/health/live");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task HealthReady_NoAuth_Returns200()
+    {
+        var client = _factory.CreateUnauthenticatedClient();
+
+        var response = await client.GetAsync("/health/ready");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }

--- a/tests/NordKredit.UnitTests/NordKredit.UnitTests.csproj
+++ b/tests/NordKredit.UnitTests/NordKredit.UnitTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />

--- a/tests/NordKredit.UnitTests/Telemetry/BatchMetricsServiceTests.cs
+++ b/tests/NordKredit.UnitTests/Telemetry/BatchMetricsServiceTests.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics.Metrics;
+using NordKredit.Functions.Telemetry;
+
+namespace NordKredit.UnitTests.Telemetry;
+
+public class BatchMetricsServiceTests : IDisposable
+{
+    private readonly IMeterFactory _meterFactory;
+    private readonly BatchMetricsService _sut;
+
+    public BatchMetricsServiceTests()
+    {
+        _meterFactory = new TestMeterFactory();
+        _sut = new BatchMetricsService(_meterFactory);
+    }
+
+    [Fact]
+    public void BatchDuration_histogram_is_created() => Assert.NotNull(_sut.BatchDuration);
+
+    [Fact]
+    public void TransactionsPosted_counter_is_created() => Assert.NotNull(_sut.TransactionsPosted);
+
+    [Fact]
+    public void TransactionsRejected_counter_is_created() => Assert.NotNull(_sut.TransactionsRejected);
+
+    [Fact]
+    public void BatchDuration_can_record_value()
+    {
+        var exception = Record.Exception(() => _sut.BatchDuration.Record(42.5));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void TransactionsPosted_can_add_value()
+    {
+        var exception = Record.Exception(() => _sut.TransactionsPosted.Add(100));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void TransactionsRejected_can_add_value()
+    {
+        var exception = Record.Exception(() => _sut.TransactionsRejected.Add(5));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Dispose_does_not_throw()
+    {
+        var exception = Record.Exception(_sut.Dispose);
+        Assert.Null(exception);
+    }
+
+    public void Dispose()
+    {
+        _sut.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed class TestMeterFactory : IMeterFactory
+    {
+        private readonly List<Meter> _meters = [];
+
+        public Meter Create(MeterOptions options)
+        {
+            var meter = new Meter(options.Name, options.Version);
+            _meters.Add(meter);
+            return meter;
+        }
+
+        public void Dispose()
+        {
+            foreach (var meter in _meters)
+            {
+                meter.Dispose();
+            }
+        }
+    }
+}

--- a/tests/NordKredit.UnitTests/Telemetry/HealthCheckTests.cs
+++ b/tests/NordKredit.UnitTests/Telemetry/HealthCheckTests.cs
@@ -1,0 +1,123 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+
+namespace NordKredit.UnitTests.Telemetry;
+
+public class HealthCheckTests
+{
+    [Fact]
+    public async Task LiveEndpoint_returns_ok_with_healthy_status()
+    {
+        using var host = await CreateTestHost();
+        var client = host.GetTestClient();
+
+        var response = await client.GetAsync("/health/live");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Healthy", content);
+    }
+
+    [Fact]
+    public async Task ReadyEndpoint_returns_ok_when_all_checks_healthy()
+    {
+        using var host = await CreateTestHost();
+        var client = host.GetTestClient();
+
+        var response = await client.GetAsync("/health/ready");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Healthy", content);
+    }
+
+    [Fact]
+    public async Task ReadyEndpoint_returns_service_unavailable_when_check_unhealthy()
+    {
+        using var host = await CreateTestHost(dbHealthy: false);
+        var client = host.GetTestClient();
+
+        var response = await client.GetAsync("/health/ready");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Unhealthy", content);
+    }
+
+    private static async Task<IHost> CreateTestHost(bool dbHealthy = true)
+    {
+        var builder = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+
+                    var healthBuilder = services.AddHealthChecks();
+
+                    if (dbHealthy)
+                    {
+                        healthBuilder.Add(new HealthCheckRegistration(
+                            "database",
+                            _ => new StubHealthCheck(HealthCheckResult.Healthy("DB OK")),
+                            failureStatus: null,
+                            tags: ["ready"]));
+                    }
+                    else
+                    {
+                        healthBuilder.Add(new HealthCheckRegistration(
+                            "database",
+                            _ => new StubHealthCheck(HealthCheckResult.Unhealthy("DB down")),
+                            failureStatus: null,
+                            tags: ["ready"]));
+                    }
+                });
+
+                webHost.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+                        {
+                            Predicate = _ => false,
+                            ResponseWriter = WriteHealthResponse,
+                        });
+
+                        endpoints.MapHealthChecks("/health/ready", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+                        {
+                            Predicate = check => check.Tags.Contains("ready"),
+                            ResponseWriter = WriteHealthResponse,
+                        });
+                    });
+                });
+            });
+
+        var host = builder.Build();
+        await host.StartAsync();
+        return host;
+    }
+
+    private static async Task WriteHealthResponse(
+        HttpContext context,
+        HealthReport report)
+    {
+        context.Response.ContentType = "application/json";
+        var status = report.Status.ToString();
+        await context.Response.WriteAsync($"{{\"status\":\"{status}\"}}");
+    }
+
+    private sealed class StubHealthCheck(HealthCheckResult result) : IHealthCheck
+    {
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default) => Task.FromResult(result);
+    }
+}

--- a/tests/NordKredit.UnitTests/Telemetry/NordKreditTelemetryInitializerTests.cs
+++ b/tests/NordKredit.UnitTests/Telemetry/NordKreditTelemetryInitializerTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.ApplicationInsights.DataContracts;
+using NordKredit.Api.Telemetry;
+
+namespace NordKredit.UnitTests.Telemetry;
+
+public class NordKreditTelemetryInitializerTests
+{
+    private readonly NordKreditTelemetryInitializer _sut = new();
+
+    [Fact]
+    public void Initialize_TransactionRequest_Tags_payments_domain()
+    {
+        var telemetry = new RequestTelemetry
+        {
+            Url = new Uri("https://localhost/api/transactions/123"),
+        };
+
+        _sut.Initialize(telemetry);
+
+        Assert.Equal("payments", telemetry.Properties["nordkredit.domain"]);
+    }
+
+    [Fact]
+    public void Initialize_CardsRequest_Tags_card_management_domain()
+    {
+        var telemetry = new RequestTelemetry
+        {
+            Url = new Uri("https://localhost/api/cards"),
+        };
+
+        _sut.Initialize(telemetry);
+
+        Assert.Equal("card-management", telemetry.Properties["nordkredit.domain"]);
+    }
+
+    [Fact]
+    public void Initialize_HealthRequest_Tags_infrastructure_domain()
+    {
+        var telemetry = new RequestTelemetry
+        {
+            Url = new Uri("https://localhost/health/ready"),
+        };
+
+        _sut.Initialize(telemetry);
+
+        Assert.Equal("infrastructure", telemetry.Properties["nordkredit.domain"]);
+    }
+
+    [Fact]
+    public void Initialize_UnknownPath_Tags_general_domain()
+    {
+        var telemetry = new RequestTelemetry
+        {
+            Url = new Uri("https://localhost/api/other"),
+        };
+
+        _sut.Initialize(telemetry);
+
+        Assert.Equal("general", telemetry.Properties["nordkredit.domain"]);
+    }
+
+    [Fact]
+    public void Initialize_NonRequestTelemetry_Tags_general_domain()
+    {
+        var telemetry = new TraceTelemetry("test message");
+
+        _sut.Initialize(telemetry);
+
+        Assert.Equal("general", telemetry.Properties["nordkredit.domain"]);
+    }
+
+    [Fact]
+    public void Initialize_RequestWithNullUrl_Tags_general_domain()
+    {
+        var telemetry = new RequestTelemetry();
+
+        _sut.Initialize(telemetry);
+
+        Assert.Equal("general", telemetry.Properties["nordkredit.domain"]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add Application Insights SDK to both API (AspNetCore) and Functions (WorkerService) projects
- Implement custom telemetry initializer that tags requests with `nordkredit.domain` (payments, card-management, infrastructure, general)
- Add batch SLA custom metrics: `batch.duration`, `batch.transactions.posted`, `batch.transactions.rejected`
- Replace simple `/health` endpoint with proper health check endpoints: `/health/live` (liveness probe) and `/health/ready` (DB connectivity readiness probe)

## Changes
- `src/NordKredit.Api/NordKredit.Api.csproj` — Added `Microsoft.ApplicationInsights.AspNetCore` and `AspNetCore.HealthChecks.SqlServer`
- `src/NordKredit.Api/Program.cs` — Configured Application Insights, telemetry initializer, health check endpoints
- `src/NordKredit.Api/Telemetry/NordKreditTelemetryInitializer.cs` — Custom telemetry initializer mapping URL paths to business domains
- `src/NordKredit.Api/appsettings.json` — Added Application Insights connection string placeholder
- `src/NordKredit.Functions/NordKredit.Functions.csproj` — Added `Microsoft.ApplicationInsights.WorkerService`
- `src/NordKredit.Functions/Program.cs` — Configured Application Insights worker service and batch metrics
- `src/NordKredit.Functions/Telemetry/BatchMetricsService.cs` — Custom metrics for batch SLA monitoring
- `src/NordKredit.Functions/appsettings.json` — Added Application Insights connection string placeholder
- `tests/NordKredit.UnitTests/` — Added 16 new tests for telemetry initializer, batch metrics, and health checks

## Regulatory
- DORA Art.11: ICT risk monitoring via Application Insights telemetry
- FFFS 2014:5 Ch.4 §3: Operational risk monitoring via batch SLA metrics

## Testing
- [x] Unit tests pass (548 tests)
- [x] BDD tests pass (70 tests)
- [x] Comparison tests pass (64 tests)
- [x] `dotnet build /warnaserror` — 0 warnings
- [x] `dotnet format --verify-no-changes` — clean

Closes #141

🤖 Generated with Claude Code