### PR TITLE
feat(#142): Add Bicep IaC templates for Azure deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ Thumbs.db
 # Node (docs-site)
 node_modules/
 
+# Bicep compiled ARM templates
+infra/**/*.json
+
 # Environment
 .env
 *.local

--- a/docs/Architecture/ADR-005-bicep-iac-templates.md
+++ b/docs/Architecture/ADR-005-bicep-iac-templates.md
@@ -1,0 +1,116 @@
+# ADR-005: Bicep IaC Templates for Azure Deployment
+
+**Date:** 2026-02-17
+
+**Status:** Accepted
+
+**Deciders:** Platform team
+
+**Tags:** infrastructure, compliance, security
+
+---
+
+## Context
+
+**What is the issue we're trying to solve?**
+
+NordKredit's target architecture runs on Azure (App Service, Azure SQL, Azure Functions, Service Bus, Key Vault, Application Insights) but no infrastructure-as-code exists. Manual provisioning is error-prone and non-auditable, which conflicts with DORA requirements for documented ICT infrastructure and GDPR data residency enforcement.
+
+**What forces are at play?**
+
+- **Regulatory:** GDPR requires data residency in EU (Sweden Central). DORA requires documented ICT third-party arrangements.
+- **Repeatability:** dev/staging/production environments must be consistent.
+- **Security:** Secrets must be stored in Key Vault, not in application configuration.
+- **Auditability:** Infrastructure changes must be version-controlled and reviewable.
+- **Existing patterns:** The project already uses Azure-native services (Service Bus, App Insights, Azure AD).
+
+---
+
+## Decision
+
+**What did we decide?**
+
+Use Azure Bicep with a modular structure:
+
+1. **One module per resource type** in `infra/modules/` — App Service, Azure SQL, Azure Functions, Service Bus, Key Vault, Application Insights.
+2. **One orchestration file** `infra/main.bicep` that composes all modules.
+3. **Per-environment parameter files** `infra/parameters/` for dev, staging, and production.
+4. **All resources deployed to Sweden Central** (swedencentral) for GDPR compliance.
+5. **Key Vault** stores all connection strings and secrets; applications reference Key Vault via managed identity.
+6. **Service Bus** defines queues for Bankgirot and SWIFT integrations.
+
+---
+
+## Alternatives Considered
+
+### Alternative 1: Terraform
+**Description:** Use HashiCorp Terraform with azurerm provider.
+
+**Pros:**
+- Multi-cloud support
+- Large community and ecosystem
+
+**Cons:**
+- Requires separate state management (remote backend)
+- Additional tool dependency (Terraform CLI)
+- Not Azure-native — slight lag in new resource support
+
+**Why rejected:** Project is Azure-only; Bicep is first-class Azure IaC with native validation and no state management overhead.
+
+### Alternative 2: ARM Templates (raw JSON)
+**Description:** Use raw ARM JSON templates directly.
+
+**Pros:**
+- No additional tooling needed
+- Direct Azure Resource Manager format
+
+**Cons:**
+- Verbose and hard to read/maintain
+- No native modularity or type safety
+- Poor developer experience
+
+**Why rejected:** Bicep compiles to ARM but provides superior authoring experience, modularity, and type safety.
+
+---
+
+## Consequences
+
+### Positive
+- Infrastructure is version-controlled and auditable (DORA compliance)
+- Consistent environments across dev/staging/production
+- GDPR data residency enforced at the template level (swedencentral)
+- Secrets managed securely via Key Vault
+- Validates with `az bicep build` before deployment
+
+### Negative
+- Requires Azure CLI with Bicep extension for local development
+- Azure AD B2C tenant cannot be provisioned via Bicep (manual step)
+
+### Risks
+- Azure AD B2C tenant provisioning is a manual step
+  - **Mitigation:** Document as manual prerequisite; reference tenant IDs via parameters
+- SKU/pricing changes between environments need careful parameter management
+  - **Mitigation:** Environment-specific parameter files with appropriate tier selections
+
+---
+
+## Implementation Notes
+
+- Module structure: `infra/modules/{resource}.bicep`
+- Parameter files: `infra/parameters/{env}.bicepparam`
+- All modules accept `location` parameter defaulting to `swedencentral`
+- Key Vault access policies use managed identities from App Service and Functions
+- Service Bus queues: `bankgirot-payments`, `swift-payments` with dead-letter enabled
+
+---
+
+## References
+
+- [Issue #142](../../..) — Create Bicep IaC templates
+- [ADR-002](ADR-002-azure-service-bus-messaging.md) — Service Bus messaging design
+- [CLAUDE.md](../../CLAUDE.md) — Target architecture specification
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,190 @@
+@description('Deployment environment name.')
+@allowed([
+  'dev'
+  'staging'
+  'production'
+])
+param environment string
+
+@description('Base name prefix for all resources.')
+param appName string = 'nordkredit'
+
+@description('Azure region. Sweden Central for GDPR data residency compliance.')
+param location string = 'swedencentral'
+
+@description('Azure AD tenant ID for Key Vault access policies.')
+param tenantId string
+
+@description('SQL Server administrator login.')
+param sqlAdminLogin string
+
+@description('SQL Server administrator password.')
+@secure()
+param sqlAdminPassword string
+
+@description('App Service Plan SKU.')
+param appServiceSkuName string = 'S1'
+
+@description('Azure SQL Database SKU.')
+param sqlSkuName string = 'S1'
+
+@description('Azure Functions SKU.')
+param functionsSkuName string = 'Y1'
+
+@description('Service Bus SKU.')
+param serviceBusSkuName string = 'Standard'
+
+@description('Storage Account SKU.')
+param storageSkuName string = 'Standard_LRS'
+
+@description('Log Analytics retention in days.')
+param logRetentionInDays int = 90
+
+// Resource name prefix includes environment
+var resourcePrefix = '${appName}-${environment}'
+
+// Pre-compute Key Vault URI to avoid circular dependency
+var keyVaultNameRaw = replace('${resourcePrefix}-kv', '-', '')
+var keyVaultName = length(keyVaultNameRaw) > 24 ? substring(keyVaultNameRaw, 0, 24) : keyVaultNameRaw
+var keyVaultUri = 'https://${keyVaultName}${az.environment().suffixes.keyvaultDns}/'
+
+var tags = {
+  Project: 'NordKredit'
+  Environment: environment
+  ManagedBy: 'Bicep'
+  Regulation: 'GDPR-DORA-PSD2'
+}
+
+// Application Insights and Log Analytics
+module appInsights 'modules/app-insights.bicep' = {
+  name: 'deploy-app-insights'
+  params: {
+    appName: resourcePrefix
+    location: location
+    retentionInDays: logRetentionInDays
+    tags: tags
+  }
+}
+
+// Storage Account (required for Azure Functions runtime)
+module storage 'modules/storage-account.bicep' = {
+  name: 'deploy-storage'
+  params: {
+    appName: resourcePrefix
+    location: location
+    skuName: storageSkuName
+    tags: tags
+  }
+}
+
+// Service Bus for Bankgirot and SWIFT integrations
+module serviceBus 'modules/service-bus.bicep' = {
+  name: 'deploy-service-bus'
+  params: {
+    appName: resourcePrefix
+    location: location
+    skuName: serviceBusSkuName
+    tags: tags
+  }
+}
+
+// Azure SQL Database for GDPR-compliant data storage
+module sql 'modules/azure-sql.bicep' = {
+  name: 'deploy-sql'
+  params: {
+    appName: resourcePrefix
+    location: location
+    sqlAdminLogin: sqlAdminLogin
+    sqlAdminPassword: sqlAdminPassword
+    skuName: sqlSkuName
+    tags: tags
+  }
+}
+
+// App Service for NordKredit.Api (REST API)
+module appService 'modules/app-service.bicep' = {
+  name: 'deploy-app-service'
+  params: {
+    appName: resourcePrefix
+    location: location
+    skuName: appServiceSkuName
+    appInsightsConnectionString: appInsights.outputs.connectionString
+    keyVaultUri: keyVaultUri
+    tags: tags
+  }
+}
+
+// Azure Functions for batch processing (NordKredit.Functions)
+module functions 'modules/azure-functions.bicep' = {
+  name: 'deploy-functions'
+  params: {
+    appName: resourcePrefix
+    location: location
+    skuName: functionsSkuName
+    appInsightsConnectionString: appInsights.outputs.connectionString
+    keyVaultUri: keyVaultUri
+    storageConnectionString: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/StorageConnection)'
+    tags: tags
+  }
+}
+
+// Key Vault for secrets management (depends on App Service and Functions for managed identity access)
+module keyVault 'modules/key-vault.bicep' = {
+  name: 'deploy-key-vault'
+  params: {
+    appName: resourcePrefix
+    location: location
+    tenantId: tenantId
+    accessPrincipalIds: [
+      appService.outputs.principalId
+      functions.outputs.principalId
+    ]
+    tags: tags
+  }
+}
+
+// Store storage account connection string in Key Vault
+module storageSecret 'modules/key-vault-storage-secret.bicep' = {
+  name: 'deploy-storage-secret'
+  params: {
+    keyVaultName: keyVault.outputs.name
+    storageAccountName: storage.outputs.name
+    secretName: 'StorageConnection'
+  }
+}
+
+// Store SQL connection string in Key Vault
+module sqlConnectionSecret 'modules/key-vault-secret.bicep' = {
+  name: 'deploy-sql-connection-secret'
+  params: {
+    keyVaultName: keyVault.outputs.name
+    secretName: 'NordKreditDb'
+    secretValue: '${sql.outputs.connectionStringTemplate}Authentication=Active Directory Default;'
+  }
+}
+
+// Store Service Bus connection string in Key Vault
+module serviceBusConnectionSecret 'modules/key-vault-servicebus-secret.bicep' = {
+  name: 'deploy-sb-connection-secret'
+  params: {
+    keyVaultName: keyVault.outputs.name
+    serviceBusNamespaceName: serviceBus.outputs.namespaceName
+    secretName: 'ServiceBus'
+  }
+}
+
+// Outputs
+@description('App Service default hostname.')
+output apiHostName string = appService.outputs.defaultHostName
+
+@description('Functions App default hostname.')
+output functionsHostName string = functions.outputs.defaultHostName
+
+@description('Key Vault URI.')
+output keyVaultOutputUri string = keyVault.outputs.uri
+
+@description('SQL Server FQDN.')
+output sqlServerFqdn string = sql.outputs.fullyQualifiedDomainName
+
+@description('Application Insights connection string.')
+output appInsightsConnectionString string = appInsights.outputs.connectionString

--- a/infra/modules/app-insights.bicep
+++ b/infra/modules/app-insights.bicep
@@ -1,0 +1,55 @@
+@description('Base name for the Application Insights resources.')
+param appName string
+
+@description('Azure region for deployment. Sweden Central for GDPR compliance.')
+param location string = 'swedencentral'
+
+@description('Log Analytics workspace retention in days.')
+@minValue(30)
+@maxValue(730)
+param retentionInDays int = 90
+
+@description('Tags applied to all resources.')
+param tags object = {}
+
+var workspaceName = '${appName}-law'
+var appInsightsName = '${appName}-ai'
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: workspaceName
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: retentionInDays
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  tags: tags
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalyticsWorkspace.id
+    IngestionMode: 'LogAnalytics'
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+    RetentionInDays: retentionInDays
+  }
+}
+
+@description('Application Insights connection string.')
+output connectionString string = appInsights.properties.ConnectionString
+
+@description('Application Insights instrumentation key.')
+output instrumentationKey string = appInsights.properties.InstrumentationKey
+
+@description('Application Insights resource ID.')
+output id string = appInsights.id
+
+@description('Log Analytics workspace ID.')
+output workspaceId string = logAnalyticsWorkspace.id

--- a/infra/modules/app-service.bicep
+++ b/infra/modules/app-service.bicep
@@ -1,0 +1,80 @@
+@description('Base name for the App Service resources.')
+param appName string
+
+@description('Azure region for deployment. Sweden Central for GDPR compliance.')
+param location string = 'swedencentral'
+
+@description('App Service Plan SKU name.')
+@allowed([
+  'B1'
+  'S1'
+  'P1v3'
+  'P2v3'
+])
+param skuName string = 'S1'
+
+@description('Application Insights connection string.')
+@secure()
+param appInsightsConnectionString string
+
+@description('Key Vault URI for secret references.')
+param keyVaultUri string
+
+@description('Tags applied to all resources.')
+param tags object = {}
+
+var appServicePlanName = '${appName}-plan'
+var appServiceName = '${appName}-api'
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: appServicePlanName
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+  }
+  properties: {
+    reserved: false
+  }
+}
+
+resource appService 'Microsoft.Web/sites@2023-12-01' = {
+  name: appServiceName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    siteConfig: {
+      netFrameworkVersion: 'v8.0'
+      minTlsVersion: '1.2'
+      ftpsState: 'Disabled'
+      healthCheckPath: '/health/live'
+      appSettings: [
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: appInsightsConnectionString
+        }
+        {
+          name: 'KeyVaultUri'
+          value: keyVaultUri
+        }
+      ]
+    }
+  }
+}
+
+@description('App Service principal ID for Key Vault access.')
+output principalId string = appService.identity.principalId
+
+@description('App Service default hostname.')
+output defaultHostName string = appService.properties.defaultHostName
+
+@description('App Service resource ID.')
+output id string = appService.id
+
+@description('App Service name.')
+output name string = appService.name

--- a/infra/modules/azure-functions.bicep
+++ b/infra/modules/azure-functions.bicep
@@ -1,0 +1,95 @@
+@description('Base name for the Azure Functions resources.')
+param appName string
+
+@description('Azure region for deployment. Sweden Central for GDPR compliance.')
+param location string = 'swedencentral'
+
+@description('App Service Plan SKU for Functions.')
+@allowed([
+  'Y1'
+  'EP1'
+  'EP2'
+])
+param skuName string = 'Y1'
+
+@description('Application Insights connection string.')
+@secure()
+param appInsightsConnectionString string
+
+@description('Key Vault URI for secret references.')
+param keyVaultUri string
+
+@description('Storage account connection string for Functions runtime.')
+@secure()
+param storageConnectionString string
+
+@description('Tags applied to all resources.')
+param tags object = {}
+
+var functionsPlanName = '${appName}-func-plan'
+var functionsAppName = '${appName}-func'
+
+resource functionsPlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: functionsPlanName
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+  }
+  properties: {
+    reserved: false
+  }
+}
+
+resource functionsApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: functionsAppName
+  location: location
+  tags: tags
+  kind: 'functionapp'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: functionsPlan.id
+    httpsOnly: true
+    siteConfig: {
+      netFrameworkVersion: 'v8.0'
+      minTlsVersion: '1.2'
+      ftpsState: 'Disabled'
+      appSettings: [
+        {
+          name: 'AzureWebJobsStorage'
+          value: storageConnectionString
+        }
+        {
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~4'
+        }
+        {
+          name: 'FUNCTIONS_WORKER_RUNTIME'
+          value: 'dotnet-isolated'
+        }
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: appInsightsConnectionString
+        }
+        {
+          name: 'KeyVaultUri'
+          value: keyVaultUri
+        }
+      ]
+    }
+  }
+}
+
+@description('Functions App principal ID for Key Vault access.')
+output principalId string = functionsApp.identity.principalId
+
+@description('Functions App default hostname.')
+output defaultHostName string = functionsApp.properties.defaultHostName
+
+@description('Functions App resource ID.')
+output id string = functionsApp.id
+
+@description('Functions App name.')
+output name string = functionsApp.name

--- a/infra/modules/azure-sql.bicep
+++ b/infra/modules/azure-sql.bicep
@@ -1,0 +1,87 @@
+@description('Base name for the SQL resources.')
+param appName string
+
+@description('Azure region for deployment. Sweden Central for GDPR data residency.')
+param location string = 'swedencentral'
+
+@description('SQL Server administrator login.')
+param sqlAdminLogin string
+
+@description('SQL Server administrator password.')
+@secure()
+param sqlAdminPassword string
+
+@description('Azure SQL Database SKU name.')
+@allowed([
+  'Basic'
+  'S0'
+  'S1'
+  'S2'
+  'P1'
+  'P2'
+])
+param skuName string = 'S1'
+
+@description('Tags applied to all resources.')
+param tags object = {}
+
+var sqlServerName = '${appName}-sql'
+var databaseName = '${appName}-db'
+
+resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
+  name: sqlServerName
+  location: location
+  tags: tags
+  properties: {
+    administratorLogin: sqlAdminLogin
+    administratorLoginPassword: sqlAdminPassword
+    minimalTlsVersion: '1.2'
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  parent: sqlServer
+  name: databaseName
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+  }
+  properties: {
+    collation: 'SQL_Latin1_General_CP1_CI_AS'
+    maxSizeBytes: 268435456000
+    zoneRedundant: skuName == 'P1' || skuName == 'P2'
+  }
+}
+
+resource firewallAllowAzureServices 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = {
+  parent: sqlServer
+  name: 'AllowAzureServices'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}
+
+resource auditingSettings 'Microsoft.Sql/servers/auditingSettings@2023-08-01-preview' = {
+  parent: sqlServer
+  name: 'default'
+  properties: {
+    state: 'Enabled'
+    isAzureMonitorTargetEnabled: true
+    retentionDays: 90
+  }
+}
+
+@description('SQL Server fully qualified domain name.')
+output fullyQualifiedDomainName string = sqlServer.properties.fullyQualifiedDomainName
+
+@description('Database name.')
+output databaseName string = sqlDatabase.name
+
+@description('SQL Server resource ID.')
+output serverId string = sqlServer.id
+
+@description('Connection string template (password not included).')
+output connectionStringTemplate string = 'Server=tcp:${sqlServer.properties.fullyQualifiedDomainName},1433;Initial Catalog=${sqlDatabase.name};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;'

--- a/infra/modules/key-vault-secret.bicep
+++ b/infra/modules/key-vault-secret.bicep
@@ -1,0 +1,24 @@
+@description('Name of the existing Key Vault.')
+param keyVaultName string
+
+@description('Name of the secret.')
+param secretName string
+
+@description('Value of the secret.')
+@secure()
+param secretValue string
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource secret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: secretName
+  properties: {
+    value: secretValue
+  }
+}
+
+@description('Secret URI.')
+output secretUri string = secret.properties.secretUri

--- a/infra/modules/key-vault-servicebus-secret.bicep
+++ b/infra/modules/key-vault-servicebus-secret.bicep
@@ -1,0 +1,35 @@
+@description('Name of the existing Key Vault.')
+param keyVaultName string
+
+@description('Name of the existing Service Bus namespace.')
+param serviceBusNamespaceName string
+
+@description('Name of the authorization rule.')
+param authRuleName string = 'AppListenSend'
+
+@description('Secret name in Key Vault.')
+param secretName string = 'ServiceBus'
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2022-10-01-preview' existing = {
+  name: serviceBusNamespaceName
+}
+
+resource authRule 'Microsoft.ServiceBus/namespaces/AuthorizationRules@2022-10-01-preview' existing = {
+  parent: serviceBusNamespace
+  name: authRuleName
+}
+
+resource secret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: secretName
+  properties: {
+    value: authRule.listKeys().primaryConnectionString
+  }
+}
+
+@description('Secret URI (without version).')
+output secretUri string = secret.properties.secretUri

--- a/infra/modules/key-vault-storage-secret.bicep
+++ b/infra/modules/key-vault-storage-secret.bicep
@@ -1,0 +1,27 @@
+@description('Name of the existing Key Vault.')
+param keyVaultName string
+
+@description('Name of the existing Storage Account.')
+param storageAccountName string
+
+@description('Secret name in Key Vault.')
+param secretName string = 'StorageConnection'
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource secret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: secretName
+  properties: {
+    value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+  }
+}
+
+@description('Secret URI (without version).')
+output secretUri string = secret.properties.secretUri

--- a/infra/modules/key-vault.bicep
+++ b/infra/modules/key-vault.bicep
@@ -1,0 +1,57 @@
+@description('Base name for the Key Vault resources.')
+param appName string
+
+@description('Azure region for deployment. Sweden Central for GDPR compliance.')
+param location string = 'swedencentral'
+
+@description('Azure AD tenant ID.')
+param tenantId string
+
+@description('Principal IDs to grant Key Vault access (App Service, Functions).')
+param accessPrincipalIds array = []
+
+@description('Tags applied to all resources.')
+param tags object = {}
+
+var keyVaultName = replace('${appName}-kv', '-', '')
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: length(keyVaultName) > 24 ? substring(keyVaultName, 0, 24) : keyVaultName
+  location: location
+  tags: tags
+  properties: {
+    tenantId: tenantId
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    enabledForDeployment: false
+    enabledForDiskEncryption: false
+    enabledForTemplateDeployment: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 90
+    enablePurgeProtection: true
+    enableRbacAuthorization: false
+    accessPolicies: [
+      for principalId in accessPrincipalIds: {
+        tenantId: tenantId
+        objectId: principalId
+        permissions: {
+          secrets: [
+            'get'
+            'list'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+@description('Key Vault URI.')
+output uri string = keyVault.properties.vaultUri
+
+@description('Key Vault resource ID.')
+output id string = keyVault.id
+
+@description('Key Vault name.')
+output name string = keyVault.name

--- a/infra/modules/service-bus.bicep
+++ b/infra/modules/service-bus.bicep
@@ -1,0 +1,97 @@
+@description('Base name for the Service Bus resources.')
+param appName string
+
+@description('Azure region for deployment. Sweden Central for GDPR compliance.')
+param location string = 'swedencentral'
+
+@description('Service Bus SKU.')
+@allowed([
+  'Basic'
+  'Standard'
+  'Premium'
+])
+param skuName string = 'Standard'
+
+@description('Tags applied to all resources.')
+param tags object = {}
+
+var namespaceName = '${appName}-sb'
+
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2022-10-01-preview' = {
+  name: namespaceName
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+    tier: skuName
+  }
+  properties: {
+    minimumTlsVersion: '1.2'
+  }
+}
+
+resource bankgirotQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
+  parent: serviceBusNamespace
+  name: 'bankgirot-payments'
+  properties: {
+    maxDeliveryCount: 3
+    deadLetteringOnMessageExpiration: true
+    defaultMessageTimeToLive: 'P1D'
+    lockDuration: 'PT1M'
+    requiresDuplicateDetection: true
+    duplicateDetectionHistoryTimeWindow: 'PT10M'
+  }
+}
+
+resource swiftQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
+  parent: serviceBusNamespace
+  name: 'swift-payments'
+  properties: {
+    maxDeliveryCount: 3
+    deadLetteringOnMessageExpiration: true
+    defaultMessageTimeToLive: 'P1D'
+    lockDuration: 'PT1M'
+    requiresDuplicateDetection: true
+    duplicateDetectionHistoryTimeWindow: 'PT10M'
+  }
+}
+
+resource bankgirotDeadLetterQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
+  parent: serviceBusNamespace
+  name: 'bankgirot-payments-dlq'
+  properties: {
+    maxDeliveryCount: 10
+    defaultMessageTimeToLive: 'P7D'
+    lockDuration: 'PT5M'
+  }
+}
+
+resource swiftDeadLetterQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
+  parent: serviceBusNamespace
+  name: 'swift-payments-dlq'
+  properties: {
+    maxDeliveryCount: 10
+    defaultMessageTimeToLive: 'P7D'
+    lockDuration: 'PT5M'
+  }
+}
+
+resource listenSendRule 'Microsoft.ServiceBus/namespaces/AuthorizationRules@2022-10-01-preview' = {
+  parent: serviceBusNamespace
+  name: 'AppListenSend'
+  properties: {
+    rights: [
+      'Listen'
+      'Send'
+    ]
+  }
+}
+
+@description('Service Bus namespace ID.')
+output namespaceId string = serviceBusNamespace.id
+
+@description('Service Bus namespace name.')
+output namespaceName string = serviceBusNamespace.name
+
+@description('Service Bus authorization rule resource ID.')
+output authRuleId string = listenSendRule.id

--- a/infra/modules/storage-account.bicep
+++ b/infra/modules/storage-account.bicep
@@ -1,0 +1,40 @@
+@description('Base name for the Storage Account resources.')
+param appName string
+
+@description('Azure region for deployment. Sweden Central for GDPR compliance.')
+param location string = 'swedencentral'
+
+@description('Storage account SKU.')
+@allowed([
+  'Standard_LRS'
+  'Standard_GRS'
+  'Standard_ZRS'
+])
+param skuName string = 'Standard_LRS'
+
+@description('Tags applied to all resources.')
+param tags object = {}
+
+var storageAccountName = replace(replace('${appName}st', '-', ''), '_', '')
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: length(storageAccountName) > 24 ? substring(storageAccountName, 0, 24) : storageAccountName
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+  }
+  kind: 'StorageV2'
+  properties: {
+    supportsHttpsTrafficOnly: true
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+    defaultToOAuthAuthentication: true
+  }
+}
+
+@description('Storage account name.')
+output name string = storageAccount.name
+
+@description('Storage account resource ID.')
+output id string = storageAccount.id

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -1,0 +1,14 @@
+using '../main.bicep'
+
+param environment = 'dev'
+param appName = 'nordkredit'
+param location = 'swedencentral'
+param tenantId = '<azure-ad-tenant-id>'
+param sqlAdminLogin = 'nordkreditadmin'
+param sqlAdminPassword = '<replace-with-secure-password>'
+param appServiceSkuName = 'B1'
+param sqlSkuName = 'Basic'
+param functionsSkuName = 'Y1'
+param serviceBusSkuName = 'Basic'
+param storageSkuName = 'Standard_LRS'
+param logRetentionInDays = 30

--- a/infra/parameters/production.bicepparam
+++ b/infra/parameters/production.bicepparam
@@ -1,0 +1,14 @@
+using '../main.bicep'
+
+param environment = 'production'
+param appName = 'nordkredit'
+param location = 'swedencentral'
+param tenantId = '<azure-ad-tenant-id>'
+param sqlAdminLogin = 'nordkreditadmin'
+param sqlAdminPassword = '<replace-with-secure-password>'
+param appServiceSkuName = 'P1v3'
+param sqlSkuName = 'P1'
+param functionsSkuName = 'EP1'
+param serviceBusSkuName = 'Premium'
+param storageSkuName = 'Standard_ZRS'
+param logRetentionInDays = 365

--- a/infra/parameters/staging.bicepparam
+++ b/infra/parameters/staging.bicepparam
@@ -1,0 +1,14 @@
+using '../main.bicep'
+
+param environment = 'staging'
+param appName = 'nordkredit'
+param location = 'swedencentral'
+param tenantId = '<azure-ad-tenant-id>'
+param sqlAdminLogin = 'nordkreditadmin'
+param sqlAdminPassword = '<replace-with-secure-password>'
+param appServiceSkuName = 'S1'
+param sqlSkuName = 'S1'
+param functionsSkuName = 'Y1'
+param serviceBusSkuName = 'Standard'
+param storageSkuName = 'Standard_LRS'
+param logRetentionInDays = 90


### PR DESCRIPTION
## Summary
- Create modular Bicep infrastructure-as-code templates for the NordKredit Azure deployment
- Enforce GDPR data residency (Sweden Central) and DORA compliance across all resources
- Store all secrets in Key Vault with managed identity access from App Service and Functions

## Changes
- **`infra/main.bicep`** — Orchestration file composing all resource modules with environment-specific configuration
- **`infra/modules/`** — 10 Bicep modules: App Service, Azure SQL, Azure Functions, Service Bus (Bankgirot + SWIFT queues), Key Vault, Application Insights, Storage Account, and secret management modules
- **`infra/parameters/`** — Parameter files for `dev`, `staging`, and `production` environments with appropriate SKU tiers
- **`docs/Architecture/ADR-005-bicep-iac-templates.md`** — Architecture Decision Record documenting the Bicep IaC approach
- **`.gitignore`** — Exclude compiled ARM JSON files

## Key Design Decisions
- Modular Bicep (one file per resource type) for maintainability
- Pre-computed Key Vault URI to avoid circular dependencies between Key Vault and App Service/Functions
- Service Bus queues with dead-letter support and duplicate detection for Bankgirot/SWIFT
- SQL Server auditing enabled with 90-day retention for regulatory compliance
- All resources tagged with project, environment, and regulatory framework metadata

## Testing
- [x] `az bicep build` validates all templates with zero errors and zero warnings
- [x] All 682 existing tests pass
- [x] `dotnet build /warnaserror` — zero warnings
- [x] `dotnet format --verify-no-changes` — clean

Closes #142

🤖 Generated with Claude Code