### PR TITLE
feat(#125): Add missing copybooks COCOM01Y.cpy and CSUSR01Y.cpy

### DIFF
--- a/docs/cobol-source/cpy/COCOM01Y.cpy
+++ b/docs/cobol-source/cpy/COCOM01Y.cpy
@@ -1,0 +1,47 @@
+      ******************************************************************
+      * Communication area for CardDemo application programs
+      ******************************************************************
+      * Copyright Amazon.com, Inc. or its affiliates.
+      * All Rights Reserved.
+      *
+      * Licensed under the Apache License, Version 2.0 (the "License").
+      * You may not use this file except in compliance with the License.
+      * You may obtain a copy of the License at
+      *
+      *    http://www.apache.org/licenses/LICENSE-2.0
+      *
+      * Unless required by applicable law or agreed to in writing,
+      * software distributed under the License is distributed on an
+      * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+      * either express or implied. See the License for the specific
+      * language governing permissions and limitations under the License
+      ******************************************************************
+       01 CARDDEMO-COMMAREA.
+          05 CDEMO-GENERAL-INFO.
+             10 CDEMO-FROM-TRANID             PIC X(04).
+             10 CDEMO-FROM-PROGRAM            PIC X(08).
+             10 CDEMO-TO-TRANID               PIC X(04).
+             10 CDEMO-TO-PROGRAM              PIC X(08).
+             10 CDEMO-USER-ID                 PIC X(08).
+             10 CDEMO-USER-TYPE               PIC X(01).
+                88 CDEMO-USRTYP-ADMIN         VALUE 'A'.
+                88 CDEMO-USRTYP-USER          VALUE 'U'.
+             10 CDEMO-PGM-CONTEXT             PIC 9(01).
+                88 CDEMO-PGM-ENTER            VALUE 0.
+                88 CDEMO-PGM-REENTER          VALUE 1.
+          05 CDEMO-CUSTOMER-INFO.
+             10 CDEMO-CUST-ID                 PIC 9(09).
+             10 CDEMO-CUST-FNAME              PIC X(25).
+             10 CDEMO-CUST-MNAME              PIC X(25).
+             10 CDEMO-CUST-LNAME              PIC X(25).
+          05 CDEMO-ACCOUNT-INFO.
+             10 CDEMO-ACCT-ID                 PIC 9(11).
+             10 CDEMO-ACCT-STATUS             PIC X(01).
+          05 CDEMO-CARD-INFO.
+             10 CDEMO-CARD-NUM                PIC 9(16).
+          05 CDEMO-MORE-INFO.
+             10  CDEMO-LAST-MAP               PIC X(7).
+             10  CDEMO-LAST-MAPSET            PIC X(7).
+      *
+      * Ver: CardDemo_v1.0-15-g27d6c6f-68 Date: 2022-07-19 23:15:57 CDT
+      *

--- a/docs/cobol-source/cpy/CSUSR01Y.cpy
+++ b/docs/cobol-source/cpy/CSUSR01Y.cpy
@@ -1,0 +1,26 @@
+      ******************************************************************
+      * Copyright Amazon.com, Inc. or its affiliates.
+      * All Rights Reserved.
+      *
+      * Licensed under the Apache License, Version 2.0 (the "License").
+      * You may not use this file except in compliance with the License.
+      * You may obtain a copy of the License at
+      *
+      *    http://www.apache.org/licenses/LICENSE-2.0
+      *
+      * Unless required by applicable law or agreed to in writing,
+      * software distributed under the License is distributed on an
+      * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+      * either express or implied. See the License for the specific
+      * language governing permissions and limitations under the License
+      ******************************************************************
+       01 SEC-USER-DATA.
+         05 SEC-USR-ID                 PIC X(08).
+         05 SEC-USR-FNAME              PIC X(20).
+         05 SEC-USR-LNAME              PIC X(20).
+         05 SEC-USR-PWD                PIC X(08).
+         05 SEC-USR-TYPE               PIC X(01).
+         05 SEC-USR-FILLER             PIC X(23).
+      *
+      * Ver: CardDemo_v1.0-15-g27d6c6f-68 Date: 2022-07-19 23:15:59 CDT
+      *


### PR DESCRIPTION
## Summary
- Adds COCOM01Y.cpy (CARDDEMO-COMMAREA) defining the CICS inter-program communication area with transaction routing, user authentication, customer/account/card context, and screen navigation fields
- Adds CSUSR01Y.cpy (SEC-USER-DATA) defining the user sign-on authentication record with user ID, name, password, and type fields
- Both copybooks sourced from canonical AWS CardDemo reference implementation (v1.0-15-g27d6c6f-68) and validated against all field references in COCRDLIC.cbl, COCRDSLC.cbl, and COCRDUPC.cbl

## Changes
- `docs/cobol-source/cpy/COCOM01Y.cpy` — New file: COMMAREA structure (CARDDEMO-COMMAREA) with CDEMO-GENERAL-INFO, CDEMO-CUSTOMER-INFO, CDEMO-ACCOUNT-INFO, CDEMO-CARD-INFO, CDEMO-MORE-INFO sections
- `docs/cobol-source/cpy/CSUSR01Y.cpy` — New file: User authentication data structure (SEC-USER-DATA) with SEC-USR-ID, SEC-USR-FNAME, SEC-USR-LNAME, SEC-USR-PWD, SEC-USR-TYPE fields

## Validation
- All CDEMO-* field references in COCRDLIC.cbl, COCRDSLC.cbl, COCRDUPC.cbl resolve correctly against COCOM01Y.cpy
- CDEMO-USRTYP-USER (88-level VALUE 'U') matches SET statements across all three programs
- CDEMO-PGM-ENTER/CDEMO-PGM-REENTER match program flow control usage
- CDEMO-ACCT-ID PIC 9(11) matches CC-ACCT-ID-N PIC 9(11) usage
- CDEMO-CARD-NUM PIC 9(16) matches CC-CARD-NUM-N PIC 9(16) usage
- SEC-USR-TYPE field in CSUSR01Y.cpy supports security business rules SEC-BR-001, SEC-BR-003, SEC-BR-005

## Testing
- [x] Build passes (`dotnet build /warnaserror` — 0 warnings)
- [x] All 775 tests pass (614 unit + 88 BDD + 73 comparison)
- [x] No code changes — documentation/source artifacts only

Closes #125

🤖 Generated with Claude Code