### PR TITLE
feat(#131): Complete User/Security business rule extraction

### DIFF
--- a/docs-site/docs/business-rules/user-security/index.md
+++ b/docs-site/docs/business-rules/user-security/index.md
@@ -11,16 +11,19 @@ Business rules for authentication, authorization, session management, data isola
 
 | Program | Type | Function | Rules Extracted |
 |---------|------|----------|----------------|
-| `COCRDLIC.cbl` | CICS Online | Credit card list with pagination and filtering | SEC-BR-001, SEC-BR-002, SEC-BR-003, SEC-BR-004, SEC-BR-005, SEC-BR-007, SEC-BR-008 |
-| `COCRDSLC.cbl` | CICS Online | Credit card detail view/select | SEC-BR-003, SEC-BR-004, SEC-BR-005, SEC-BR-007, SEC-BR-008 |
-| `COCRDUPC.cbl` | CICS Online | Credit card update | SEC-BR-003, SEC-BR-004, SEC-BR-005, SEC-BR-006, SEC-BR-007, SEC-BR-008 |
+| `COCRDLIC.cbl` | CICS Online | Credit card list with pagination and filtering | SEC-BR-001, SEC-BR-002, SEC-BR-003, SEC-BR-004, SEC-BR-005, SEC-BR-007, SEC-BR-008, SEC-BR-009 |
+| `COCRDSLC.cbl` | CICS Online | Credit card detail view/select | SEC-BR-003, SEC-BR-004, SEC-BR-005, SEC-BR-007, SEC-BR-008, SEC-BR-009 |
+| `COCRDUPC.cbl` | CICS Online | Credit card update | SEC-BR-003, SEC-BR-004, SEC-BR-005, SEC-BR-006, SEC-BR-007, SEC-BR-008, SEC-BR-009 |
+| `COTRN00C.cbl` | CICS Online | Transaction list | SEC-BR-010 |
+| `COTRN01C.cbl` | CICS Online | Transaction detail | SEC-BR-010 |
+| `COTRN02C.cbl` | CICS Online | Transaction add | SEC-BR-010 |
 
 ### Related Copybooks
 
 | Copybook | Purpose | Rules Extracted |
 |----------|---------|----------------|
-| `COCOM01Y.cpy` (not in workspace) | COMMAREA structure — session context contract | SEC-BR-001, SEC-BR-003, SEC-BR-005 |
-| `CSUSR01Y.cpy` (not in workspace) | Signed-on user data — authenticated user identity and attributes | SEC-BR-001, SEC-BR-003, SEC-BR-005 |
+| `COCOM01Y.cpy` | COMMAREA structure — session context contract with user identity fields (`CDEMO-USER-ID`, `CDEMO-USER-TYPE`) | SEC-BR-001, SEC-BR-003, SEC-BR-005, SEC-BR-009, SEC-BR-010 |
+| `CSUSR01Y.cpy` | Signed-on user data — user record with ID, name, password (`SEC-USR-PWD`), and type | SEC-BR-001, SEC-BR-003, SEC-BR-005, SEC-BR-009, SEC-BR-010 |
 | `CVCRD01Y.cpy` | Card work area (AID keys, screen fields, program navigation) | SEC-BR-004, SEC-BR-008 |
 
 ## Extracted Rules
@@ -35,31 +38,38 @@ Business rules for authentication, authorization, session management, data isola
 | [SEC-BR-006](./sec-br-006) | Data modification authorization and confirmation workflow | Critical | COCRDUPC.cbl | PSD2, FFFS 2014:5 |
 | [SEC-BR-007](./sec-br-007) | Abend handling and secure error management | High | Shared (all 3 programs) | FFFS 2014:5, DORA, GDPR |
 | [SEC-BR-008](./sec-br-008) | Navigation audit trail and program flow tracking | High | Shared (all 3 programs) | DORA, FFFS 2014:5, GDPR, PSD2 |
+| [SEC-BR-009](./sec-br-009) | Password storage and credential management | Critical | CSUSR01Y.cpy | PSD2, GDPR, FFFS 2014:5, DORA |
+| [SEC-BR-010](./sec-br-010) | User identity propagation from sign-on to application | High | COCOM01Y.cpy, CSUSR01Y.cpy, COTRN*.cbl | PSD2, GDPR, FFFS 2014:5, DORA |
 
 ## Status
 
-All 8 business rules have been extracted from the COBOL source. All rules have `status: extracted` and are awaiting domain expert validation.
+10 business rules extracted from COBOL source (SEC-BR-001 through SEC-BR-010). All rules have `status: extracted` and are awaiting domain expert validation.
 
-### Critical Gaps Identified
+### Resolved Gaps
 
-- **COCOM01Y.cpy** (COMMAREA structure): Referenced in all programs but not in workspace. Defines `CARDDEMO-COMMAREA` including `CDEMO-USRTYP-USER` flag. Must be obtained from mainframe team.
-- **CSUSR01Y.cpy** (Signed-on user data): Referenced in all programs but not in workspace. Contains authenticated user identity and attributes populated by CICS CESN sign-on. Must be obtained from mainframe team.
-- **Sign-on program**: The authentication entry point (e.g., COSGN00C) is not in the workspace. Current programs delegate authentication entirely to CICS/RACF.
-- **PSD2 SCA gap**: Current mainframe uses single-factor authentication (password only via CICS CESN). Migration to Azure AD B2C must add a second factor to comply with PSD2 Art. 97.
+- **COCOM01Y.cpy** (COMMAREA structure): Now available in `docs/cobol-source/cpy/COCOM01Y.cpy`. Confirmed `CARDDEMO-COMMAREA` structure with `CDEMO-USER-ID` (PIC X(08)), `CDEMO-USER-TYPE` (PIC X(01), 'A'=admin, 'U'=user), customer info (name, ID), account/card context, and navigation tracking fields. SEC-BR-001, SEC-BR-003, SEC-BR-005 updated with actual field definitions.
+- **CSUSR01Y.cpy** (Signed-on user data): Now available in `docs/cobol-source/cpy/CSUSR01Y.cpy`. Confirmed `SEC-USER-DATA` structure with `SEC-USR-ID` (PIC X(08)), `SEC-USR-FNAME`/`SEC-USR-LNAME`, `SEC-USR-PWD` (PIC X(08), plain-text password), `SEC-USR-TYPE` (PIC X(01)). Two new rules extracted: SEC-BR-009 (password storage) and SEC-BR-010 (identity propagation).
+
+### Remaining Gaps
+
+- **Sign-on program (COSGN00C)**: Not in the workspace. Referenced by COTRN00C, COTRN01C, and COTRN02C as the authentication entry point and session recovery fallback. Authentication logic (password validation method, session establishment) cannot be verified without this program. Should be obtained from mainframe team if available.
+- **PSD2 SCA gap**: Current mainframe uses single-factor authentication (password only, with 8-character limit per SEC-USR-PWD). Migration to Azure AD B2C must add a second factor (MFA) and enforce modern password policies to comply with PSD2 Art. 97. Plain-text password storage (SEC-BR-009) must be replaced with hashed credentials.
+- **Password migration**: Plain-text passwords in SEC-USR-PWD cannot be migrated to Azure AD B2C's hashed store. All users will need to reset passwords on first login to the migrated system.
 
 ## Regulatory Coverage
 
 | Regulation | Rules Covering |
 |------------|---------------|
-| PSD2 Art. 97 (Strong Customer Authentication) | SEC-BR-001, SEC-BR-002, SEC-BR-003, SEC-BR-004, SEC-BR-005, SEC-BR-006, SEC-BR-008 |
+| PSD2 Art. 97 (Strong Customer Authentication) | SEC-BR-001, SEC-BR-002, SEC-BR-003, SEC-BR-004, SEC-BR-005, SEC-BR-006, SEC-BR-008, SEC-BR-009, SEC-BR-010 |
 | PSD2 Art. 98 (Dynamic Linking) | SEC-BR-005, SEC-BR-006 |
 | GDPR Art. 5(1)(c) (Data Minimization) | SEC-BR-002 |
-| GDPR Art. 5(1)(f) (Integrity & Confidentiality) | SEC-BR-001, SEC-BR-002, SEC-BR-003, SEC-BR-007 |
+| GDPR Art. 5(1)(f) (Integrity & Confidentiality) | SEC-BR-001, SEC-BR-002, SEC-BR-003, SEC-BR-007, SEC-BR-009 |
 | GDPR Art. 5(2) (Accountability) | SEC-BR-008 |
-| GDPR Art. 25 (Data Protection by Design) | SEC-BR-001, SEC-BR-002 |
-| FFFS 2014:5 Ch. 8 §4 (Internal Controls) | SEC-BR-001, SEC-BR-002, SEC-BR-003, SEC-BR-004, SEC-BR-005, SEC-BR-006, SEC-BR-007, SEC-BR-008 |
+| GDPR Art. 25 (Data Protection by Design) | SEC-BR-001, SEC-BR-002, SEC-BR-010 |
+| GDPR Art. 32 (Security of Processing) | SEC-BR-009 |
+| FFFS 2014:5 Ch. 8 §4 (Internal Controls) | SEC-BR-001, SEC-BR-002, SEC-BR-003, SEC-BR-004, SEC-BR-005, SEC-BR-006, SEC-BR-007, SEC-BR-008, SEC-BR-009, SEC-BR-010 |
 | FFFS 2014:5 Ch. 4 §3 (Operational Risk) | SEC-BR-004, SEC-BR-006, SEC-BR-007 |
-| DORA Art. 9 (Strong Authentication) | SEC-BR-005 |
+| DORA Art. 9 (Strong Authentication) | SEC-BR-005, SEC-BR-009, SEC-BR-010 |
 | DORA Art. 11 (ICT Risk Management) | SEC-BR-003, SEC-BR-007, SEC-BR-008 |
 
 ## Migration Considerations
@@ -71,3 +81,6 @@ All 8 business rules have been extracted from the COBOL source. All rules have `
 5. **Abend handling to exception middleware**: CICS HANDLE ABEND maps to ASP.NET Core exception handling middleware with structured error responses. Error messages must not leak internal system details (GDPR, DORA compliance).
 6. **Audit trail**: COMMAREA-based navigation tracking (FROM-PROGRAM, FROM-TRANID) maps to application-level audit logging with Application Insights, capturing user identity, action, timestamp, and correlation IDs.
 7. **Optimistic concurrency**: The confirm-before-write pattern with re-read verification (COCRDUPC) maps to ETag-based HTTP concurrency or SQL rowversion columns.
+8. **Password migration**: Passwords are stored as plain text in `SEC-USR-PWD` (8-character PIC X field). These cannot be migrated to Azure AD B2C's hashed credential store. All users must reset passwords on first login. Consider a staged migration: (a) import user profiles (ID, name, type) to Azure AD B2C, (b) trigger password reset flow on first login, (c) enforce new password policy (12+ chars, complexity, MFA).
+9. **User identity mapping**: Legacy `SEC-USR-ID` / `CDEMO-USER-ID` (8-character EBCDIC) must be mapped to Azure AD object IDs (GUID format). A mapping table is required for the parallel-run period to correlate mainframe and Azure AD sessions.
+10. **Identity propagation trust model**: The mainframe uses a trust-once model (COSGN00C authenticates, downstream programs trust COMMAREA). The migrated system must validate JWT tokens on every API request (zero-trust model). This is a fundamental architectural change — ASP.NET Core authentication middleware replaces the COMMAREA trust chain.

--- a/docs-site/docs/business-rules/user-security/sec-br-009.md
+++ b/docs-site/docs/business-rules/user-security/sec-br-009.md
@@ -1,0 +1,228 @@
+---
+id: "sec-br-009"
+title: "Password storage and credential management"
+domain: "user-security"
+cobol_source: "CSUSR01Y.cpy:17-23,COCRDLIC.cbl:284-285,COCRDSLC.cbl:226-227,COCRDUPC.cbl:345-346"
+requirement_id: "SEC-BR-009"
+regulations:
+  - "PSD2 Art. 97"
+  - "GDPR Art. 32"
+  - "GDPR Art. 5(1)(f)"
+  - "FFFS 2014:5 Ch. 8 §4"
+  - "DORA Art. 9"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# SEC-BR-009: Password storage and credential management
+
+## Summary
+
+The CSUSR01Y copybook defines the user authentication data structure (`SEC-USER-DATA`) used by the CardDemo sign-on program (COSGN00C). This structure reveals that passwords are stored as plain-text 8-character fields (`SEC-USR-PWD PIC X(08)`) in the user data record. All three card management programs include this copybook, meaning the password field is accessible in working storage during program execution. The 8-character limit and plain-text storage represent the legacy mainframe credential management approach, which must be completely replaced during migration to meet modern security standards and PSD2 SCA requirements.
+
+## Business Logic
+
+### Pseudocode
+
+```
+USER DATA RECORD STRUCTURE (CSUSR01Y.cpy):
+    RECORD SEC-USER-DATA:
+        user-id        : CHAR(8)    -- Unique user identifier
+        first-name     : CHAR(20)   -- User's first name (PII)
+        last-name      : CHAR(20)   -- User's last name (PII)
+        password       : CHAR(8)    -- Plain-text password (CRITICAL)
+        user-type      : CHAR(1)    -- 'A' = admin, 'U' = regular user
+        filler         : CHAR(23)   -- Reserved space
+
+SIGN-ON PROCESS (inferred from COSGN00C references):
+    1. User enters user-id and password at CICS terminal
+    2. COSGN00C reads SEC-USER-DATA record for the given user-id
+    3. Compare entered password with SEC-USR-PWD
+    4. IF match:
+        SET CDEMO-USER-ID = SEC-USR-ID
+        SET CDEMO-USER-TYPE = SEC-USR-TYPE
+        TRANSFER to menu program with populated COMMAREA
+    5. IF no match:
+        Display error, allow retry
+
+PASSWORD CONSTRAINTS (from data structure):
+    - Maximum length: 8 characters (PIC X(08))
+    - Character set: Any EBCDIC character (PIC X)
+    - No complexity enforcement visible in data structure
+    - No password history or expiration fields in the record
+    - No failed attempt counter in the record
+    - No account lockout flag in the record
+```
+
+### Credential Data Flow
+
+```
+[User Data File] → SEC-USER-DATA (CSUSR01Y)
+    ↓
+[COSGN00C - Sign-on Program]
+    ↓ (validates SEC-USR-PWD against entered password)
+    ↓ (copies SEC-USR-ID → CDEMO-USER-ID)
+    ↓ (copies SEC-USR-TYPE → CDEMO-USER-TYPE)
+    ↓
+[COMMAREA - COCOM01Y] → All application programs
+    ↓
+[COCRDLIC / COCRDSLC / COCRDUPC]
+    (SEC-USER-DATA still in WORKING-STORAGE via COPY CSUSR01Y)
+```
+
+### Password Policy Gap Analysis
+
+| Aspect | Current (Mainframe) | Required (PSD2/DORA) | Migration Target |
+|--------|-------------------|---------------------|-----------------|
+| Storage | Plain text (PIC X(08)) | Hashed with salt | Azure AD B2C (bcrypt/PBKDF2) |
+| Max length | 8 characters | No practical limit | Azure AD B2C (256 chars) |
+| Complexity | Not enforced in data structure | Required (upper, lower, digit, special) | Azure AD B2C custom policy |
+| Expiration | Not tracked in record | Required (90-day recommendation) | Azure AD conditional access |
+| History | Not tracked | Required (prevent reuse) | Azure AD B2C password history |
+| Lockout | Not in record (may be ESM-level) | Required after N failures | Azure AD B2C smart lockout |
+| MFA | Not present (single factor) | Required for SCA (PSD2 Art. 97) | Azure AD B2C MFA |
+
+## Source COBOL Reference
+
+**Copybook:** `CSUSR01Y.cpy`
+**Lines:** 17-23 (Complete user data structure)
+
+```cobol
+ 01 SEC-USER-DATA.
+    05 SEC-USR-ID                 PIC X(08).
+    05 SEC-USR-FNAME              PIC X(20).
+    05 SEC-USR-LNAME              PIC X(20).
+    05 SEC-USR-PWD                PIC X(08).
+    05 SEC-USR-TYPE               PIC X(01).
+    05 SEC-USR-FILLER             PIC X(23).
+```
+
+**Program:** `COCRDLIC.cbl`
+**Lines:** 284-285 (Copybook inclusion — password accessible in working storage)
+
+```cobol
+000284 *Signed on user data
+000285  COPY CSUSR01Y.
+```
+
+**Program:** `COCRDSLC.cbl`
+**Lines:** 226-227 (Copybook inclusion)
+
+```cobol
+000226 *Signed on user data
+000227  COPY CSUSR01Y.
+```
+
+**Program:** `COCRDUPC.cbl`
+**Lines:** 345-346 (Copybook inclusion)
+
+```cobol
+000345 *Signed on user data
+000346  COPY CSUSR01Y.
+```
+
+### Sign-on Program References (COSGN00C)
+
+COSGN00C is referenced as the fallback return destination in multiple programs, confirming its role as the authentication entry point:
+
+```cobol
+* COTRN00C.cbl:108 — Return to sign-on when no COMMAREA
+  MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+
+* COTRN01C.cbl:95 — Return to sign-on when no COMMAREA
+  MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+
+* COTRN02C.cbl:116 — Return to sign-on when no COMMAREA
+  MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+```
+
+This pattern confirms: when a program detects no session context (EIBCALEN = 0) or no return target, it routes back to COSGN00C for re-authentication.
+
+## Acceptance Criteria
+
+### Scenario 1: Password validates against user record
+
+```gherkin
+GIVEN a user enters their user-id and password at the CICS sign-on screen
+  AND a SEC-USER-DATA record exists for the given user-id
+WHEN the sign-on program compares the entered password to SEC-USR-PWD
+THEN if the passwords match, the user is authenticated
+  AND CDEMO-USER-ID is set to SEC-USR-ID
+  AND CDEMO-USER-TYPE is set to SEC-USR-TYPE
+  AND control transfers to the menu program
+```
+
+### Scenario 2: Invalid password is rejected
+
+```gherkin
+GIVEN a user enters a valid user-id but incorrect password
+WHEN the sign-on program compares the entered password to SEC-USR-PWD
+THEN the authentication fails
+  AND the user is prompted to re-enter credentials
+  AND the failed attempt is handled (lockout policy may apply at ESM level)
+```
+
+### Scenario 3: Password field accessible in all programs
+
+```gherkin
+GIVEN any card management program includes COPY CSUSR01Y
+WHEN the copybook is expanded during compilation
+THEN SEC-USR-PWD is allocated in the program's WORKING-STORAGE
+  AND the password field is technically accessible (though not used by the card programs)
+  AND this represents a data exposure risk in the current architecture
+```
+
+### Scenario 4: Migrated system enforces modern password policy
+
+```gherkin
+GIVEN the system is migrated from COBOL to .NET 8 on Azure
+WHEN user authentication is handled by Azure AD B2C
+THEN passwords are stored using industry-standard hashing (bcrypt/PBKDF2)
+  AND passwords support at least 12 characters minimum
+  AND complexity requirements are enforced (upper, lower, digit, special)
+  AND password history prevents reuse of recent passwords
+  AND account lockout occurs after consecutive failed attempts
+```
+
+### Scenario 5: Password migration requires forced reset
+
+```gherkin
+GIVEN existing user passwords are stored as plain text in SEC-USR-PWD
+WHEN the system migrates to Azure AD B2C
+THEN plain-text passwords CANNOT be migrated to the hashed store
+  AND all users must reset their passwords on first login to the new system
+  AND a secure password reset flow is provided (email/SMS verification)
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 97 | Strong customer authentication including knowledge element (password) | Current system uses password-only authentication; SEC-USR-PWD is the knowledge factor. Migration must add possession/inherence factor for SCA |
+| GDPR | Art. 32 | Security of processing — implement appropriate technical measures including encryption and pseudonymization | Plain-text password storage in SEC-USR-PWD violates the principle of appropriate security measures; migration must use hashed passwords |
+| GDPR | Art. 5(1)(f) | Integrity and confidentiality — appropriate security of personal data | User names (SEC-USR-FNAME, SEC-USR-LNAME) and passwords are stored without encryption in the same record; migration must separate and protect credentials |
+| FFFS 2014:5 | Ch. 8 §4 | Credit institutions must have adequate internal controls including information security | Password storage, complexity, and lifecycle management are foundational security controls that must be documented and enforced |
+| DORA | Art. 9 | Strong authentication mechanisms and access control policies | Password policy (length, complexity, expiration, lockout) must meet DORA requirements for ICT system access control |
+
+## Edge Cases
+
+1. **Plain-text password in WORKING-STORAGE**: Every program that includes `COPY CSUSR01Y` has `SEC-USR-PWD` allocated in WORKING-STORAGE. Even though the card management programs do not use this field, it is technically accessible. A malicious or buggy program modification could read or display passwords. The migrated system must never expose credential data to application code.
+
+2. **8-character password limit**: `PIC X(08)` limits passwords to 8 characters. Modern security standards recommend minimum 12-character passwords. During migration, users must be forced to create longer passwords. Legacy 8-character passwords should not be accepted by the new system.
+
+3. **No password hashing**: The `PIC X(08)` format and the apparent comparison pattern suggest plain-text comparison. There is no salt, hash algorithm, or key derivation function. A database breach would expose all user passwords. This is a critical vulnerability by modern standards.
+
+4. **FILLER field**: The 23-byte `SEC-USR-FILLER` field suggests the record was designed for future extension. If the production system has evolved, additional fields (e.g., last login date, failed attempt count, password change date) may exist in this space. The domain expert should confirm the production record layout.
+
+5. **No separation between identity and credential stores**: `SEC-USER-DATA` combines identity (ID, name, type) and credential (password) in a single record. Modern architecture separates these concerns — Azure AD B2C manages credentials independently from application user profiles.
+
+## Domain Expert Notes
+
+- **Copybook analysis complete** — CSUSR01Y confirms plain-text password storage in an 8-character field. The sign-on program COSGN00C is not in the workspace but is confirmed as the authentication entry point by references in COTRN00C, COTRN01C, and COTRN02C. **Questions for domain expert:** (1) Does COSGN00C perform direct password comparison against SEC-USR-PWD, or does it delegate to RACF/ESM? (2) Has the 23-byte FILLER in SEC-USER-DATA been used in production for additional fields (e.g., password expiry date, failed login count)? (3) How are new user accounts provisioned — is there an admin program that writes SEC-USER-DATA records? (4) What is the current password reset process on the mainframe? (5) Can the COSGN00C program be obtained for analysis?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/user-security/sec-br-010.md
+++ b/docs-site/docs/business-rules/user-security/sec-br-010.md
@@ -1,0 +1,266 @@
+---
+id: "sec-br-010"
+title: "User identity propagation from sign-on to application"
+domain: "user-security"
+cobol_source: "COCOM01Y.cpy:25-28,CSUSR01Y.cpy:17-23,COTRN00C.cbl:108,COTRN00C.cbl:513,COTRN01C.cbl:95,COTRN01C.cbl:200,COTRN02C.cbl:116,COTRN02C.cbl:503"
+requirement_id: "SEC-BR-010"
+regulations:
+  - "PSD2 Art. 97"
+  - "GDPR Art. 25"
+  - "FFFS 2014:5 Ch. 8 §4"
+  - "DORA Art. 9"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# SEC-BR-010: User identity propagation from sign-on to application
+
+## Summary
+
+The CardDemo system propagates authenticated user identity from the sign-on program (COSGN00C) to all application programs via two mechanisms: (1) the COMMAREA fields `CDEMO-USER-ID` and `CDEMO-USER-TYPE` defined in COCOM01Y.cpy, which carry the user identity and role across all CICS program transfers; and (2) the `SEC-USER-DATA` structure from CSUSR01Y.cpy, which is allocated in each program's WORKING-STORAGE. When a program loses its session context (EIBCALEN = 0) or has no return target, it routes back to COSGN00C for re-authentication, establishing COSGN00C as the trusted authentication boundary. This identity propagation pattern — where the sign-on program populates a shared data area that all downstream programs read but never re-validate — is the CICS equivalent of a session token. In the migrated system, this maps to JWT token claims populated during Azure AD authentication and validated by API middleware.
+
+## Business Logic
+
+### Pseudocode
+
+```
+IDENTITY PROPAGATION FLOW:
+
+SIGN-ON (COSGN00C — not in workspace, inferred from references):
+    READ SEC-USER-DATA for entered user-id
+    VALIDATE password (SEC-USR-PWD vs entered password)
+    IF valid:
+        SET CDEMO-USER-ID = SEC-USR-ID         -- PIC X(08) → PIC X(08)
+        SET CDEMO-USER-TYPE = SEC-USR-TYPE      -- PIC X(01) → PIC X(01)
+        -- 88 CDEMO-USRTYP-ADMIN VALUE 'A'
+        -- 88 CDEMO-USRTYP-USER  VALUE 'U'
+        TRANSFER to menu program with COMMAREA
+
+APPLICATION PROGRAMS (all downstream):
+    -- Receive identity via COMMAREA
+    IF EIBCALEN > 0
+        RESTORE CARDDEMO-COMMAREA from DFHCOMMAREA
+        -- CDEMO-USER-ID and CDEMO-USER-TYPE are now available
+        -- Programs trust these values without re-validation
+    END-IF
+
+    -- Use identity for access control decisions
+    IF CDEMO-USRTYP-ADMIN
+        -- Admin: no account filtering, full access
+    ELSE IF CDEMO-USRTYP-USER
+        -- Regular user: filter by own account
+    END-IF
+
+SESSION RECOVERY (fallback to sign-on):
+    -- When session context is lost, return to COSGN00C
+    IF EIBCALEN = 0 (no COMMAREA = no session)
+        MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+        PERFORM RETURN-TO-PREV-SCREEN
+    END-IF
+
+    -- When return target is unknown, default to COSGN00C
+    IF CDEMO-TO-PROGRAM = LOW-VALUES OR SPACES
+        MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+    END-IF
+```
+
+### Identity Field Mapping
+
+| Source (CSUSR01Y) | COMMAREA (COCOM01Y) | Purpose | Migration Target |
+|-------------------|---------------------|---------|-----------------|
+| SEC-USR-ID (X(08)) | CDEMO-USER-ID (X(08)) | User identifier | JWT `sub` / `oid` claim |
+| SEC-USR-TYPE (X(01)) | CDEMO-USER-TYPE (X(01)) | Role ('A'/'U') | JWT `roles` claim (Azure AD app role) |
+| SEC-USR-FNAME (X(20)) | CDEMO-CUST-FNAME (X(25)) | First name | JWT `given_name` claim |
+| SEC-USR-LNAME (X(20)) | CDEMO-CUST-LNAME (X(25)) | Last name | JWT `family_name` claim |
+
+### Sign-On as Authentication Boundary
+
+```
+                 ┌─────────────────────────────────┐
+                 │  AUTHENTICATION BOUNDARY         │
+                 │                                  │
+  [Terminal] ──→ │  COSGN00C (Sign-on Program)      │
+                 │    ↓ validates SEC-USR-PWD       │
+                 │    ↓ populates COMMAREA          │
+                 └──────────────┬────────────────────┘
+                                │ XCTL with COMMAREA
+                 ┌──────────────▼────────────────────┐
+                 │  APPLICATION ZONE                  │
+                 │  (trusts COMMAREA identity)        │
+                 │                                    │
+                 │  Menu ──→ Card List ──→ Card Detail│
+                 │           ──→ Card Update          │
+                 │  Transaction Programs (COTRN*)     │
+                 │                                    │
+                 │  On session loss → back to COSGN00C│
+                 └────────────────────────────────────┘
+```
+
+## Source COBOL Reference
+
+**Copybook:** `COCOM01Y.cpy`
+**Lines:** 25-28 (User identity fields in COMMAREA)
+
+```cobol
+       10 CDEMO-USER-ID                 PIC X(08).
+       10 CDEMO-USER-TYPE               PIC X(01).
+          88 CDEMO-USRTYP-ADMIN         VALUE 'A'.
+          88 CDEMO-USRTYP-USER          VALUE 'U'.
+```
+
+**Copybook:** `CSUSR01Y.cpy`
+**Lines:** 17-23 (Source user data record)
+
+```cobol
+ 01 SEC-USER-DATA.
+    05 SEC-USR-ID                 PIC X(08).
+    05 SEC-USR-FNAME              PIC X(20).
+    05 SEC-USR-LNAME              PIC X(20).
+    05 SEC-USR-PWD                PIC X(08).
+    05 SEC-USR-TYPE               PIC X(01).
+    05 SEC-USR-FILLER             PIC X(23).
+```
+
+**Program:** `COTRN00C.cbl`
+**Lines:** 107-109 (Return to sign-on when no session)
+
+```cobol
+000107           IF EIBCALEN = 0
+000108               MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+000109               PERFORM RETURN-TO-PREV-SCREEN
+```
+
+**Lines:** 512-513 (Default to sign-on when no return target)
+
+```cobol
+000512           IF CDEMO-TO-PROGRAM = LOW-VALUES OR SPACES
+000513               MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+```
+
+**Program:** `COTRN01C.cbl`
+**Lines:** 94-96 (Return to sign-on when no session)
+
+```cobol
+000094           IF EIBCALEN = 0
+000095               MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+000096               PERFORM RETURN-TO-PREV-SCREEN
+```
+
+**Lines:** 199-200 (Default to sign-on when no return target)
+
+```cobol
+000199           IF CDEMO-TO-PROGRAM = LOW-VALUES OR SPACES
+000200               MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+```
+
+**Program:** `COTRN02C.cbl`
+**Lines:** 115-117 (Return to sign-on when no session)
+
+```cobol
+000115           IF EIBCALEN = 0
+000116               MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+000117               PERFORM RETURN-TO-PREV-SCREEN
+```
+
+**Lines:** 502-503 (Default to sign-on when no return target)
+
+```cobol
+000502           IF CDEMO-TO-PROGRAM = LOW-VALUES OR SPACES
+000503               MOVE 'COSGN00C' TO CDEMO-TO-PROGRAM
+```
+
+## Acceptance Criteria
+
+### Scenario 1: Sign-on populates COMMAREA with user identity
+
+```gherkin
+GIVEN a user successfully authenticates via COSGN00C
+WHEN the sign-on program transfers control to the menu
+THEN CDEMO-USER-ID contains the authenticated user's ID (8 characters)
+  AND CDEMO-USER-TYPE contains the user's role ('A' for admin, 'U' for regular)
+  AND the COMMAREA is passed to the menu program via CICS XCTL
+```
+
+### Scenario 2: Application programs trust COMMAREA identity
+
+```gherkin
+GIVEN a program receives control with a valid COMMAREA (EIBCALEN > 0)
+WHEN the program restores CARDDEMO-COMMAREA from DFHCOMMAREA
+THEN CDEMO-USER-ID and CDEMO-USER-TYPE are available
+  AND the program does NOT re-validate the user's credentials
+  AND access control decisions are based on the COMMAREA values
+```
+
+### Scenario 3: Lost session triggers re-authentication
+
+```gherkin
+GIVEN a CICS transaction program is invoked without a COMMAREA (EIBCALEN = 0)
+WHEN the program detects no session context
+THEN CDEMO-TO-PROGRAM is set to 'COSGN00C'
+  AND the program performs RETURN-TO-PREV-SCREEN
+  AND control returns to the sign-on program for re-authentication
+```
+
+### Scenario 4: Unknown return target defaults to sign-on
+
+```gherkin
+GIVEN a program needs to return to the calling program
+  AND CDEMO-TO-PROGRAM is LOW-VALUES or SPACES (no target recorded)
+WHEN the return logic executes
+THEN CDEMO-TO-PROGRAM defaults to 'COSGN00C'
+  AND the user is routed back to the sign-on screen
+  AND this acts as a safety net ensuring unauthenticated sessions cannot persist
+```
+
+### Scenario 5: Identity propagated across full program chain
+
+```gherkin
+GIVEN a user authenticated as admin (CDEMO-USER-TYPE = 'A')
+WHEN the user navigates: Sign-on → Menu → Card List → Card Detail → Card Update
+THEN CDEMO-USER-ID remains the same across all program transfers
+  AND CDEMO-USER-TYPE remains 'A' across all transfers
+  AND no program in the chain re-authenticates or re-reads SEC-USER-DATA
+```
+
+### Scenario 6: Migrated system validates identity on every request
+
+```gherkin
+GIVEN the system is migrated to .NET 8 on Azure
+WHEN a user makes an API request
+THEN the JWT token is validated by ASP.NET Core authentication middleware
+  AND the user identity (sub claim) and roles (roles claim) are extracted
+  AND EVERY request is validated (unlike the mainframe trust model)
+  AND expired or tampered tokens are rejected with 401 Unauthorized
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 97 | Strong customer authentication — session integrity must be maintained | COSGN00C acts as the authentication boundary; all downstream programs inherit the authenticated identity via COMMAREA. Migration must replicate with JWT validation on every request |
+| GDPR | Art. 25 | Data protection by design and by default | The sign-on boundary ensures only authenticated users reach application programs. The migrated system enhances this with per-request token validation |
+| FFFS 2014:5 | Ch. 8 §4 | Adequate internal controls including user identification and authentication | The COMMAREA-based identity propagation provides a consistent user identification mechanism across all programs; the sign-on fallback ensures sessions cannot persist without authentication |
+| DORA | Art. 9 | Strong authentication mechanisms and access control policies | The authentication boundary (COSGN00C) and re-authentication fallback pattern enforce that only authenticated users can access application functions |
+
+## Edge Cases
+
+1. **No per-request validation**: Once the COMMAREA is populated by COSGN00C, downstream programs trust the identity without re-validation. A compromised or modified COMMAREA could impersonate another user. The migrated system must validate the JWT token on every API request, not just at login.
+
+2. **User type hardcoded on XCTL**: Several programs set `CDEMO-USRTYP-USER TO TRUE` on every XCTL call (e.g., COCRDLIC line 320, COCRDSLC line 326, COCRDUPC line 464). This means the user type is reset to 'U' (regular) regardless of the actual role. The true role from COSGN00C may be overwritten. The domain expert must clarify whether admin users maintain their role through the card management flow.
+
+3. **COSGN00C not in workspace**: The actual sign-on program is referenced but not available for analysis. The authentication logic, password validation method, and session establishment code cannot be verified. This is a gap in the extraction that should be closed if the program becomes available.
+
+4. **Identity fields are fixed-width**: `CDEMO-USER-ID` is PIC X(08) — user IDs are limited to 8 characters, right-padded with spaces. The migrated system (Azure AD) uses GUIDs (36 chars) or email addresses. A mapping table from legacy user IDs to Azure AD object IDs will be required during migration.
+
+5. **No session token invalidation**: There is no mechanism in the COMMAREA to invalidate a specific session. CICS manages session lifecycle at the terminal level. The migrated system must support token revocation (e.g., for password change, account lockout, or admin force-logout).
+
+## Domain Expert Notes
+
+- **Copybook analysis complete** — COCOM01Y confirms `CDEMO-USER-ID` (X(08)) and `CDEMO-USER-TYPE` (X(01), 'A'/'U') as the identity propagation fields. CSUSR01Y confirms the source user data structure. COSGN00C is referenced by COTRN00C, COTRN01C, and COTRN02C as the authentication entry point and session recovery fallback. **Questions for domain expert:** (1) Does COSGN00C populate CDEMO-USER-ID from SEC-USR-ID, or from EIBUSERID? (2) Why do downstream programs reset CDEMO-USRTYP-USER to TRUE on XCTL — is admin role intentionally dropped for the card management flow? (3) Can COSGN00C be obtained from the mainframe team for direct analysis? (4) Is there a user provisioning program that creates/modifies SEC-USER-DATA records?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17


### PR DESCRIPTION
## Summary
- Updated SEC-BR-001, SEC-BR-003, SEC-BR-005 with verified field definitions from the now-available COCOM01Y.cpy and CSUSR01Y.cpy copybooks (replacing "not in workspace" references)
- Extracted two new rules: SEC-BR-009 (password storage — plain-text SEC-USR-PWD with 8-char limit) and SEC-BR-010 (user identity propagation from COSGN00C sign-on to application programs)
- Updated index.md: resolved COCOM01Y/CSUSR01Y gaps, documented remaining gaps (COSGN00C program, PSD2 SCA), added new regulatory coverage entries

## Changes
- `docs-site/docs/business-rules/user-security/sec-br-001.md` — Added COCOM01Y/CSUSR01Y field definitions, updated edge cases and domain expert notes
- `docs-site/docs/business-rules/user-security/sec-br-003.md` — Added full COMMAREA structure from copybook, added SEC-USER-DATA structure, updated PII exposure analysis
- `docs-site/docs/business-rules/user-security/sec-br-005.md` — Added verified CSUSR01Y structure with password field analysis, updated authentication flow, replaced missing-copybook edge case with plain-text password concern
- `docs-site/docs/business-rules/user-security/sec-br-009.md` — **NEW** Password storage and credential management rule (Critical priority)
- `docs-site/docs/business-rules/user-security/sec-br-010.md` — **NEW** User identity propagation from sign-on to application rule (High priority)
- `docs-site/docs/business-rules/user-security/index.md` — Updated source programs, copybooks, rules table, status/gaps, regulatory coverage, and migration considerations

## Testing
- [x] Docusaurus build succeeds
- [x] .NET build succeeds (0 warnings)
- [x] All tests pass (775 total: 614 unit + 88 BDD + 73 comparison)
- [x] dotnet format passes

Closes #131

🤖 Generated with Claude Code