### PR TITLE
feat(#127): Extract Lending domain business rules from COBOL source

### DIFF
--- a/docs-site/docs/business-rules/lending/index.md
+++ b/docs-site/docs/business-rules/lending/index.md
@@ -1,0 +1,103 @@
+---
+title: Lending
+sidebar_position: 7
+---
+
+# Lending Business Rules
+
+Business rules for loan origination, credit limit enforcement, interest calculation, collateral management, disbursement, repayment processing, delinquency management, and maturity enforcement extracted from COBOL source programs and regulatory requirements for the NordKredit AB core banking system.
+
+## Source Programs
+
+| Program | Type | Function | Rules Extracted |
+|---------|------|----------|----------------|
+| `CBTRN02C.cbl` | Batch | Daily transaction posting with credit limit enforcement, balance updates, and category tracking | LND-BR-001, LND-BR-002, LND-BR-005, LND-BR-009, LND-BR-010 |
+| `COCRDUPC.cbl` | CICS Online | Card/account update with account validation | LND-BR-001 |
+
+### Related Copybooks
+
+| Copybook | Purpose | Rules Extracted |
+|----------|---------|----------------|
+| `CVACT01Y.cpy` | Account master record layout — credit limit, balance, and disclosure group fields (referenced but not fully in repository) | LND-BR-001, LND-BR-002, LND-BR-003, LND-BR-004 |
+| `CVACT03Y.cpy` | Card cross-reference record — card-to-account linkage used during credit limit validation | LND-BR-002 |
+
+## Extracted Rules
+
+| Rule ID | Title | Priority | Source | Regulation |
+|---------|-------|----------|--------|------------|
+| [LND-BR-001](./lnd-br-001) | Loan account data structure and field definitions | Critical | CVACT01Y.cpy (reconstructed) | FSA FFFS 2014:5 Ch. 6, GDPR, Consumer Credit Directive |
+| [LND-BR-002](./lnd-br-002) | Credit limit enforcement and overlimit detection | Critical | CBTRN02C.cbl:393-421 | FSA FFFS 2014:5 Ch. 6, Consumer Credit Directive, PSD2 |
+| [LND-BR-003](./lnd-br-003) | Loan origination and credit assessment | Critical | Dedicated program not yet in repository | FSA FFFS 2014:5 Ch. 6, Consumer Credit Directive Art. 8, AML |
+| [LND-BR-004](./lnd-br-004) | Interest calculation and amortization schedule | Critical | Dedicated program not yet in repository | FSA FFFS 2014:5 Ch. 6, Consumer Credit Directive Art. 10, 19 |
+| [LND-BR-005](./lnd-br-005) | Repayment processing and balance update | Critical | CBTRN02C.cbl:545-560 | FSA FFFS 2014:5 Ch. 3, PSD2, Consumer Credit Directive Art. 16 |
+| [LND-BR-006](./lnd-br-006) | Collateral management and valuation | High | Dedicated program not yet in repository | FSA FFFS 2014:5 Ch. 6, 8, CRR Art. 194-217 |
+| [LND-BR-007](./lnd-br-007) | Loan disbursement and fund transfer | High | Dedicated program not yet in repository | PSD2 Art. 83, 89, FSA FFFS 2014:5 Ch. 3, AML |
+| [LND-BR-008](./lnd-br-008) | Delinquency management and collections | High | Dedicated program not yet in repository | FSA FFFS 2014:5 Ch. 6, Consumer Credit Directive, Inkassolagen |
+| [LND-BR-009](./lnd-br-009) | Account expiration enforcement for lending | High | CBTRN02C.cbl:414-420 | FSA FFFS 2014:5 Ch. 6, Consumer Credit Directive, PSD2 |
+| [LND-BR-010](./lnd-br-010) | Lending transaction categorization and balance tracking | Medium | CBTRN02C.cbl:467-542 | FSA FFFS 2014:5 Ch. 3, 7, PSD2, DORA |
+
+## Status
+
+All 10 business rules have been extracted. Rules LND-BR-001, LND-BR-002, LND-BR-005, LND-BR-009, and LND-BR-010 are extracted directly from available COBOL source code (CBTRN02C.cbl). Rules LND-BR-003, LND-BR-004, LND-BR-006, LND-BR-007, and LND-BR-008 are extracted from regulatory requirements and inferred from the account data structure, pending dedicated COBOL source programs from the mainframe team. All rules have `status: extracted` and are awaiting domain expert validation.
+
+**Note on COBOL source coverage**: The available COBOL source programs are from the CardDemo credit card application and do not include dedicated lending programs. The lending-relevant logic extracted here represents:
+
+1. **Credit limit enforcement** (LND-BR-002): Directly extracted from CBTRN02C.cbl overlimit detection logic
+2. **Repayment processing** (LND-BR-005): Directly extracted from CBTRN02C.cbl balance update logic
+3. **Account expiration** (LND-BR-009): Directly extracted from CBTRN02C.cbl maturity enforcement
+4. **Transaction categorization** (LND-BR-010): Directly extracted from CBTRN02C.cbl category balance tracking
+5. **Account data structure** (LND-BR-001): Reconstructed from CVACT01Y.cpy field references
+
+The following dedicated COBOL programs must be obtained from the mainframe team to complete the lending domain extraction:
+
+- **Loan origination/account opening**: Credit assessment, limit determination, account creation
+- **Interest calculation batch**: Nightly interest accrual, disclosure group rate lookup, day-count computation
+- **Collateral management**: Collateral registration, periodic revaluation, LTV monitoring
+- **Disbursement**: Term loan funding, revolving credit activation, external fund transfer
+- **Collections/delinquency**: Missed payment detection, dunning, escalation, write-off processing
+- **Minimum payment calculation**: Monthly statement generation, minimum payment determination
+- **Credit line management**: Limit increases/decreases, temporary limit overrides
+
+## Regulatory Coverage
+
+| Regulation | Rules Covering |
+|------------|---------------|
+| FSA FFFS 2014:5 Ch. 3 (Accounting Records) | LND-BR-001, LND-BR-005, LND-BR-007, LND-BR-010 |
+| FSA FFFS 2014:5 Ch. 6 (Credit Risk Management) | LND-BR-001, LND-BR-002, LND-BR-003, LND-BR-004, LND-BR-006, LND-BR-008, LND-BR-009 |
+| FSA FFFS 2014:5 Ch. 7 (Financial Systems) | LND-BR-010 |
+| FSA FFFS 2014:5 Ch. 8 (Assets) | LND-BR-006 |
+| EU Consumer Credit Directive 2008/48/EC Art. 8 (Creditworthiness) | LND-BR-003 |
+| EU Consumer Credit Directive 2008/48/EC Art. 10 (Credit Agreement Information) | LND-BR-001, LND-BR-004, LND-BR-009 |
+| EU Consumer Credit Directive 2008/48/EC Art. 16 (Early Repayment) | LND-BR-005 |
+| EU Consumer Credit Directive 2008/48/EC Art. 19 (APR Calculation) | LND-BR-004 |
+| PSD2 Art. 64 (Transaction Data Integrity) | LND-BR-002, LND-BR-009, LND-BR-010 |
+| PSD2 Art. 83 (Execution Time) | LND-BR-007 |
+| PSD2 Art. 89 (Value Dating) | LND-BR-005, LND-BR-007 |
+| GDPR Art. 5(1)(a) (Lawfulness, Fairness, Transparency) | LND-BR-008 |
+| GDPR Art. 5(1)(c) (Data Minimization) | LND-BR-001, LND-BR-006 |
+| GDPR Art. 5(1)(d) (Accuracy) | LND-BR-001 |
+| GDPR Art. 5(1)(e) (Storage Limitation) | LND-BR-006 |
+| GDPR Art. 6(1)(b) (Contract Performance) | LND-BR-003 |
+| GDPR Art. 15 (Right of Access) | LND-BR-004 |
+| AML 2017:11 (Customer Due Diligence) | LND-BR-003, LND-BR-007 |
+| EU CRR Art. 194-217 (Credit Risk Mitigation) | LND-BR-006 |
+| Swedish Inkassolagen 1974:182 (Debt Recovery) | LND-BR-008 |
+| DORA Art. 11 (ICT Risk Management) | LND-BR-010 |
+
+## Migration Considerations
+
+1. **Dedicated lending programs required**: The most critical gap is the absence of dedicated lending COBOL programs. The mainframe team must provide programs for loan origination, interest calculation, collateral management, and collections. These programs contain the core lending business logic that cannot be fully inferred from the card transaction processing code.
+
+2. **Real-time credit limit enforcement**: The current COBOL system checks credit limits only during daily batch processing (CBTRN02C). The migrated system should implement real-time overlimit detection for online transactions, using optimistic concurrency control to handle concurrent access.
+
+3. **Interest calculation precision**: COBOL PIC S9(10)V99 provides 2-decimal precision. The migrated Azure SQL system should use `DECIMAL(12,4)` for intermediate interest calculations and `DECIMAL(12,2)` for final posted amounts to avoid rounding errors over billing cycles.
+
+4. **Batch SLA compliance**: The nightly interest calculation batch must complete by 06:00 (per current SLAs). Azure Functions with parallel processing should be designed to handle ~2 million accounts within this window.
+
+5. **Repayment allocation**: The current system applies all repayments uniformly to the balance. The migrated system may need to implement payment allocation waterfall (interest → fees → principal) per Swedish Consumer Credit Act requirements.
+
+6. **Collateral data model**: No collateral VSAM file structure is available. The migrated system should design a normalized collateral schema supporting one-to-many (loan-to-collateral) and many-to-many (cross-collateralization) relationships.
+
+7. **Delinquency state machine**: The COBOL account status field (ACCT-ACTIVE-STATUS) supports only Y/N. The migrated system must extend this to a full state machine: Active → Early Delinquent → Stage 1-3 → Collections → Write-off → Closed, with transition rules and audit logging.
+
+8. **Regulatory reporting**: Swedish lending regulations require periodic reporting to Finansinspektionen on credit risk exposures, non-performing loans, and collateral coverage. The migrated system must maintain data structures that support automated regulatory report generation.

--- a/docs-site/docs/business-rules/lending/lnd-br-001.md
+++ b/docs-site/docs/business-rules/lending/lnd-br-001.md
@@ -1,0 +1,160 @@
+---
+id: "lnd-br-001"
+title: "Loan account data structure and field definitions"
+domain: "lending"
+cobol_source: "CVACT01Y.cpy:1-30 (credit limit fields referenced across programs)"
+requirement_id: "LND-BR-001"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 6"
+  - "GDPR Art. 5(1)(c)"
+  - "GDPR Art. 5(1)(d)"
+  - "EU Consumer Credit Directive 2008/48/EC Art. 10"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# LND-BR-001: Loan account data structure and field definitions
+
+## Summary
+
+The lending domain relies on the account master record (CVACT01Y copybook) which contains credit-related fields that form the foundation for lending operations. The account record includes credit limit fields (`ACCT-CREDIT-LIMIT`, `ACCT-CASH-CREDIT-LIMIT`), balance tracking fields (`ACCT-CURR-BAL`, `ACCT-CURR-CYC-CREDIT`, `ACCT-CURR-CYC-DEBIT`), and a disclosure group field (`ACCT-GROUP-ID`) that links to interest rate schedules. These fields are referenced across multiple COBOL programs for credit risk management, transaction validation, and balance maintenance.
+
+The loan account structure must support the full lending lifecycle: origination (setting initial credit limits), utilization tracking (current balance vs. credit limit), repayment processing (cycle debit accumulation), and interest calculation (via disclosure group linkage). Dedicated lending COBOL programs for loan origination, servicing, and collections are not yet available in the repository and must be obtained from the mainframe team.
+
+## Business Logic
+
+### Data Structure
+
+```
+LOAN-ACCOUNT-FIELDS (extracted from CVACT01Y.cpy, 300-byte account record):
+    ACCT-ID                   PIC 9(11)      -- Primary key, 11-digit account number
+    ACCT-ACTIVE-STATUS        PIC X(01)      -- 'Y' = active, 'N' = inactive
+    ACCT-CURR-BAL             PIC S9(10)V99  -- Current outstanding balance (signed)
+    ACCT-CREDIT-LIMIT         PIC S9(10)V99  -- Maximum authorized credit (purchase limit)
+    ACCT-CASH-CREDIT-LIMIT    PIC S9(10)V99  -- Cash advance credit limit (separate ceiling)
+    ACCT-CURR-CYC-CREDIT      PIC S9(10)V99  -- Current cycle charges (utilization)
+    ACCT-CURR-CYC-DEBIT       PIC S9(10)V99  -- Current cycle payments (repayments)
+    ACCT-EXPIRAION-DATE       PIC X(10)      -- Account/loan maturity date (YYYY-MM-DD)
+    ACCT-GROUP-ID             PIC X(10)      -- Disclosure/interest rate group assignment
+
+DERIVED LENDING METRICS:
+    Available Credit = ACCT-CREDIT-LIMIT - (ACCT-CURR-CYC-CREDIT - ACCT-CURR-CYC-DEBIT)
+    Utilization Rate = ACCT-CURR-BAL / ACCT-CREDIT-LIMIT × 100
+    Cash Advance Available = ACCT-CASH-CREDIT-LIMIT - (cash advance portion of balance)
+```
+
+### Decision Table
+
+| Field | Lending Function | Used In | Regulatory Relevance |
+|-------|-----------------|---------|---------------------|
+| ACCT-CREDIT-LIMIT | Maximum borrowing capacity | CBTRN02C.cbl:407 | FSA FFFS 2014:5 Ch. 6 (credit risk) |
+| ACCT-CASH-CREDIT-LIMIT | Cash advance ceiling | Account master | Consumer Credit Directive Art. 10 |
+| ACCT-CURR-BAL | Outstanding debt | CBTRN02C.cbl:547 | FSA FFFS 2014:5 Ch. 3 (accounting) |
+| ACCT-CURR-CYC-CREDIT | Period utilization | CBTRN02C.cbl:403-404,549 | PSD2 Art. 64 (transaction integrity) |
+| ACCT-CURR-CYC-DEBIT | Period repayments | CBTRN02C.cbl:404,551 | PSD2 Art. 64 (transaction integrity) |
+| ACCT-GROUP-ID | Interest rate group | Account master | Consumer Credit Directive Art. 10 |
+| ACCT-EXPIRAION-DATE | Loan maturity | CBTRN02C.cbl:414 | FSA FFFS 2014:5 Ch. 6 |
+
+## Source COBOL Reference
+
+**Copybook:** `CVACT01Y.cpy` (referenced but not fully available in repository — reconstructed from program references)
+**Programs referencing credit fields:** `CBTRN02C.cbl`, `COCRDUPC.cbl`
+
+```cobol
+000403               COMPUTE WS-TEMP-BAL = ACCT-CURR-CYC-CREDIT
+000404                                   - ACCT-CURR-CYC-DEBIT
+000405                                   + DALYTRAN-AMT
+000407               IF ACCT-CREDIT-LIMIT >= WS-TEMP-BAL
+```
+*(Lines 403-407, CBTRN02C.cbl — credit limit comparison for overlimit detection, demonstrating ACCT-CREDIT-LIMIT, ACCT-CURR-CYC-CREDIT, ACCT-CURR-CYC-DEBIT fields)*
+
+```cobol
+000547           ADD DALYTRAN-AMT  TO ACCT-CURR-BAL
+000548           IF DALYTRAN-AMT >= 0
+000549              ADD DALYTRAN-AMT TO ACCT-CURR-CYC-CREDIT
+000550           ELSE
+000551              ADD DALYTRAN-AMT TO ACCT-CURR-CYC-DEBIT
+000552           END-IF
+```
+*(Lines 547-552, CBTRN02C.cbl — balance update showing credit/debit classification for lending cycle tracking)*
+
+```cobol
+000414               IF ACCT-EXPIRAION-DATE >= DALYTRAN-ORIG-TS (1:10)
+```
+*(Line 414, CBTRN02C.cbl — account/loan expiration enforcement)*
+
+## Acceptance Criteria
+
+### Scenario 1: Loan account record contains all required lending fields
+
+```gherkin
+GIVEN a loan account record is created in the migrated system
+WHEN the record is persisted to Azure SQL
+THEN all lending fields are present:
+  | Field              | SQL Type       | Nullable |
+  | AccountId          | CHAR(11)       | NO       |
+  | ActiveStatus       | CHAR(1)        | NO       |
+  | CurrentBalance     | DECIMAL(12,2)  | NO       |
+  | CreditLimit        | DECIMAL(12,2)  | NO       |
+  | CashCreditLimit    | DECIMAL(12,2)  | NO       |
+  | CycleCredit        | DECIMAL(12,2)  | NO       |
+  | CycleDebit         | DECIMAL(12,2)  | NO       |
+  | ExpirationDate     | DATE           | NO       |
+  | DisclosureGroupId  | VARCHAR(10)    | YES      |
+```
+
+### Scenario 2: Financial field precision preservation
+
+```gherkin
+GIVEN a loan account with CreditLimit = 9999999999.99
+WHEN the value is stored and retrieved from Azure SQL
+THEN the value is exactly 9999999999.99
+  AND no floating-point precision loss occurs
+  AND the SQL type is DECIMAL(12,2)
+```
+
+### Scenario 3: Dual credit limit structure
+
+```gherkin
+GIVEN a loan account with:
+  | CreditLimit     | 50000.00 |
+  | CashCreditLimit | 10000.00 |
+WHEN the available credit is calculated
+THEN the purchase credit available is CreditLimit minus outstanding purchase balance
+  AND the cash advance credit available is CashCreditLimit minus outstanding cash advance balance
+  AND the two limits are enforced independently
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 6 | Credit risk management — institutions must maintain adequate records of credit exposures | The loan account record tracks current balance, credit limits, and cycle utilization providing a complete view of credit exposure per account |
+| GDPR | Art. 5(1)(c) | Data minimization — personal data limited to what is necessary | The loan account contains only financial and status fields; customer PII is stored separately, not in the account master record |
+| GDPR | Art. 5(1)(d) | Accuracy — data must be kept accurate and up to date | Balance fields are updated atomically during transaction posting (CBTRN02C.cbl:547-552), maintaining accuracy through structured credit/debit classification |
+| Consumer Credit Directive | Art. 10 | Information to be included in credit agreements — total amount of credit, borrowing rate, conditions governing application of rate | The credit limit, cash credit limit, and disclosure group ID fields provide the data foundation for credit agreement terms |
+
+## Edge Cases
+
+1. **EBCDIC numeric encoding**: COBOL PIC S9(10)V99 fields use packed decimal format in EBCDIC. The implied decimal point (V99) must be correctly interpreted during migration. Incorrect conversion would cause all balances to be off by a factor of 100.
+
+2. **Negative balances**: All financial fields use signed notation (S prefix). A negative current balance represents an overpayment or credit to the account. The migrated system must allow negative values in balance columns.
+
+3. **Dual credit limit interaction**: The relationship between ACCT-CREDIT-LIMIT and ACCT-CASH-CREDIT-LIMIT is not explicitly defined in available COBOL source. The mainframe team must clarify whether cash advance limit is a subset of the total credit limit or an independent ceiling.
+
+4. **Disclosure group linkage**: The ACCT-GROUP-ID field links to interest rate schedules, but the disclosure group master file and its COBOL programs are not yet available. This linkage is critical for interest calculation rules (LND-BR-004).
+
+5. **Account expiration vs. loan maturity**: The ACCT-EXPIRAION-DATE field is used for both card expiration (in card programs) and potentially loan maturity (in lending context). The mainframe team must confirm whether separate maturity date fields exist for term loans.
+
+6. **Filler area contents**: The 300-byte account record likely contains additional lending-relevant fields not yet identified (origination date, last payment date, minimum payment amount, delinquency counters). A full dump of the CVACT01Y copybook is needed.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. CRITICAL: The full CVACT01Y.cpy copybook must be obtained from the mainframe team to validate the reconstructed record layout and identify additional lending-specific fields. Key questions: (1) Does the account record contain loan origination date, term length, and maturity date? (2) Is the disclosure group ID the sole linkage to interest rate schedules? (3) Are there separate account types distinguishing revolving credit from term loans? (4) What fields in the filler area relate to delinquency tracking or minimum payment calculations?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/lending/lnd-br-002.md
+++ b/docs-site/docs/business-rules/lending/lnd-br-002.md
@@ -1,0 +1,254 @@
+---
+id: "lnd-br-002"
+title: "Credit limit enforcement and overlimit detection"
+domain: "lending"
+cobol_source: "CBTRN02C.cbl:393-421"
+requirement_id: "LND-BR-002"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 6"
+  - "EU Consumer Credit Directive 2008/48/EC Art. 10"
+  - "PSD2 Art. 64"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# LND-BR-002: Credit limit enforcement and overlimit detection
+
+## Summary
+
+The credit limit enforcement rule is the primary lending risk control in the system. During daily batch transaction posting (CBTRN02C), each transaction is validated against the account's authorized credit limit before posting. The system computes a projected balance by taking the current cycle credits, subtracting current cycle debits, and adding the pending transaction amount. If this projected balance exceeds the account's credit limit, the transaction is rejected with validation failure code 102 ("OVERLIMIT TRANSACTION") and written to the daily rejects file. This is a hard limit — there is no tolerance margin or soft overlimit allowance in the current COBOL implementation.
+
+This rule implements the core credit risk management requirement under FSA FFFS 2014:5 Chapter 6, ensuring that credit exposures do not exceed authorized limits. The validation occurs during batch processing, meaning overlimit detection is not real-time but operates on a daily cycle.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM CREDIT-LIMIT-CHECK:
+    -- Step 1: Look up card cross-reference to find account
+    READ XREF-FILE using DALYTRAN-CARD-NUM
+    IF card not found
+        SET validation-fail-reason = 100
+        SET fail-description = 'INVALID CARD NUMBER FOUND'
+        EXIT (reject transaction)
+    END-IF
+
+    -- Step 2: Look up account record
+    READ ACCOUNT-FILE using XREF-ACCT-ID
+    IF account not found
+        SET validation-fail-reason = 101
+        SET fail-description = 'ACCOUNT RECORD NOT FOUND'
+        EXIT (reject transaction)
+    END-IF
+
+    -- Step 3: Compute projected balance after transaction
+    COMPUTE projected-balance = current-cycle-credit
+                              - current-cycle-debit
+                              + transaction-amount
+
+    -- Step 4: Compare against credit limit
+    IF credit-limit >= projected-balance
+        CONTINUE (transaction passes credit check)
+    ELSE
+        SET validation-fail-reason = 102
+        SET fail-description = 'OVERLIMIT TRANSACTION'
+    END-IF
+
+    -- Step 5: Check account expiration
+    IF account-expiration-date >= transaction-date
+        CONTINUE (account is not expired)
+    ELSE
+        SET validation-fail-reason = 103
+        SET fail-description = 'TRANSACTION RECEIVED AFTER ACCT EXPIRATION'
+    END-IF
+```
+
+### Decision Table
+
+| Condition | Card Found | Account Found | Within Credit Limit | Account Not Expired | Outcome |
+|-----------|-----------|---------------|--------------------|--------------------|---------|
+| All valid | Yes | Yes | Yes | Yes | Transaction posted |
+| Invalid card | No | N/A | N/A | N/A | Rejected (code 100) |
+| No account | Yes | No | N/A | N/A | Rejected (code 101) |
+| Overlimit | Yes | Yes | No | Yes | Rejected (code 102) |
+| Expired | Yes | Yes | Yes | No | Rejected (code 103) |
+| Overlimit + Expired | Yes | Yes | No | No | Rejected (code 102, first failure wins) |
+
+## Source COBOL Reference
+
+**Program:** `CBTRN02C.cbl`
+**Lines:** 370-421 (validation), 193-234 (main processing loop)
+
+```cobol
+001500 1500-VALIDATE-TRAN.
+000371           PERFORM 1500-A-LOOKUP-XREF.
+000372           IF WS-VALIDATION-FAIL-REASON = 0
+000373              PERFORM 1500-B-LOOKUP-ACCT
+000374           ELSE
+000375              CONTINUE
+000376           END-IF
+000377      * ADD MORE VALIDATIONS HERE
+000378           EXIT.
+```
+*(Lines 370-378 — validation dispatcher: first validates card cross-reference, then validates account if card is valid)*
+
+```cobol
+000380 1500-A-LOOKUP-XREF.
+000382           MOVE DALYTRAN-CARD-NUM TO FD-XREF-CARD-NUM
+000383           READ XREF-FILE INTO CARD-XREF-RECORD
+000384              INVALID KEY
+000385                MOVE 100 TO WS-VALIDATION-FAIL-REASON
+000386                MOVE 'INVALID CARD NUMBER FOUND'
+000387                  TO WS-VALIDATION-FAIL-REASON-DESC
+000388              NOT INVALID KEY
+000390                  CONTINUE
+000391           END-READ
+000392           EXIT.
+```
+*(Lines 380-392 — card cross-reference validation: checks that the card number exists in the XREF file)*
+
+```cobol
+000393 1500-B-LOOKUP-ACCT.
+000394           MOVE XREF-ACCT-ID TO FD-ACCT-ID
+000395           READ ACCOUNT-FILE INTO ACCOUNT-RECORD
+000396              INVALID KEY
+000397                MOVE 101 TO WS-VALIDATION-FAIL-REASON
+000398                MOVE 'ACCOUNT RECORD NOT FOUND'
+000399                  TO WS-VALIDATION-FAIL-REASON-DESC
+000400              NOT INVALID KEY
+000403                COMPUTE WS-TEMP-BAL = ACCT-CURR-CYC-CREDIT
+000404                                    - ACCT-CURR-CYC-DEBIT
+000405                                    + DALYTRAN-AMT
+000407                IF ACCT-CREDIT-LIMIT >= WS-TEMP-BAL
+000408                  CONTINUE
+000409                ELSE
+000410                  MOVE 102 TO WS-VALIDATION-FAIL-REASON
+000411                  MOVE 'OVERLIMIT TRANSACTION'
+000412                    TO WS-VALIDATION-FAIL-REASON-DESC
+000413                END-IF
+000414                IF ACCT-EXPIRAION-DATE >= DALYTRAN-ORIG-TS (1:10)
+000415                  CONTINUE
+000416                ELSE
+000417                  MOVE 103 TO WS-VALIDATION-FAIL-REASON
+000418                  MOVE 'TRANSACTION RECEIVED AFTER ACCT EXPIRATION'
+000419                    TO WS-VALIDATION-FAIL-REASON-DESC
+000420                END-IF
+000421           END-READ
+```
+*(Lines 393-421 — the core credit limit enforcement: computes projected balance and compares against ACCT-CREDIT-LIMIT)*
+
+```cobol
+000202           PERFORM UNTIL END-OF-FILE = 'Y'
+000208                     MOVE 0 TO WS-VALIDATION-FAIL-REASON
+000209                     MOVE SPACES TO WS-VALIDATION-FAIL-REASON-DESC
+000210                     PERFORM 1500-VALIDATE-TRAN
+000211                     IF WS-VALIDATION-FAIL-REASON = 0
+000212                       PERFORM 2000-POST-TRANSACTION
+000213                     ELSE
+000214                       ADD 1 TO WS-REJECT-COUNT
+000215                       PERFORM 2500-WRITE-REJECT-REC
+000216                     END-IF
+```
+*(Lines 202-216 — main loop: validates each daily transaction and either posts or rejects it)*
+
+## Acceptance Criteria
+
+### Scenario 1: Transaction within credit limit is posted
+
+```gherkin
+GIVEN a loan account with:
+  | Credit Limit        | 10000.00 |
+  | Current Cycle Credit | 3000.00  |
+  | Current Cycle Debit  | 1000.00  |
+WHEN a transaction of 5000.00 is submitted
+THEN the projected balance is calculated as 3000.00 - 1000.00 + 5000.00 = 7000.00
+  AND 10000.00 >= 7000.00 is TRUE
+  AND the transaction is posted successfully
+```
+
+### Scenario 2: Transaction exceeding credit limit is rejected
+
+```gherkin
+GIVEN a loan account with:
+  | Credit Limit        | 10000.00 |
+  | Current Cycle Credit | 8000.00  |
+  | Current Cycle Debit  | 500.00   |
+WHEN a transaction of 3000.00 is submitted
+THEN the projected balance is calculated as 8000.00 - 500.00 + 3000.00 = 10500.00
+  AND 10000.00 >= 10500.00 is FALSE
+  AND the transaction is rejected with code 102
+  AND the rejection reason is "OVERLIMIT TRANSACTION"
+  AND the transaction is written to the daily rejects file
+```
+
+### Scenario 3: Transaction exactly at credit limit is posted
+
+```gherkin
+GIVEN a loan account with:
+  | Credit Limit        | 10000.00 |
+  | Current Cycle Credit | 5000.00  |
+  | Current Cycle Debit  | 0.00     |
+WHEN a transaction of 5000.00 is submitted
+THEN the projected balance is calculated as 5000.00 - 0.00 + 5000.00 = 10000.00
+  AND 10000.00 >= 10000.00 is TRUE (boundary: equal is allowed)
+  AND the transaction is posted successfully
+```
+
+### Scenario 4: Negative transaction (payment) always passes credit check
+
+```gherkin
+GIVEN a loan account with:
+  | Credit Limit        | 10000.00  |
+  | Current Cycle Credit | 10000.00  |
+  | Current Cycle Debit  | 0.00      |
+WHEN a payment (negative transaction) of -2000.00 is submitted
+THEN the projected balance is calculated as 10000.00 - 0.00 + (-2000.00) = 8000.00
+  AND 10000.00 >= 8000.00 is TRUE
+  AND the payment is posted successfully
+```
+
+### Scenario 5: Overlimit check uses cycle balances, not current balance
+
+```gherkin
+GIVEN a loan account with:
+  | Current Balance     | 15000.00  |
+  | Credit Limit        | 10000.00  |
+  | Current Cycle Credit | 2000.00   |
+  | Current Cycle Debit  | 0.00      |
+WHEN a transaction of 7000.00 is submitted
+THEN the projected balance uses CYCLE values: 2000.00 - 0.00 + 7000.00 = 9000.00
+  AND 10000.00 >= 9000.00 is TRUE
+  AND the transaction is posted (even though current balance exceeds credit limit)
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 6 | Credit risk management — institutions must have policies and procedures for managing credit risk, including setting and enforcing credit limits | The overlimit detection prevents credit exposure from exceeding the authorized limit by rejecting transactions that would breach the ceiling |
+| Consumer Credit Directive | Art. 10(2)(d) | Credit agreement must specify total amount of credit and conditions governing drawdown | The credit limit field defines the total authorized credit; the enforcement logic ensures drawdowns (transactions) do not exceed this amount |
+| PSD2 | Art. 64 | Transaction data integrity — payment service providers must ensure integrity of payment transactions | The validation ensures only authorized transactions (within credit limits) are posted to the transaction file; rejected transactions are written to a separate rejects file with audit trail |
+
+## Edge Cases
+
+1. **Batch-only enforcement**: The overlimit check runs only during daily batch posting (CBTRN02C). There is no real-time overlimit check in the online CICS programs. A customer could theoretically exceed their limit through multiple same-day transactions that are individually within limits but collectively exceed it. The migrated system should consider real-time credit limit enforcement.
+
+2. **Validation order dependency**: The COBOL code checks credit limit BEFORE checking account expiration (lines 407-420). If both conditions fail, only code 102 (overlimit) is recorded because code 103 overwrites it. The last validation failure wins. The migrated system should collect all failures, not just the last one.
+
+3. **Cycle balance vs. current balance**: The projected balance formula uses `ACCT-CURR-CYC-CREDIT - ACCT-CURR-CYC-DEBIT + transaction`, NOT `ACCT-CURR-BAL + transaction`. This means the overlimit check operates on the current billing cycle's net utilization, not the running account balance. If there is a carried-over balance from a previous cycle, it is not included in the overlimit calculation.
+
+4. **Zero credit limit**: If ACCT-CREDIT-LIMIT is zero, any positive transaction will be rejected as overlimit. The COBOL code does not have a special case for zero limits. The migrated system must decide whether a zero limit means "credit frozen" or is an error condition.
+
+5. **Cash advance limit not checked**: The ACCT-CASH-CREDIT-LIMIT field exists in the account record but is NOT checked in CBTRN02C. The available COBOL source does not differentiate between purchase transactions and cash advances for limit enforcement. Dedicated cash advance validation logic may exist in programs not yet obtained from the mainframe.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. CRITICAL QUESTIONS: (1) Is the cycle-based overlimit check intentional, or should the running balance (ACCT-CURR-BAL) be used instead? (2) Is there a separate real-time overlimit check in CICS online programs not yet obtained? (3) Are there soft overlimit allowances or grace amounts for certain account types? (4) How is the cash advance limit (ACCT-CASH-CREDIT-LIMIT) enforced — is there a separate validation program? (5) What happens when an overlimit transaction is rejected — is the customer notified in real-time or only through the daily reject report?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/lending/lnd-br-003.md
+++ b/docs-site/docs/business-rules/lending/lnd-br-003.md
@@ -1,0 +1,193 @@
+---
+id: "lnd-br-003"
+title: "Loan origination and credit assessment"
+domain: "lending"
+cobol_source: "Dedicated program not yet in repository (referenced via CVACT01Y.cpy field structure)"
+requirement_id: "LND-BR-003"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 6"
+  - "EU Consumer Credit Directive 2008/48/EC Art. 8"
+  - "AML 2017:11"
+  - "GDPR Art. 6(1)(b)"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# LND-BR-003: Loan origination and credit assessment
+
+## Summary
+
+Loan origination is the process of creating a new lending account with an authorized credit limit. While no dedicated loan origination COBOL program has been obtained from the mainframe, the account master record structure (CVACT01Y.cpy) and the credit limit enforcement logic in CBTRN02C.cbl reveal the data requirements for origination. A new loan account must be initialized with an ACCT-CREDIT-LIMIT, ACCT-CASH-CREDIT-LIMIT, and ACCT-GROUP-ID (linking to the applicable interest rate schedule). The ACCT-ACTIVE-STATUS must be set to 'Y' and ACCT-EXPIRAION-DATE set to the loan maturity date.
+
+Under Swedish regulatory requirements (FSA FFFS 2014:5 Chapter 6) and the EU Consumer Credit Directive (Art. 8), creditworthiness assessment is mandatory before granting credit. The origination program must validate the borrower's ability to repay, apply risk-based pricing, and ensure AML/KYC checks are completed before account activation. The specific COBOL programs implementing these checks must be obtained from the mainframe team.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM LOAN-ORIGINATION:
+    -- Step 1: Validate customer identity (AML/KYC)
+    PERFORM AML-KYC-CHECK using customer-id
+    IF AML-KYC-CHECK fails
+        REJECT origination with 'AML/KYC VERIFICATION FAILED'
+        EXIT
+    END-IF
+
+    -- Step 2: Assess creditworthiness (FSA requirement)
+    PERFORM CREDITWORTHINESS-ASSESSMENT using customer-id, requested-amount
+    IF creditworthiness-score < minimum-threshold
+        REJECT origination with 'CREDIT ASSESSMENT FAILED'
+        EXIT
+    END-IF
+
+    -- Step 3: Determine credit limit and terms
+    SET ACCT-CREDIT-LIMIT = approved-credit-amount
+    SET ACCT-CASH-CREDIT-LIMIT = cash-advance-limit (typically % of credit limit)
+    SET ACCT-GROUP-ID = applicable-interest-rate-group
+
+    -- Step 4: Initialize account record
+    GENERATE new ACCT-ID (11-digit sequential)
+    SET ACCT-ACTIVE-STATUS = 'Y'
+    SET ACCT-CURR-BAL = 0.00
+    SET ACCT-CURR-CYC-CREDIT = 0.00
+    SET ACCT-CURR-CYC-DEBIT = 0.00
+    SET ACCT-EXPIRAION-DATE = loan-maturity-date
+
+    -- Step 5: Write account record
+    WRITE ACCOUNT-RECORD to ACCTFILE
+    IF write fails
+        ABEND with error
+    END-IF
+
+    -- Step 6: Create card cross-reference (if applicable)
+    WRITE XREF-RECORD linking card to new account
+```
+
+### Decision Table
+
+| AML/KYC Passed | Credit Score ≥ Threshold | Requested Amount ≤ Max Limit | Outcome |
+|----------------|--------------------------|------------------------------|---------|
+| No | N/A | N/A | Origination rejected (AML/KYC) |
+| Yes | No | N/A | Origination rejected (creditworthiness) |
+| Yes | Yes | No | Origination rejected (exceeds max limit) |
+| Yes | Yes | Yes | Account created, credit limit set |
+
+## Source COBOL Reference
+
+**Program:** Dedicated loan origination program not yet available in repository.
+**Inferred from:** `CVACT01Y.cpy` (account record structure), `CBTRN02C.cbl` (credit limit field usage)
+
+The account initialization fields are inferred from the account record layout referenced across programs:
+
+```cobol
+      *ACCOUNT RECORD LAYOUT
+      *COPY CVACT01Y.
+```
+*(Lines 230-231, COCRDSLC.cbl — copybook reference showing CVACT01Y defines the account master used in origination)*
+
+```cobol
+000088       01  FD-ACCTFILE-REC.
+000089           05 FD-ACCT-ID                        PIC 9(11).
+000090           05 FD-ACCT-DATA                      PIC X(289).
+```
+*(Lines 88-90, CBTRN02C.cbl — account file record layout showing 300-byte structure: 11-digit key + 289-byte data area)*
+
+The credit limit and balance fields are set during origination and later validated during transaction posting:
+
+```cobol
+000407               IF ACCT-CREDIT-LIMIT >= WS-TEMP-BAL
+000408                  CONTINUE
+000409                ELSE
+000410                  MOVE 102 TO WS-VALIDATION-FAIL-REASON
+000411                  MOVE 'OVERLIMIT TRANSACTION'
+000412                    TO WS-VALIDATION-FAIL-REASON-DESC
+000413                END-IF
+```
+*(Lines 407-413, CBTRN02C.cbl — credit limit enforcement depends on the limit value set during origination)*
+
+## Acceptance Criteria
+
+### Scenario 1: Successful loan origination
+
+```gherkin
+GIVEN a customer has passed AML/KYC verification
+  AND the creditworthiness assessment approves a credit limit of 50000.00
+WHEN a loan origination request is processed
+THEN a new account record is created with:
+  | Field              | Value      |
+  | AccountId          | (11-digit) |
+  | ActiveStatus       | Y          |
+  | CurrentBalance     | 0.00       |
+  | CreditLimit        | 50000.00   |
+  | CycleCredit        | 0.00       |
+  | CycleDebit         | 0.00       |
+  AND the account is available for transactions
+```
+
+### Scenario 2: Origination rejected due to AML/KYC failure
+
+```gherkin
+GIVEN a customer has NOT passed AML/KYC verification
+WHEN a loan origination request is submitted
+THEN the origination is rejected
+  AND no account record is created
+  AND the rejection reason includes 'AML/KYC VERIFICATION FAILED'
+  AND the rejection is logged for regulatory audit
+```
+
+### Scenario 3: Origination rejected due to insufficient creditworthiness
+
+```gherkin
+GIVEN a customer has passed AML/KYC verification
+  AND the creditworthiness assessment score is below the minimum threshold
+WHEN a loan origination request is submitted
+THEN the origination is rejected
+  AND no account record is created
+  AND the rejection reason includes 'CREDIT ASSESSMENT FAILED'
+  AND the customer is informed of the adverse decision per Consumer Credit Directive Art. 9
+```
+
+### Scenario 4: Account initialized with zero balances
+
+```gherkin
+GIVEN a new loan account is originated
+WHEN the account record is written to the ACCTFILE
+THEN ACCT-CURR-BAL = 0.00
+  AND ACCT-CURR-CYC-CREDIT = 0.00
+  AND ACCT-CURR-CYC-DEBIT = 0.00
+  AND all financial fields start at zero
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 6 | Creditworthiness assessment before granting credit — institutions must assess the borrower's ability to fulfil obligations | The origination process includes a mandatory creditworthiness assessment step before setting the credit limit |
+| Consumer Credit Directive | Art. 8 | Obligation to assess the creditworthiness of the consumer before concluding a credit agreement | Credit assessment is a prerequisite for account creation; failed assessments prevent origination |
+| Consumer Credit Directive | Art. 9 | Database access and adverse action notification — consumer must be informed of adverse credit decisions | Origination rejections generate a rejection reason that can be communicated to the applicant |
+| AML 2017:11 | §3 | Customer due diligence — identity verification before establishing business relationship | AML/KYC check is the first step in origination, blocking account creation for unverified customers |
+| GDPR | Art. 6(1)(b) | Processing necessary for performance of a contract — personal data processing is lawful when necessary to enter into a contract | Customer data collected during origination is limited to what is necessary for the credit assessment and account creation |
+
+## Edge Cases
+
+1. **Duplicate account prevention**: The COBOL ACCTFILE uses ACCT-ID as a KSDS primary key. Attempting to write a duplicate key would trigger an INVALID KEY condition. The migrated system must enforce unique account IDs and handle collisions gracefully.
+
+2. **Maximum credit limit**: ACCT-CREDIT-LIMIT is PIC S9(10)V99, allowing up to ±9,999,999,999.99. The migrated system should enforce institution-specific maximum credit limits well below this technical maximum, per risk appetite and regulatory requirements.
+
+3. **Cash advance limit relationship**: The relationship between ACCT-CREDIT-LIMIT and ACCT-CASH-CREDIT-LIMIT during origination is unknown. Typically the cash advance limit is a percentage (e.g., 20-50%) of the total credit limit. The mainframe team must confirm the business rule.
+
+4. **Interest rate group assignment**: The ACCT-GROUP-ID field links the account to a disclosure group for interest rate determination. The origination program must assign the correct group based on the product type and risk tier. The disclosure group master file programs have not yet been obtained.
+
+5. **Concurrent origination**: If two operators attempt to create accounts simultaneously, the sequential ACCT-ID generation could create duplicates. The COBOL system may use a counter file or sequence program. The migrated system should use database sequences or GUID-based IDs.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. CRITICAL: The loan origination COBOL program must be obtained from the mainframe team. Key questions: (1) What is the program name for loan/account origination? (2) What creditworthiness assessment criteria are used (income verification, existing debt ratio, credit bureau check)? (3) How are credit limits determined — manual underwriting, automated scoring, or both? (4) What is the ACCT-ID generation mechanism — sequential counter, check-digit algorithm, or external sequence? (5) Is there a separate program for credit line increases vs. new origination?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/lending/lnd-br-004.md
+++ b/docs-site/docs/business-rules/lending/lnd-br-004.md
@@ -1,0 +1,222 @@
+---
+id: "lnd-br-004"
+title: "Interest calculation and amortization schedule"
+domain: "lending"
+cobol_source: "Dedicated program not yet in repository (referenced via ACCT-GROUP-ID in CVACT01Y.cpy)"
+requirement_id: "LND-BR-004"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 6"
+  - "EU Consumer Credit Directive 2008/48/EC Art. 10"
+  - "EU Consumer Credit Directive 2008/48/EC Art. 19"
+  - "GDPR Art. 15"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# LND-BR-004: Interest calculation and amortization schedule
+
+## Summary
+
+Interest calculation is a core lending function that determines the cost of borrowing for each account. The COBOL system links accounts to interest rate schedules via the ACCT-GROUP-ID (disclosure group) field in the account master record. While the dedicated interest calculation batch program has not yet been obtained from the mainframe, the data structure and regulatory requirements allow extraction of the business rule framework. The interest calculation batch job must run nightly (per the system's batch SLA of completion by 06:00) and produce interest accruals for each active account based on its outstanding balance and applicable rate.
+
+Under the EU Consumer Credit Directive (Art. 19), the Annual Percentage Rate of charge (APR) must be calculated using a standardized formula. For Swedish krona (SEK) lending, interest is typically calculated on an Actual/360 or 30/360 day-count convention. The amortization schedule for term loans defines the repayment plan, splitting each payment into principal and interest components.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM NIGHTLY-INTEREST-CALCULATION:
+    OPEN ACCTFILE for INPUT
+    OPEN INTEREST-ACCRUAL-FILE for OUTPUT
+    OPEN DISCLOSURE-GROUP-FILE for INPUT
+
+    PERFORM UNTIL end-of-accounts
+        READ next ACCOUNT-RECORD from ACCTFILE
+        IF ACCT-ACTIVE-STATUS = 'Y'
+           AND ACCT-CURR-BAL > 0
+
+            -- Look up interest rate from disclosure group
+            READ DISCLOSURE-GROUP-FILE using ACCT-GROUP-ID
+            SET annual-rate = DISCLOSURE-ANNUAL-RATE
+            SET day-count-method = DISCLOSURE-DAY-COUNT
+
+            -- Calculate daily interest
+            IF day-count-method = 'ACT/360'
+                SET daily-rate = annual-rate / 360
+                SET days-in-period = actual-days-elapsed
+            ELSE IF day-count-method = '30/360'
+                SET daily-rate = annual-rate / 360
+                SET days-in-period = 30 (for monthly)
+            END-IF
+
+            COMPUTE interest-amount = ACCT-CURR-BAL
+                                    × daily-rate
+                                    × days-in-period
+
+            -- Round to 2 decimal places (banker's rounding)
+            COMPUTE interest-amount ROUNDED = interest-amount
+
+            -- Write interest accrual record
+            WRITE INTEREST-ACCRUAL-RECORD
+                (ACCT-ID, interest-amount, annual-rate, period-start, period-end)
+
+        END-IF
+    END-PERFORM
+
+PERFORM AMORTIZATION-SCHEDULE:
+    -- For term loans (not revolving credit)
+    SET principal = loan-amount
+    SET monthly-rate = annual-rate / 12
+    SET num-payments = loan-term-months
+
+    -- Fixed monthly payment (annuity formula)
+    COMPUTE monthly-payment = principal
+        × (monthly-rate × (1 + monthly-rate) ^ num-payments)
+        / ((1 + monthly-rate) ^ num-payments - 1)
+
+    FOR each payment period:
+        COMPUTE interest-portion = remaining-principal × monthly-rate
+        COMPUTE principal-portion = monthly-payment - interest-portion
+        COMPUTE remaining-principal = remaining-principal - principal-portion
+        WRITE schedule-record
+            (period, payment, principal-portion, interest-portion, remaining-principal)
+    END-FOR
+```
+
+### Decision Table
+
+| Account Active | Balance > 0 | Disclosure Group Found | Outcome |
+|---------------|-------------|----------------------|---------|
+| No | N/A | N/A | Skip — no interest calculated |
+| Yes | No (= 0) | N/A | Skip — no interest on zero balance |
+| Yes | Yes | No | Error — missing rate configuration |
+| Yes | Yes | Yes | Interest calculated and accrued |
+
+## Source COBOL Reference
+
+**Program:** Dedicated interest calculation batch program not yet available in repository.
+**Inferred from:** `CVACT01Y.cpy` (ACCT-GROUP-ID field), `CBTRN02C.cbl` (batch processing pattern)
+
+The disclosure group linkage is defined in the account master record:
+
+```cobol
+      * ACCT-GROUP-ID             PIC X(10)
+      * Links account to disclosure/interest rate group
+```
+*(Reconstructed from CVACT01Y.cpy — ACCT-GROUP-ID field provides the foreign key to the interest rate schedule)*
+
+The batch processing pattern from CBTRN02C shows how lending batch jobs are structured:
+
+```cobol
+000193       PROCEDURE DIVISION.
+000194           DISPLAY 'START OF EXECUTION OF PROGRAM CBTRN02C'.
+000195           PERFORM 0000-DALYTRAN-OPEN.
+             ...
+000202           PERFORM UNTIL END-OF-FILE = 'Y'
+000203               IF  END-OF-FILE = 'N'
+000204                   PERFORM 1000-DALYTRAN-GET-NEXT
+                     ...
+000219           END-PERFORM.
+             ...
+000232           DISPLAY 'END OF EXECUTION OF PROGRAM CBTRN02C'.
+000234           GOBACK.
+```
+*(Lines 193-234, CBTRN02C.cbl — standard batch processing pattern: open files, process in loop, close files, GOBACK. The interest calculation batch would follow this same pattern.)*
+
+## Acceptance Criteria
+
+### Scenario 1: Daily interest accrual on active account
+
+```gherkin
+GIVEN an active loan account with:
+  | Current Balance  | 100000.00 |
+  | Disclosure Group | GRP-STD   |
+  AND disclosure group GRP-STD has annual rate 8.50%
+  AND the day-count method is Actual/360
+WHEN the nightly interest calculation batch runs
+THEN the daily interest is calculated as: 100000.00 × (0.085 / 360) × 1 = 23.61
+  AND an interest accrual record is written for the account
+  AND the accrual amount is rounded to 2 decimal places
+```
+
+### Scenario 2: No interest on zero balance
+
+```gherkin
+GIVEN an active loan account with:
+  | Current Balance  | 0.00    |
+  | Disclosure Group | GRP-STD |
+WHEN the nightly interest calculation batch runs
+THEN no interest accrual record is generated for this account
+```
+
+### Scenario 3: No interest on inactive account
+
+```gherkin
+GIVEN an account with:
+  | Active Status    | N        |
+  | Current Balance  | 50000.00 |
+WHEN the nightly interest calculation batch runs
+THEN no interest accrual record is generated for this account
+```
+
+### Scenario 4: Term loan amortization schedule
+
+```gherkin
+GIVEN a term loan with:
+  | Principal    | 500000.00 |
+  | Annual Rate  | 6.00%     |
+  | Term         | 360 months |
+WHEN the amortization schedule is generated
+THEN the monthly payment is approximately 2997.75 (annuity formula)
+  AND the first payment splits as: interest = 2500.00, principal = 497.75
+  AND each subsequent payment has decreasing interest and increasing principal
+  AND the final payment reduces remaining principal to 0.00
+```
+
+### Scenario 5: APR calculation per Consumer Credit Directive
+
+```gherkin
+GIVEN a loan with:
+  | Nominal Rate | 8.50%   |
+  | Fees         | 500.00  |
+  | Term         | 12 months |
+  | Amount       | 100000.00 |
+WHEN the APR is calculated per EU Consumer Credit Directive Art. 19
+THEN the APR includes the nominal rate plus all mandatory fees
+  AND the APR is expressed as an annual percentage to 1 decimal place
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 6 | Credit risk management — accurate measurement of credit exposure including accrued interest | Nightly interest calculation ensures the outstanding balance reflects accrued interest charges accurately |
+| Consumer Credit Directive | Art. 10(2)(f) | Credit agreement must specify borrowing rate, conditions governing application of the rate, and any index or reference rate | The disclosure group mechanism provides the rate structure; the calculation method (day count, compounding) is defined per group |
+| Consumer Credit Directive | Art. 19 | Annual Percentage Rate of charge — calculation using standardized EU formula | APR calculation must include all costs (interest + fees) and be presented per the Directive's annex formula |
+| GDPR | Art. 15 | Right of access — data subjects can request information about how their data is processed | Interest calculation details (rate applied, method, period) must be available for customer inquiry and regulatory audit |
+
+## Edge Cases
+
+1. **Rounding accumulation**: Daily interest calculation with rounding to 2 decimal places can accumulate rounding errors over a billing cycle. The COBOL system may use a "true-up" mechanism at cycle close. The migrated system should use banker's rounding (round half to even) to minimize bias.
+
+2. **Variable rate changes**: If the disclosure group rate changes mid-period, the interest calculation must pro-rate: apply the old rate up to the change date and the new rate from the change date. The mechanism for rate changes is not yet visible in the available COBOL source.
+
+3. **Negative balance interest**: If ACCT-CURR-BAL is negative (customer overpaid), the system may need to calculate credit interest payable to the customer. Whether the COBOL system handles this or treats it as zero-interest is unknown.
+
+4. **Leap year handling**: With Actual/360 day count, a leap year has 366 days divided by 360, resulting in slightly higher annual interest than the stated rate. The system must handle February 29 correctly.
+
+5. **Batch SLA compliance**: The nightly interest calculation must complete by 06:00 (per batch SLAs). For ~2 million accounts, the migrated Azure Functions implementation must be designed for parallel processing to meet this deadline.
+
+6. **Currency precision**: Swedish krona (SEK) uses 2 decimal places for display but may use higher precision (e.g., 4 decimal places) for intermediate calculations. The COBOL PIC S9(10)V99 suggests 2-decimal precision throughout. The migrated system should use DECIMAL(12,4) for intermediate calculations.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. CRITICAL: The interest calculation batch program must be obtained from the mainframe team. Key questions: (1) What is the program name for interest calculation? (2) What day-count convention is used (Actual/360, 30/360, Actual/365)? (3) Is interest compounded daily, monthly, or at statement cycle close? (4) What is the disclosure group master file structure — does it contain tiered rates based on balance ranges? (5) How are rate changes applied — immediately, at next cycle, or at next statement? (6) Is there a separate program for APR calculation and disclosure?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/lending/lnd-br-005.md
+++ b/docs-site/docs/business-rules/lending/lnd-br-005.md
@@ -1,0 +1,214 @@
+---
+id: "lnd-br-005"
+title: "Repayment processing and balance update"
+domain: "lending"
+cobol_source: "CBTRN02C.cbl:545-560"
+requirement_id: "LND-BR-005"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 3"
+  - "PSD2 Art. 64"
+  - "PSD2 Art. 89"
+  - "EU Consumer Credit Directive 2008/48/EC Art. 16"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "critical"
+---
+
+# LND-BR-005: Repayment processing and balance update
+
+## Summary
+
+Repayment processing updates the loan account balance when a payment (negative transaction) is received. In the COBOL system, repayments flow through the same daily batch transaction posting process (CBTRN02C) as all other transactions. A repayment is identified by a negative transaction amount (`DALYTRAN-AMT < 0`). The program adds the negative amount to the current balance (effectively reducing it) and accumulates the payment in the cycle debit field (`ACCT-CURR-CYC-DEBIT`). The account record is then rewritten to the ACCTFILE with the updated balances.
+
+This rule implements the payment application logic required by PSD2 Art. 89 (value dating) and the Consumer Credit Directive Art. 16 (early repayment). All repayments must be applied to the account balance accurately and atomically, with full audit trail through the posted transaction file.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM REPAYMENT-PROCESSING (within 2000-POST-TRANSACTION):
+    -- Transaction has already passed validation (1500-VALIDATE-TRAN)
+    -- For repayments: DALYTRAN-AMT is negative
+
+    -- Step 1: Update running balance
+    ADD DALYTRAN-AMT TO ACCT-CURR-BAL
+    -- (Adding a negative amount reduces the balance)
+
+    -- Step 2: Classify into cycle tracking
+    IF DALYTRAN-AMT >= 0
+        -- This is a charge/purchase (positive)
+        ADD DALYTRAN-AMT TO ACCT-CURR-CYC-CREDIT
+    ELSE
+        -- This is a payment/repayment (negative)
+        ADD DALYTRAN-AMT TO ACCT-CURR-CYC-DEBIT
+    END-IF
+
+    -- Step 3: Persist updated account
+    REWRITE ACCOUNT-RECORD to ACCTFILE
+    IF rewrite fails (INVALID KEY)
+        SET validation-fail-reason = 109
+        SET fail-description = 'ACCOUNT RECORD NOT FOUND'
+    END-IF
+
+    -- Step 4: Update transaction category balance
+    PERFORM 2700-UPDATE-TCATBAL
+
+    -- Step 5: Write transaction to posted transaction file
+    PERFORM 2900-WRITE-TRANSACTION-FILE
+```
+
+### Decision Table
+
+| Transaction Amount | Classification | Balance Effect | Cycle Field Updated |
+|-------------------|---------------|---------------|-------------------|
+| Positive (>= 0) | Charge/Purchase | Balance increases | ACCT-CURR-CYC-CREDIT |
+| Negative (< 0) | Payment/Repayment | Balance decreases | ACCT-CURR-CYC-DEBIT |
+
+## Source COBOL Reference
+
+**Program:** `CBTRN02C.cbl`
+**Lines:** 545-560 (balance update), 424-444 (post transaction orchestration)
+
+```cobol
+000545 2800-UPDATE-ACCOUNT-REC.
+000546      * Update the balances in account record to reflect posted trans.
+000547           ADD DALYTRAN-AMT  TO ACCT-CURR-BAL
+000548           IF DALYTRAN-AMT >= 0
+000549              ADD DALYTRAN-AMT TO ACCT-CURR-CYC-CREDIT
+000550           ELSE
+000551              ADD DALYTRAN-AMT TO ACCT-CURR-CYC-DEBIT
+000552           END-IF
+000553
+000554           REWRITE FD-ACCTFILE-REC FROM  ACCOUNT-RECORD
+000555              INVALID KEY
+000556                MOVE 109 TO WS-VALIDATION-FAIL-REASON
+000557                MOVE 'ACCOUNT RECORD NOT FOUND'
+000558                  TO WS-VALIDATION-FAIL-REASON-DESC
+000559           END-REWRITE.
+000560           EXIT.
+```
+*(Lines 545-560 — the core repayment balance update: adds negative transaction amount to running balance and cycle debit field, then rewrites the account record atomically)*
+
+```cobol
+000424 2000-POST-TRANSACTION.
+000425           MOVE  DALYTRAN-ID            TO    TRAN-ID
+000426           MOVE  DALYTRAN-TYPE-CD       TO    TRAN-TYPE-CD
+000427           MOVE  DALYTRAN-CAT-CD        TO    TRAN-CAT-CD
+000428           MOVE  DALYTRAN-SOURCE        TO    TRAN-SOURCE
+000429           MOVE  DALYTRAN-DESC          TO    TRAN-DESC
+000430           MOVE  DALYTRAN-AMT           TO    TRAN-AMT
+             ...
+000440           PERFORM 2700-UPDATE-TCATBAL
+000441           PERFORM 2800-UPDATE-ACCOUNT-REC
+000442           PERFORM 2900-WRITE-TRANSACTION-FILE
+000444           EXIT.
+```
+*(Lines 424-444 — post transaction flow: maps daily transaction fields, updates category balance, updates account, writes to transaction file)*
+
+```cobol
+000467 2700-UPDATE-TCATBAL.
+000468      * Update the balances in transaction balance file.
+000469           MOVE XREF-ACCT-ID TO FD-TRANCAT-ACCT-ID
+000470           MOVE DALYTRAN-TYPE-CD TO FD-TRANCAT-TYPE-CD
+000471           MOVE DALYTRAN-CAT-CD TO FD-TRANCAT-CD
+```
+*(Lines 467-471 — transaction category balance update: tracks balances by account + transaction type + category code)*
+
+## Acceptance Criteria
+
+### Scenario 1: Standard repayment reduces balance
+
+```gherkin
+GIVEN a loan account with:
+  | Current Balance     | 25000.00 |
+  | Current Cycle Credit | 5000.00  |
+  | Current Cycle Debit  | 0.00     |
+WHEN a repayment of -3000.00 is processed
+THEN the current balance is updated to 22000.00 (25000.00 + (-3000.00))
+  AND the cycle debit is updated to -3000.00 (0.00 + (-3000.00))
+  AND the cycle credit remains 5000.00 (unchanged)
+  AND the account record is rewritten to the ACCTFILE
+  AND the repayment transaction is written to the transaction file
+```
+
+### Scenario 2: Overpayment creates negative balance
+
+```gherkin
+GIVEN a loan account with:
+  | Current Balance     | 1000.00 |
+  | Current Cycle Credit | 1000.00 |
+  | Current Cycle Debit  | 0.00    |
+WHEN a repayment of -1500.00 is processed
+THEN the current balance is updated to -500.00 (overpayment)
+  AND the cycle debit is updated to -1500.00
+  AND the negative balance represents a credit to the customer
+```
+
+### Scenario 3: Repayment passes credit limit check
+
+```gherkin
+GIVEN a loan account with:
+  | Credit Limit        | 10000.00 |
+  | Current Cycle Credit | 10000.00 |
+  | Current Cycle Debit  | 0.00     |
+WHEN a repayment of -5000.00 is submitted
+THEN the projected balance is: 10000.00 - 0.00 + (-5000.00) = 5000.00
+  AND 10000.00 >= 5000.00 is TRUE
+  AND the repayment is not rejected by the overlimit check
+  AND the balance is updated to reflect the payment
+```
+
+### Scenario 4: Multiple repayments accumulate in cycle debit
+
+```gherkin
+GIVEN a loan account with:
+  | Current Balance     | 50000.00  |
+  | Current Cycle Debit  | -2000.00  |
+WHEN a repayment of -3000.00 is processed
+THEN the current balance is updated to 47000.00
+  AND the cycle debit is updated to -5000.00 (-2000.00 + (-3000.00))
+```
+
+### Scenario 5: Transaction category balance updated for repayment
+
+```gherkin
+GIVEN a loan account with account ID "12345678901"
+WHEN a repayment with type code "PA" and category code "0001" is processed
+THEN the transaction category balance file is updated for key:
+  | Account ID | 12345678901 |
+  | Type Code  | PA          |
+  | Category   | 0001        |
+  AND the category balance reflects the repayment amount
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 3 | Accurate accounting records — institutions must maintain correct and up-to-date records of all financial transactions | The balance update atomically modifies the account record, and the transaction is written to the posted file for audit trail |
+| PSD2 | Art. 64 | Transaction data integrity — payment service providers must ensure the integrity of payment transactions | The REWRITE operation is atomic; the transaction is classified (credit vs. debit) and tracked in both account and category balance files |
+| PSD2 | Art. 89 | Value dating — the credit value date must be no later than the business day on which the amount is received | Repayments are processed in the daily batch, ensuring the balance is updated on the same business day the payment is received (within batch processing window) |
+| Consumer Credit Directive | Art. 16 | Early repayment — the consumer is entitled to early repayment at any time, with a reduction in the total cost of credit | The system accepts repayments of any amount, including overpayments that exceed the balance, enabling partial and full early repayment |
+
+## Edge Cases
+
+1. **REWRITE failure (code 109)**: If the REWRITE fails with INVALID KEY, the validation fail reason is set to 109 but the program does NOT abend — it continues processing. This means a failed balance update could leave the transaction posted but the account balance unchanged. The migrated system must treat this as a critical error requiring rollback.
+
+2. **Non-atomic multi-file update**: The post transaction performs three sequential file updates (category balance, account balance, transaction file) without a transaction coordinator. A failure between updates could leave files inconsistent. The migrated system should use a database transaction to ensure atomicity.
+
+3. **Cycle debit sign convention**: Cycle debits are stored as negative values (the negative transaction amount is added to the field). This means ACCT-CURR-CYC-DEBIT accumulates negative values. The projected balance formula in the overlimit check subtracts cycle debits, which double-negates back to positive. The migrated system should clarify the sign convention.
+
+4. **Repayment allocation order**: The COBOL system does not implement payment allocation (principal vs. interest vs. fees). All repayments reduce the current balance uniformly. Dedicated repayment allocation logic (e.g., interest first, then principal, per regulation) may exist in programs not yet obtained.
+
+5. **Same-day balance conflict**: If multiple batch transactions update the same account (e.g., a charge and a repayment), the COBOL sequential processing ensures they are applied in order. However, the READ-COMPUTE-REWRITE pattern means each transaction reads the latest balance. The migrated system must handle concurrent access carefully.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. Key questions: (1) Is there a separate repayment allocation program that splits payments into principal, interest, and fees? (2) Does the system support designated repayments (customer specifying which charges to pay)? (3) What happens when a repayment creates a negative balance — is a refund triggered automatically? (4) Is there a minimum payment enforcement mechanism (e.g., minimum monthly payment)? (5) How are returned/bounced payments handled — is there a reversal program?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/lending/lnd-br-006.md
+++ b/docs-site/docs/business-rules/lending/lnd-br-006.md
@@ -1,0 +1,189 @@
+---
+id: "lnd-br-006"
+title: "Collateral management and valuation"
+domain: "lending"
+cobol_source: "Dedicated program not yet in repository"
+requirement_id: "LND-BR-006"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 6"
+  - "FSA FFFS 2014:5 Ch. 8"
+  - "EU Capital Requirements Regulation (CRR) Art. 194-217"
+  - "GDPR Art. 5(1)(e)"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# LND-BR-006: Collateral management and valuation
+
+## Summary
+
+Collateral management encompasses the registration, valuation, monitoring, and release of assets pledged as security for lending facilities. While no dedicated collateral management COBOL program has been obtained from the mainframe, the regulatory requirements under FSA FFFS 2014:5 (Chapter 6 — Credit Risk, Chapter 8 — Assets) and the EU Capital Requirements Regulation mandate that the bank maintain accurate records of all collateral, perform periodic revaluations, and ensure proper loan-to-value (LTV) ratio monitoring.
+
+NordKredit AB's lending portfolio includes secured lending products (mortgages, vehicle financing, business loans) where collateral is a prerequisite for credit approval. The collateral management system must track collateral type, current valuation, valuation date, LTV ratio, and linkage to the secured loan account. This data feeds into the bank's capital adequacy calculations (CRR risk-weighted assets) and is subject to regulatory reporting requirements.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM COLLATERAL-REGISTRATION:
+    -- Step 1: Validate collateral data
+    VALIDATE collateral-type (REAL_ESTATE, VEHICLE, SECURITIES, GUARANTEE, OTHER)
+    VALIDATE collateral-value > 0
+    VALIDATE valuation-date is not future
+    VALIDATE loan-account-id exists in ACCTFILE
+
+    -- Step 2: Calculate loan-to-value ratio
+    COMPUTE LTV-ratio = ACCT-CURR-BAL / collateral-value × 100
+
+    -- Step 3: Check LTV against product limits
+    IF collateral-type = 'REAL_ESTATE'
+        IF LTV-ratio > 85   -- Swedish mortgage cap (Finansinspektionen)
+            REJECT with 'LTV EXCEEDS REGULATORY LIMIT'
+        END-IF
+    ELSE IF collateral-type = 'VEHICLE'
+        IF LTV-ratio > 80
+            FLAG for manual review
+        END-IF
+    END-IF
+
+    -- Step 4: Register collateral record
+    WRITE COLLATERAL-RECORD
+        (collateral-id, loan-acct-id, type, value, valuation-date, LTV)
+
+PERFORM PERIODIC-REVALUATION (batch):
+    FOR EACH active collateral record:
+        IF months-since-last-valuation > revaluation-frequency
+            -- Real estate: revalue annually (FSA requirement)
+            -- Securities: revalue daily (mark-to-market)
+            -- Vehicles: revalue annually (depreciation model)
+            PERFORM REVALUATION using collateral-type, asset-reference
+            UPDATE collateral-value and valuation-date
+            RECOMPUTE LTV-ratio
+            IF LTV-ratio > warning-threshold
+                GENERATE LTV-BREACH-ALERT
+            END-IF
+        END-IF
+    END-FOR
+```
+
+### Decision Table
+
+| Collateral Type | Revaluation Frequency | LTV Limit | Source of Valuation |
+|----------------|----------------------|-----------|-------------------|
+| Real Estate | Annual (FSA FFFS 2014:5) | 85% (Finansinspektionen mortgage cap) | Independent valuation or statistical model |
+| Vehicle | Annual | 80% (institution policy) | Depreciation model or market comparison |
+| Securities | Daily (mark-to-market) | 70% (haircut for volatility) | Market data feed |
+| Guarantee | At issuance + annual review | N/A (binary: valid/expired) | Guarantor creditworthiness assessment |
+
+## Source COBOL Reference
+
+**Program:** Dedicated collateral management program not yet available in repository.
+**Inferred from:** Regulatory requirements and account structure.
+
+The account master record does not contain embedded collateral fields. Collateral data is expected to reside in a separate VSAM file with the loan account ID as a foreign key:
+
+```cobol
+      * Inferred COLLATERAL record structure:
+      * COLLATERAL-ID             PIC X(12)    -- Unique collateral identifier
+      * COLLATERAL-ACCT-ID        PIC 9(11)    -- FK to ACCTFILE
+      * COLLATERAL-TYPE           PIC X(02)    -- RE=Real Estate, VH=Vehicle, SC=Securities, GR=Guarantee
+      * COLLATERAL-VALUE          PIC S9(12)V99 -- Current assessed value (SEK)
+      * COLLATERAL-VALUATION-DATE PIC X(10)    -- Date of last valuation (YYYY-MM-DD)
+      * COLLATERAL-LTV-RATIO      PIC 9(03)V99 -- Loan-to-value percentage
+      * COLLATERAL-DESCRIPTION    PIC X(80)    -- Free-text asset description
+      * COLLATERAL-STATUS         PIC X(01)    -- A=Active, R=Released, E=Expired
+```
+
+The loan account balance used for LTV calculation is the same field used in credit limit enforcement:
+
+```cobol
+000547           ADD DALYTRAN-AMT  TO ACCT-CURR-BAL
+```
+*(Line 547, CBTRN02C.cbl — ACCT-CURR-BAL is the outstanding balance against which LTV is calculated)*
+
+## Acceptance Criteria
+
+### Scenario 1: Register collateral for a new secured loan
+
+```gherkin
+GIVEN a loan account "12345678901" with a current balance of 2000000.00 SEK
+  AND a property valuation of 3000000.00 SEK
+WHEN collateral of type "Real Estate" is registered
+THEN a collateral record is created with:
+  | Linked Account  | 12345678901 |
+  | Type            | REAL_ESTATE |
+  | Value           | 3000000.00  |
+  | LTV Ratio       | 66.67%      |
+  AND the LTV is within the 85% regulatory limit
+```
+
+### Scenario 2: Reject registration when LTV exceeds regulatory limit
+
+```gherkin
+GIVEN a loan account with current balance of 900000.00 SEK
+  AND a property valuation of 1000000.00 SEK
+WHEN collateral registration is attempted
+THEN the LTV ratio is calculated as 90.00%
+  AND the registration is rejected with "LTV EXCEEDS REGULATORY LIMIT"
+  AND the rejection is logged for regulatory audit
+```
+
+### Scenario 3: Periodic revaluation triggers LTV breach alert
+
+```gherkin
+GIVEN an active collateral record with:
+  | Collateral Value | 3000000.00 |
+  | Loan Balance     | 2400000.00 |
+  | LTV Ratio        | 80.00%     |
+WHEN the annual revaluation determines the property value is now 2700000.00
+THEN the collateral value is updated to 2700000.00
+  AND the LTV ratio is recalculated as 88.89%
+  AND an LTV breach alert is generated (exceeds 85% threshold)
+  AND the loan officer is notified for remediation action
+```
+
+### Scenario 4: Collateral release upon loan payoff
+
+```gherkin
+GIVEN a loan account with current balance of 0.00
+  AND an active collateral record linked to the account
+WHEN a collateral release request is processed
+THEN the collateral status is changed to "Released"
+  AND the release date is recorded
+  AND the collateral is no longer counted in regulatory capital calculations
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 6 | Credit risk management — collateral must be properly valued and monitored | Periodic revaluation ensures collateral values are current; LTV monitoring detects deterioration |
+| FSA FFFS 2014:5 | Ch. 8 | Assets — institutions must maintain accurate records of all assets, including collateral | Collateral records maintain type, value, valuation date, and linkage to the secured loan account |
+| CRR | Art. 194-217 | Credit risk mitigation — conditions for using collateral to reduce risk-weighted assets | Collateral registration and valuation provides the data needed for CRR risk-weight calculations |
+| GDPR | Art. 5(1)(e) | Storage limitation — data kept no longer than necessary | Collateral records for released loans should be retained only for the regulatory retention period (10 years for Swedish financial records) then purged |
+
+## Edge Cases
+
+1. **Multiple collateral per loan**: A single loan may be secured by multiple collateral items (e.g., property + guarantee). The LTV calculation should use the aggregate collateral value against the loan balance. The collateral data model must support one-to-many relationship.
+
+2. **Cross-collateralization**: A single collateral asset may secure multiple loans. The available collateral value for LTV calculation must account for all loans against the same asset. The migrated system needs a many-to-many relationship model.
+
+3. **Currency mismatch**: If collateral is denominated in a currency different from the loan (e.g., EUR property securing a SEK loan), the LTV calculation must use the current exchange rate. This introduces FX risk in the LTV monitoring.
+
+4. **Valuation disputes**: Independent valuations may differ from the bank's internal model. The system should support multiple valuation records per collateral with a designated "official" valuation for LTV purposes.
+
+5. **Collateral depreciation**: Vehicle and equipment collateral depreciates over time. The revaluation mechanism should apply appropriate depreciation models between formal revaluations.
+
+6. **Finansinspektionen mortgage cap**: Swedish regulations impose an 85% LTV cap for residential mortgages. Existing loans that exceed this threshold due to property value decline are subject to amortization requirements, not forced liquidation. The system must distinguish between new origination limits and existing portfolio monitoring.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. CRITICAL: Collateral management COBOL programs must be obtained from the mainframe team. Key questions: (1) What is the VSAM file structure for collateral records? (2) Is there a collateral valuation batch job — what is its frequency and methodology? (3) How is cross-collateralization tracked? (4) What is the LTV monitoring frequency for different collateral types? (5) Are there automated escalation procedures when LTV thresholds are breached? (6) How is the Finansinspektionen mortgage cap enforced in the origination process?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/lending/lnd-br-007.md
+++ b/docs-site/docs/business-rules/lending/lnd-br-007.md
@@ -1,0 +1,190 @@
+---
+id: "lnd-br-007"
+title: "Loan disbursement and fund transfer"
+domain: "lending"
+cobol_source: "Dedicated program not yet in repository (inferred from CBTRN02C.cbl transaction posting pattern)"
+requirement_id: "LND-BR-007"
+regulations:
+  - "PSD2 Art. 83"
+  - "PSD2 Art. 89"
+  - "FSA FFFS 2014:5 Ch. 3"
+  - "AML 2017:11"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# LND-BR-007: Loan disbursement and fund transfer
+
+## Summary
+
+Loan disbursement is the process of transferring approved loan funds to the borrower's account. After successful origination (LND-BR-003) and collateral registration (LND-BR-006 for secured loans), the approved credit amount is made available through either a lump-sum disbursement (term loans) or credit line activation (revolving credit). While no dedicated disbursement COBOL program has been obtained from the mainframe, the transaction posting pattern in CBTRN02C.cbl shows how funds flow through the system.
+
+For term loans, disbursement creates a positive transaction that increases the account balance to the approved amount. For revolving credit (the primary model visible in the COBOL source), activation sets the credit limit and the borrower draws funds through individual transactions that are validated against the limit (LND-BR-002). Under PSD2, fund transfers must be executed within the agreed timeframe, and under AML regulations, disbursements above threshold amounts require enhanced due diligence.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM LOAN-DISBURSEMENT:
+    -- Step 1: Validate disbursement prerequisites
+    READ ACCOUNT-RECORD using loan-acct-id
+    IF ACCT-ACTIVE-STATUS NOT = 'Y'
+        REJECT with 'ACCOUNT NOT ACTIVE'
+        EXIT
+    END-IF
+    IF disbursement-amount > ACCT-CREDIT-LIMIT
+        REJECT with 'DISBURSEMENT EXCEEDS CREDIT LIMIT'
+        EXIT
+    END-IF
+
+    -- Step 2: AML check for large disbursements
+    IF disbursement-amount >= 150000.00  (SEK threshold)
+        PERFORM ENHANCED-DUE-DILIGENCE
+        IF EDD-check fails
+            REJECT with 'AML/EDD CHECK FAILED'
+            EXIT
+        END-IF
+    END-IF
+
+    -- Step 3: For term loan — full disbursement
+    IF loan-type = 'TERM'
+        MOVE disbursement-amount TO DALYTRAN-AMT
+        SET DALYTRAN-TYPE-CD = 'DB'  (disbursement)
+        PERFORM 2000-POST-TRANSACTION
+        -- Balance increases by disbursement amount
+
+    -- Step 4: For revolving credit — activate credit line
+    ELSE IF loan-type = 'REVOLVING'
+        -- No balance change at activation
+        -- Borrower draws funds through future transactions
+        -- Credit limit already set during origination
+        SET disbursement-status = 'CREDIT LINE ACTIVE'
+    END-IF
+
+    -- Step 5: Generate disbursement confirmation
+    WRITE DISBURSEMENT-CONFIRMATION-RECORD
+    -- Trigger fund transfer via Bankgirot/SWIFT if external account
+```
+
+### Decision Table
+
+| Loan Type | Account Active | Within Limit | AML Passed | Outcome |
+|-----------|---------------|-------------|-----------|---------|
+| Term | No | N/A | N/A | Rejected (account inactive) |
+| Term | Yes | No | N/A | Rejected (exceeds limit) |
+| Term | Yes | Yes | No | Rejected (AML failure) |
+| Term | Yes | Yes | Yes | Funds disbursed, balance updated |
+| Revolving | No | N/A | N/A | Rejected (account inactive) |
+| Revolving | Yes | N/A | N/A | Credit line activated |
+
+## Source COBOL Reference
+
+**Program:** Dedicated disbursement program not yet available in repository.
+**Inferred from:** `CBTRN02C.cbl` (transaction posting pattern for balance updates)
+
+The disbursement would follow the same posting pattern as regular transactions:
+
+```cobol
+000424 2000-POST-TRANSACTION.
+000425           MOVE  DALYTRAN-ID            TO    TRAN-ID
+000426           MOVE  DALYTRAN-TYPE-CD       TO    TRAN-TYPE-CD
+000427           MOVE  DALYTRAN-CAT-CD        TO    TRAN-CAT-CD
+000428           MOVE  DALYTRAN-SOURCE        TO    TRAN-SOURCE
+000429           MOVE  DALYTRAN-DESC          TO    TRAN-DESC
+000430           MOVE  DALYTRAN-AMT           TO    TRAN-AMT
+             ...
+000440           PERFORM 2700-UPDATE-TCATBAL
+000441           PERFORM 2800-UPDATE-ACCOUNT-REC
+000442           PERFORM 2900-WRITE-TRANSACTION-FILE
+```
+*(Lines 424-442, CBTRN02C.cbl — standard transaction posting: a disbursement would use this same flow with a positive amount and disbursement type code)*
+
+```cobol
+000547           ADD DALYTRAN-AMT  TO ACCT-CURR-BAL
+000548           IF DALYTRAN-AMT >= 0
+000549              ADD DALYTRAN-AMT TO ACCT-CURR-CYC-CREDIT
+```
+*(Lines 547-549, CBTRN02C.cbl — a disbursement (positive amount) increases the current balance and accumulates in cycle credit)*
+
+## Acceptance Criteria
+
+### Scenario 1: Term loan full disbursement
+
+```gherkin
+GIVEN a newly originated term loan account with:
+  | Account ID    | 12345678901 |
+  | Active Status | Y           |
+  | Credit Limit  | 500000.00   |
+  | Balance       | 0.00        |
+WHEN a disbursement of 500000.00 is processed
+THEN the account balance is updated to 500000.00
+  AND the cycle credit is updated to 500000.00
+  AND a disbursement transaction is recorded in the transaction file
+  AND a disbursement confirmation is generated
+```
+
+### Scenario 2: Revolving credit line activation
+
+```gherkin
+GIVEN a newly originated revolving credit account with:
+  | Account ID    | 98765432100 |
+  | Active Status | Y           |
+  | Credit Limit  | 100000.00   |
+  | Balance       | 0.00        |
+WHEN the credit line is activated
+THEN the balance remains 0.00 (no immediate disbursement)
+  AND the credit limit of 100000.00 is available for drawdown
+  AND the account status confirms credit line is active
+```
+
+### Scenario 3: Disbursement rejected for inactive account
+
+```gherkin
+GIVEN a loan account with Active Status = 'N'
+WHEN a disbursement is attempted
+THEN the disbursement is rejected with reason "ACCOUNT NOT ACTIVE"
+  AND no balance change occurs
+```
+
+### Scenario 4: Large disbursement triggers enhanced due diligence
+
+```gherkin
+GIVEN a term loan account approved for 200000.00 SEK
+WHEN the disbursement is processed
+THEN enhanced due diligence is performed (amount >= 150000.00 SEK threshold)
+  AND the disbursement proceeds only if EDD check passes
+  AND the EDD check result is recorded for AML audit trail
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| PSD2 | Art. 83 | Execution time for payment transactions — funds must be available within agreed timeframe | Disbursement processing ensures funds are credited to the borrower's account within the batch processing cycle (same business day) |
+| PSD2 | Art. 89 | Value dating — credit value date must be no later than the business day on which the amount is received | The batch posting mechanism credits the disbursement on the processing date |
+| FSA FFFS 2014:5 | Ch. 3 | Accounting records — all financial transactions must be accurately recorded | The disbursement is posted as a transaction with full audit trail (transaction ID, type, amount, timestamp) |
+| AML 2017:11 | §4 | Enhanced due diligence for transactions above thresholds | Disbursements above the SEK threshold trigger enhanced due diligence checks before fund release |
+
+## Edge Cases
+
+1. **Partial disbursement**: Some term loans may support phased disbursement (e.g., construction loans where funds are released in stages). The system must track cumulative disbursements against the approved amount.
+
+2. **External account disbursement**: If funds are disbursed to an external bank account (not held at NordKredit), the transfer flows through Bankgirot (domestic) or SWIFT (international). These external transfers have different settlement times and fee structures.
+
+3. **Disbursement reversal**: If a disbursement needs to be reversed (e.g., origination fraud discovered), the system must support a reversal transaction. The COBOL system's sequential processing means reversals would be a separate negative transaction.
+
+4. **Concurrent disbursement prevention**: For term loans, only one full disbursement should be allowed. A guard must prevent duplicate disbursements to the same account. The COBOL system may use a disbursement flag in the account record.
+
+5. **Weekend/holiday disbursement**: Batch processing runs daily but banking settlement only occurs on business days. A Friday disbursement may not settle until Monday. The value date must reflect the actual settlement date per PSD2 requirements.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. CRITICAL: The disbursement COBOL program must be obtained from the mainframe team. Key questions: (1) What is the program name for loan disbursement? (2) Is there a distinction between term loan disbursement and revolving credit activation? (3) What type codes are used for disbursement transactions? (4) How are external transfers (Bankgirot/SWIFT) triggered from the disbursement program? (5) Is there a multi-stage disbursement mechanism for construction or project loans?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/lending/lnd-br-008.md
+++ b/docs-site/docs/business-rules/lending/lnd-br-008.md
@@ -1,0 +1,216 @@
+---
+id: "lnd-br-008"
+title: "Delinquency management and collections"
+domain: "lending"
+cobol_source: "Dedicated program not yet in repository"
+requirement_id: "LND-BR-008"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 6"
+  - "EU Consumer Credit Directive 2008/48/EC Art. 14"
+  - "GDPR Art. 5(1)(a)"
+  - "Swedish Debt Recovery Act (Inkassolagen 1974:182)"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# LND-BR-008: Delinquency management and collections
+
+## Summary
+
+Delinquency management tracks overdue loan payments and initiates the collections process when borrowers fail to meet their repayment obligations. While no dedicated collections COBOL program has been obtained from the mainframe, the regulatory framework and account structure reveal the required business logic. The system must detect missed payments, classify accounts into delinquency stages (30/60/90+ days past due), calculate late fees, send dunning notices, and escalate to external collections or legal action when necessary.
+
+Under FSA FFFS 2014:5 Chapter 6, credit institutions must have robust processes for managing non-performing exposures. The Swedish Debt Recovery Act (Inkassolagen) regulates the collections process, including requirements for written notices, cooling-off periods, and consumer protection. GDPR Art. 5(1)(a) requires that all processing (including collections communications) is lawful, fair, and transparent.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM DELINQUENCY-DETECTION (nightly batch):
+    FOR EACH active account with ACCT-CURR-BAL > 0:
+        -- Step 1: Check if minimum payment is due
+        IF current-date > payment-due-date
+           AND minimum-payment-not-received
+            SET days-past-due = current-date - payment-due-date
+
+            -- Step 2: Classify delinquency stage
+            EVALUATE TRUE
+                WHEN days-past-due >= 1 AND < 30
+                    SET delinquency-stage = 'EARLY'
+                    -- Send payment reminder
+                WHEN days-past-due >= 30 AND < 60
+                    SET delinquency-stage = 'STAGE-1'
+                    -- First formal dunning notice
+                    PERFORM CALCULATE-LATE-FEE
+                WHEN days-past-due >= 60 AND < 90
+                    SET delinquency-stage = 'STAGE-2'
+                    -- Second dunning notice with escalation warning
+                    PERFORM CALCULATE-LATE-FEE
+                WHEN days-past-due >= 90
+                    SET delinquency-stage = 'STAGE-3'
+                    -- Account flagged for collections/write-off review
+                    PERFORM CALCULATE-LATE-FEE
+                    IF days-past-due >= 90
+                        SET account-classification = 'NON-PERFORMING'
+                    END-IF
+            END-EVALUATE
+
+            -- Step 3: Apply late fee (if applicable)
+            IF late-fee > 0
+                ADD late-fee TO ACCT-CURR-BAL
+                WRITE late-fee transaction
+            END-IF
+
+            -- Step 4: Update delinquency record
+            WRITE DELINQUENCY-RECORD
+                (acct-id, days-past-due, stage, late-fee, action-taken)
+        END-IF
+    END-FOR
+
+PERFORM COLLECTIONS-ESCALATION:
+    FOR EACH account in STAGE-3 (90+ days):
+        IF not already referred to external collections
+            -- Inkassolagen requirements:
+            -- 1. Send written demand (kravbrev) with 8-day response period
+            -- 2. Include total amount owed, breakdown, and payment instructions
+            -- 3. Inform of right to dispute
+            GENERATE KRAVBREV (demand letter)
+            SET escalation-date = current-date
+            SET response-deadline = current-date + 8 days
+        END-IF
+        IF response-deadline has passed AND no payment received
+            REFER to external collections agency
+            SET account-status = 'COLLECTIONS'
+        END-IF
+    END-FOR
+```
+
+### Decision Table
+
+| Days Past Due | Stage | Action | Late Fee | Regulatory Notice |
+|---------------|-------|--------|----------|-------------------|
+| 1-29 | Early | Payment reminder (SMS/email) | No | No |
+| 30-59 | Stage 1 | First dunning notice (letter) | Yes | Inkassolagen §5 |
+| 60-89 | Stage 2 | Second dunning + escalation warning | Yes | Inkassolagen §5 |
+| 90+ | Stage 3 | Collections referral / write-off review | Yes | Inkassolagen §8, FSA NPE |
+| 365+ | Write-off | Recommend write-off to credit committee | Final | FSA FFFS 2014:5 Ch. 6 |
+
+## Source COBOL Reference
+
+**Program:** Dedicated delinquency management and collections program not yet available in repository.
+**Inferred from:** Account structure and regulatory requirements.
+
+The account balance field used for delinquency assessment:
+
+```cobol
+000547           ADD DALYTRAN-AMT  TO ACCT-CURR-BAL
+```
+*(Line 547, CBTRN02C.cbl — ACCT-CURR-BAL represents the outstanding amount that must be repaid; delinquency is assessed when scheduled payments are not received to reduce this balance)*
+
+The account status field used for delinquency flagging:
+
+```cobol
+      * ACCT-ACTIVE-STATUS        PIC X(01)    -- 'Y' = active, 'N' = inactive
+```
+*(Reconstructed from CVACT01Y.cpy — the active status field may need extension to support delinquency states in the migrated system)*
+
+The reject processing pattern shows how the system handles exceptions:
+
+```cobol
+000214                       ADD 1 TO WS-REJECT-COUNT
+000215                       PERFORM 2500-WRITE-REJECT-REC
+```
+*(Lines 214-215, CBTRN02C.cbl — the reject pattern for failed validations could be analogous to how delinquent accounts are flagged and tracked)*
+
+## Acceptance Criteria
+
+### Scenario 1: Early delinquency detection (1-29 days)
+
+```gherkin
+GIVEN a loan account with a minimum payment due on 2026-01-15
+  AND no payment has been received
+WHEN the delinquency detection batch runs on 2026-01-25
+THEN the account is classified as "EARLY" delinquency (10 days past due)
+  AND a payment reminder is generated
+  AND no late fee is applied
+```
+
+### Scenario 2: Stage 1 delinquency with late fee (30-59 days)
+
+```gherkin
+GIVEN a loan account with a minimum payment due on 2026-01-15
+  AND no payment has been received
+WHEN the delinquency detection batch runs on 2026-02-15
+THEN the account is classified as "STAGE-1" delinquency (31 days past due)
+  AND a formal dunning notice is generated per Inkassolagen §5
+  AND a late fee is calculated and added to the balance
+```
+
+### Scenario 3: Non-performing loan classification (90+ days)
+
+```gherkin
+GIVEN a loan account with a minimum payment due on 2025-10-15
+  AND no payment has been received
+WHEN the delinquency detection batch runs on 2026-01-15
+THEN the account is classified as "STAGE-3" delinquency (92 days past due)
+  AND the account is flagged as "NON-PERFORMING" per FSA guidelines
+  AND the account is queued for collections escalation
+```
+
+### Scenario 4: Collections demand letter (Kravbrev)
+
+```gherkin
+GIVEN an account in Stage 3 delinquency
+  AND not previously referred to external collections
+WHEN the collections escalation process runs
+THEN a written demand letter (kravbrev) is generated containing:
+  | Total Amount Owed      | (balance + accrued interest + fees) |
+  | Payment Deadline       | 8 days from letter date             |
+  | Dispute Instructions   | Contact details for disputes        |
+  AND the response deadline is tracked
+```
+
+### Scenario 5: Partial payment reduces delinquency
+
+```gherkin
+GIVEN a loan account classified as "STAGE-1" (35 days past due)
+  AND the minimum payment due is 5000.00 SEK
+WHEN a partial payment of 3000.00 SEK is received
+THEN the balance is reduced by 3000.00
+  AND the delinquency classification is reassessed
+  AND if minimum payment threshold is now met, the account returns to current status
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 6 | Non-performing exposure management — institutions must identify, measure, and manage non-performing loans | The delinquency staging system classifies accounts by days past due and triggers appropriate management actions at each stage |
+| Consumer Credit Directive | Art. 14 | Right of withdrawal — consumer has 14 days to withdraw from credit agreement | Delinquency detection must not classify an account as delinquent within the withdrawal period of a new loan |
+| Swedish Inkassolagen | §5, §8 | Debt recovery requirements — written notice with specified content, response period, and consumer rights | The kravbrev generation includes all legally required elements (amount, deadline, dispute rights) |
+| GDPR | Art. 5(1)(a) | Lawfulness, fairness, and transparency — processing must be transparent to the data subject | Dunning notices clearly explain the amount owed, basis for the claim, and the borrower's rights |
+
+## Edge Cases
+
+1. **Grace period handling**: Some loan products include a grace period (e.g., 3-5 days after due date) before delinquency is triggered. The system must support product-specific grace periods.
+
+2. **Multiple missed payments**: If a borrower misses multiple consecutive payments, the delinquency should track cumulative missed amount, not just the most recent missed payment. The days-past-due calculation should reference the first missed payment date.
+
+3. **Partial payment ambiguity**: When a partial payment is received, the system must decide whether to apply it to the oldest due amount first (FIFO) or to the most recent. Swedish convention typically applies to the oldest debt first.
+
+4. **Restructured loans**: If a delinquent loan is restructured (new terms agreed), the delinquency counter should be reset. However, FSA requires that restructured loans remain flagged as "forborne" for regulatory reporting.
+
+5. **Bankruptcy notification**: When a borrower files for personal bankruptcy (skuldsanering), collections activity must cease immediately per Swedish law. The system must support a "bankruptcy hold" status.
+
+6. **Joint account delinquency**: For joint liability loans, delinquency notices must be sent to all liable parties. GDPR requires careful handling of personal data when communicating with multiple borrowers.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. CRITICAL: The delinquency management and collections COBOL programs must be obtained from the mainframe team. Key questions: (1) What is the batch job name for delinquency detection? (2) What are the configured late fee amounts and calculation methods? (3) Is there a minimum payment calculation program? (4) How are grace periods configured per product? (5) What external collections agencies are used and how are referrals transmitted (file transfer, API)? (6) Is there a write-off committee approval workflow in the COBOL system?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/lending/lnd-br-009.md
+++ b/docs-site/docs/business-rules/lending/lnd-br-009.md
@@ -1,0 +1,167 @@
+---
+id: "lnd-br-009"
+title: "Account expiration enforcement for lending"
+domain: "lending"
+cobol_source: "CBTRN02C.cbl:414-420"
+requirement_id: "LND-BR-009"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 6"
+  - "EU Consumer Credit Directive 2008/48/EC Art. 10"
+  - "PSD2 Art. 64"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "high"
+---
+
+# LND-BR-009: Account expiration enforcement for lending
+
+## Summary
+
+The account expiration enforcement rule prevents transactions from being posted to accounts that have passed their expiration (maturity) date. In the COBOL system, this check is performed during daily batch transaction posting (CBTRN02C) by comparing the account's expiration date field (`ACCT-EXPIRAION-DATE`) against the transaction's origination timestamp. If the transaction date is after the account expiration date, the transaction is rejected with validation failure code 103 ("TRANSACTION RECEIVED AFTER ACCT EXPIRATION").
+
+In the lending context, the expiration date represents the loan maturity date — the final date by which the loan must be fully repaid. After maturity, no new drawdowns should be permitted on the credit facility. The check uses a string comparison of dates in YYYY-MM-DD format, which provides correct ordering for date values in this format. Note: the COBOL field contains the historical typo "EXPIRAION" (missing 'T') which is preserved across all programs.
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM EXPIRATION-CHECK (within 1500-B-LOOKUP-ACCT):
+    -- Account record has been read successfully
+    -- Credit limit check has already been performed
+
+    -- Compare account expiration date against transaction date
+    IF ACCT-EXPIRAION-DATE >= DALYTRAN-ORIG-TS (1:10)
+        -- Account has not expired relative to the transaction date
+        CONTINUE (transaction passes expiration check)
+    ELSE
+        -- Transaction date is after account expiration
+        SET validation-fail-reason = 103
+        SET fail-description = 'TRANSACTION RECEIVED AFTER ACCT EXPIRATION'
+    END-IF
+
+    -- NOTE: String comparison works because both dates are in YYYY-MM-DD format
+    -- DALYTRAN-ORIG-TS (1:10) extracts the first 10 characters (date portion)
+    -- from the full timestamp field
+```
+
+### Decision Table
+
+| Account Expiration Date | Transaction Date | Comparison Result | Outcome |
+|------------------------|-----------------|-------------------|---------|
+| 2027-12-31 | 2026-06-15 | 2027-12-31 >= 2026-06-15 = TRUE | Transaction accepted |
+| 2026-06-30 | 2026-06-30 | 2026-06-30 >= 2026-06-30 = TRUE | Transaction accepted (boundary: same day) |
+| 2026-05-31 | 2026-06-01 | 2026-05-31 >= 2026-06-01 = FALSE | Transaction rejected (code 103) |
+
+## Source COBOL Reference
+
+**Program:** `CBTRN02C.cbl`
+**Lines:** 414-420 (expiration check)
+
+```cobol
+000414               IF ACCT-EXPIRAION-DATE >= DALYTRAN-ORIG-TS (1:10)
+000415                  CONTINUE
+000416                ELSE
+000417                  MOVE 103 TO WS-VALIDATION-FAIL-REASON
+000418                  MOVE 'TRANSACTION RECEIVED AFTER ACCT EXPIRATION'
+000419                    TO WS-VALIDATION-FAIL-REASON-DESC
+000420                END-IF
+```
+*(Lines 414-420, CBTRN02C.cbl — the account expiration enforcement: compares the 10-character date portion of the account expiration against the 10-character date portion of the transaction origination timestamp)*
+
+**Context — this check follows the credit limit check:**
+
+```cobol
+000407                IF ACCT-CREDIT-LIMIT >= WS-TEMP-BAL
+000408                  CONTINUE
+000409                ELSE
+000410                  MOVE 102 TO WS-VALIDATION-FAIL-REASON
+000411                  MOVE 'OVERLIMIT TRANSACTION'
+000412                    TO WS-VALIDATION-FAIL-REASON-DESC
+000413                END-IF
+000414                IF ACCT-EXPIRAION-DATE >= DALYTRAN-ORIG-TS (1:10)
+```
+*(Lines 407-414 — the expiration check runs sequentially after the credit limit check, both within the 1500-B-LOOKUP-ACCT paragraph)*
+
+## Acceptance Criteria
+
+### Scenario 1: Transaction before maturity date is accepted
+
+```gherkin
+GIVEN a loan account with expiration date "2028-12-31"
+WHEN a transaction with origination date "2026-06-15" is submitted
+THEN the expiration check passes ("2028-12-31" >= "2026-06-15")
+  AND the transaction proceeds to posting
+```
+
+### Scenario 2: Transaction on maturity date is accepted
+
+```gherkin
+GIVEN a loan account with expiration date "2026-06-30"
+WHEN a transaction with origination date "2026-06-30" is submitted
+THEN the expiration check passes ("2026-06-30" >= "2026-06-30" — boundary case)
+  AND the transaction proceeds to posting
+```
+
+### Scenario 3: Transaction after maturity date is rejected
+
+```gherkin
+GIVEN a loan account with expiration date "2026-05-31"
+WHEN a transaction with origination date "2026-06-01" is submitted
+THEN the expiration check fails ("2026-05-31" >= "2026-06-01" is FALSE)
+  AND the transaction is rejected with code 103
+  AND the rejection reason is "TRANSACTION RECEIVED AFTER ACCT EXPIRATION"
+  AND the transaction is written to the daily rejects file
+```
+
+### Scenario 4: Repayment after maturity is still rejected
+
+```gherkin
+GIVEN a loan account with expiration date "2026-05-31"
+  AND the account has an outstanding balance of 10000.00
+WHEN a repayment of -5000.00 with origination date "2026-06-15" is submitted
+THEN the expiration check fails (the check does not distinguish charges from repayments)
+  AND the repayment is rejected with code 103
+```
+
+### Scenario 5: Overlimit AND expired both trigger rejection
+
+```gherkin
+GIVEN a loan account that is both overlimit and expired
+WHEN a transaction is submitted
+THEN the overlimit check sets code 102
+  AND the expiration check overwrites with code 103
+  AND the final rejection code is 103 (last check wins)
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 6 | Credit risk management — credit facilities must not be extended beyond their authorized term | The expiration check prevents new credit utilization after the loan maturity date |
+| Consumer Credit Directive | Art. 10(2)(h) | Credit agreement must specify duration of the credit agreement | The expiration date field enforces the agreed duration by blocking transactions after the end date |
+| PSD2 | Art. 64 | Transaction data integrity — only authorized transactions should be executed | Transactions on expired accounts are unauthorized and are correctly rejected with an audit trail |
+
+## Edge Cases
+
+1. **Repayment rejection after maturity**: The COBOL code rejects ALL transactions after expiration, including repayments. This is a potential issue — borrowers should be able to make repayments after maturity to settle outstanding balances. The migrated system should allow repayments (negative amounts) on expired accounts while blocking new drawdowns.
+
+2. **Validation order dependency**: The expiration check (code 103) runs after the credit limit check (code 102). If both fail, only code 103 is recorded because it overwrites code 102. The migrated system should collect all validation failures rather than overwriting.
+
+3. **Date format dependency**: The string comparison works correctly only because both dates use YYYY-MM-DD format. If either date used a different format (e.g., DD-MM-YYYY), the comparison would produce incorrect results. The migrated system should use proper date types instead of string comparison.
+
+4. **Timestamp truncation**: `DALYTRAN-ORIG-TS (1:10)` extracts only the date portion from the transaction's full timestamp. This means the check is date-level, not timestamp-level. A transaction at 23:59:59 on the expiration date passes, but a transaction at 00:00:01 the next day fails.
+
+5. **Maturity date extension**: If a loan is renewed or extended, the ACCT-EXPIRAION-DATE must be updated. The mechanism for updating this field (and whether it requires re-origination or a simple field update) is not visible in the available COBOL source.
+
+6. **Timezone considerations**: The COBOL system runs on z/OS in the bank's local timezone (CET/CEST for Sweden). The migrated Azure system must ensure timezone-consistent date comparisons to avoid rejecting transactions that should pass (or vice versa) near midnight.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. Key questions: (1) Is it intentional that repayments are rejected after account expiration, or is this a defect that should be corrected in the migrated system? (2) What is the process for extending/renewing a loan maturity date? (3) Are there different expiration behaviors for revolving credit (which may auto-renew) vs. term loans (which mature)? (4) Is there a grace period after expiration before the account is fully blocked?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17

--- a/docs-site/docs/business-rules/lending/lnd-br-010.md
+++ b/docs-site/docs/business-rules/lending/lnd-br-010.md
@@ -1,0 +1,210 @@
+---
+id: "lnd-br-010"
+title: "Lending transaction categorization and balance tracking"
+domain: "lending"
+cobol_source: "CBTRN02C.cbl:467-542"
+requirement_id: "LND-BR-010"
+regulations:
+  - "FSA FFFS 2014:5 Ch. 3"
+  - "FSA FFFS 2014:5 Ch. 7"
+  - "PSD2 Art. 64"
+  - "DORA Art. 11"
+status: "extracted"
+validated_by: null
+validated_date: null
+priority: "medium"
+---
+
+# LND-BR-010: Lending transaction categorization and balance tracking
+
+## Summary
+
+The transaction categorization system maintains running balances per account, transaction type, and transaction category. This triple-key structure (`ACCT-ID + TRAN-TYPE-CD + TRAN-CAT-CD`) enables granular tracking of lending activity — distinguishing between purchases, cash advances, balance transfers, fees, interest charges, and repayments. During daily batch posting (CBTRN02C), each posted transaction updates the corresponding category balance record in the TCATBAL file. If no record exists for the key combination, a new record is created; otherwise, the existing balance is updated.
+
+This categorization supports FSA regulatory reporting requirements (FFFS 2014:5 Chapter 7 — Financial Systems) by enabling breakdown of lending portfolio activity by type and category. It also supports credit risk analysis by revealing utilization patterns per account (e.g., proportion of cash advances vs. purchases, which may indicate different risk profiles).
+
+## Business Logic
+
+### Pseudocode
+
+```
+PERFORM UPDATE-TRANSACTION-CATEGORY-BALANCE:
+    -- Build composite key
+    MOVE account-id TO TRANCAT-ACCT-ID
+    MOVE transaction-type-code TO TRANCAT-TYPE-CD
+    MOVE transaction-category-code TO TRANCAT-CD
+
+    -- Attempt to read existing record
+    READ TCATBAL-FILE using composite key
+    IF record found (status = '00')
+        -- Update existing balance
+        ADD transaction-amount TO TRAN-CAT-BAL
+        REWRITE TCATBAL record
+    ELSE IF record not found (status = '23')
+        -- Create new category balance record
+        INITIALIZE TRAN-CAT-BAL-RECORD
+        MOVE account-id TO TRANCAT-ACCT-ID
+        MOVE transaction-type-code TO TRANCAT-TYPE-CD
+        MOVE transaction-category-code TO TRANCAT-CD
+        MOVE transaction-amount TO TRAN-CAT-BAL
+        WRITE new TCATBAL record
+    ELSE
+        -- Unexpected file error
+        ABEND with error
+    END-IF
+```
+
+### Decision Table
+
+| Record Exists | File Status | Action | Outcome |
+|--------------|-------------|--------|---------|
+| Yes | '00' | ADD amount, REWRITE | Balance updated |
+| No | '23' | INITIALIZE, WRITE | New record created |
+| Error | Other | ABEND | Processing halted |
+
+## Source COBOL Reference
+
+**Program:** `CBTRN02C.cbl`
+**Lines:** 467-542 (category balance update)
+
+```cobol
+000467 2700-UPDATE-TCATBAL.
+000468      * Update the balances in transaction balance file.
+000469           MOVE XREF-ACCT-ID TO FD-TRANCAT-ACCT-ID
+000470           MOVE DALYTRAN-TYPE-CD TO FD-TRANCAT-TYPE-CD
+000471           MOVE DALYTRAN-CAT-CD TO FD-TRANCAT-CD
+000472
+000473           MOVE 'N' TO WS-CREATE-TRANCAT-REC
+000474           READ TCATBAL-FILE INTO TRAN-CAT-BAL-RECORD
+000475              INVALID KEY
+000476                DISPLAY 'TCATBAL record not found for key : '
+000477                   FD-TRAN-CAT-KEY '.. Creating.'
+000478                MOVE 'Y' TO WS-CREATE-TRANCAT-REC
+000479           END-READ.
+```
+*(Lines 467-479 — composite key construction and record lookup: attempts to read existing category balance, flags for creation if not found)*
+
+```cobol
+000495           IF WS-CREATE-TRANCAT-REC = 'Y'
+000496              PERFORM 2700-A-CREATE-TCATBAL-REC
+000497           ELSE
+000498              PERFORM 2700-B-UPDATE-TCATBAL-REC
+000499           END-IF
+```
+*(Lines 495-499 — branching logic: creates new record or updates existing based on lookup result)*
+
+```cobol
+000503 2700-A-CREATE-TCATBAL-REC.
+000504           INITIALIZE TRAN-CAT-BAL-RECORD
+000505           MOVE XREF-ACCT-ID TO TRANCAT-ACCT-ID
+000506           MOVE DALYTRAN-TYPE-CD TO TRANCAT-TYPE-CD
+000507           MOVE DALYTRAN-CAT-CD TO TRANCAT-CD
+000508           ADD DALYTRAN-AMT TO TRAN-CAT-BAL
+000509
+000510           WRITE FD-TRAN-CAT-BAL-RECORD FROM TRAN-CAT-BAL-RECORD
+```
+*(Lines 503-510 — new record creation: initializes record, sets key fields, adds transaction amount as initial balance)*
+
+```cobol
+000526 2700-B-UPDATE-TCATBAL-REC.
+000527           ADD DALYTRAN-AMT TO TRAN-CAT-BAL
+000528           REWRITE FD-TRAN-CAT-BAL-RECORD FROM TRAN-CAT-BAL-RECORD
+```
+*(Lines 526-528 — existing record update: adds transaction amount to running balance and rewrites)*
+
+**Transaction category balance file structure:**
+
+```cobol
+000057       FD  TCATBAL-FILE.
+000092       01  FD-TRAN-CAT-BAL-RECORD.
+000093           05 FD-TRAN-CAT-KEY.
+000094              10 FD-TRANCAT-ACCT-ID             PIC 9(11).
+000095              10 FD-TRANCAT-TYPE-CD             PIC X(02).
+000096              10 FD-TRANCAT-CD                  PIC 9(04).
+000097           05 FD-FD-TRAN-CAT-DATA               PIC X(33).
+```
+*(Lines 92-97 — TCATBAL file record: 17-byte composite key (11-digit account + 2-char type + 4-digit category) + 33-byte data area containing the running balance)*
+
+## Acceptance Criteria
+
+### Scenario 1: First transaction creates new category balance record
+
+```gherkin
+GIVEN no transaction category balance record exists for:
+  | Account ID     | 12345678901 |
+  | Type Code      | PU          |
+  | Category Code  | 0001        |
+WHEN a purchase transaction of 500.00 is posted
+THEN a new TCATBAL record is created with balance 500.00
+  AND the composite key is "12345678901PU0001"
+```
+
+### Scenario 2: Subsequent transaction updates existing balance
+
+```gherkin
+GIVEN a transaction category balance record exists for:
+  | Account ID     | 12345678901 |
+  | Type Code      | PU          |
+  | Category Code  | 0001        |
+  | Current Balance | 500.00      |
+WHEN another purchase transaction of 300.00 is posted
+THEN the TCATBAL balance is updated to 800.00 (500.00 + 300.00)
+```
+
+### Scenario 3: Repayment reduces category balance
+
+```gherkin
+GIVEN a transaction category balance record for repayments:
+  | Account ID     | 12345678901 |
+  | Type Code      | PA          |
+  | Category Code  | 0001        |
+  | Current Balance | -3000.00     |
+WHEN a repayment of -1000.00 is posted
+THEN the TCATBAL balance is updated to -4000.00 (-3000.00 + (-1000.00))
+```
+
+### Scenario 4: Multiple transaction types tracked separately
+
+```gherkin
+GIVEN a loan account "12345678901"
+WHEN the following transactions are posted:
+  | Type | Category | Amount   |
+  | PU   | 0001     | 1000.00  |
+  | CA   | 0001     | 500.00   |
+  | PA   | 0001     | -750.00  |
+THEN three separate TCATBAL records exist:
+  | Key               | Balance  |
+  | 12345678901PU0001 | 1000.00  |
+  | 12345678901CA0001 | 500.00   |
+  | 12345678901PA0001 | -750.00  |
+```
+
+## Regulatory Mapping
+
+| Regulation | Article/Section | Requirement | How This Rule Satisfies It |
+|------------|----------------|-------------|---------------------------|
+| FSA FFFS 2014:5 | Ch. 3 | Accounting records — institutions must maintain accurate and detailed records of all financial transactions | The category balance system maintains running totals by transaction type and category, supporting detailed accounting breakdowns |
+| FSA FFFS 2014:5 | Ch. 7 | Financial systems — IT systems must support reliable and timely financial reporting | The categorized balances enable regulatory reporting by transaction type (purchases, cash advances, repayments) |
+| PSD2 | Art. 64 | Transaction data integrity — payment service providers must ensure integrity of transaction data | Each transaction updates the category balance atomically, maintaining data integrity across the double-entry system |
+| DORA | Art. 11 | ICT risk management — data integrity controls | The create-or-update pattern with file status checking ensures data integrity; any unexpected file error triggers an abend rather than silent corruption |
+
+## Edge Cases
+
+1. **Concurrent access to same key**: If two transactions for the same account/type/category are in the same batch, they are processed sequentially by the COBOL loop. Each READ gets the latest value. However, in the migrated system with parallel processing, concurrent updates to the same key must use optimistic locking or atomic increment operations.
+
+2. **INITIALIZE clears balance to zero**: When creating a new TCATBAL record (line 504), INITIALIZE sets all fields to their default values. For the balance field (PIC S9), this means zero. The ADD on line 508 then sets it to the transaction amount. This is correct but the INITIALIZE + ADD pattern must be preserved in the migration.
+
+3. **Category code interpretation**: The TRAN-CAT-CD is a 4-digit numeric code (PIC 9(04)). The meaning of specific category codes (e.g., 0001 = retail purchase, 0002 = online purchase) is not defined in the available COBOL source. A category code master table must be obtained from the mainframe team.
+
+4. **Balance sign convention**: Category balances accumulate signed amounts. Purchase categories will have positive balances; repayment categories will have negative balances. The migrated system must preserve this sign convention for correct financial reconciliation.
+
+5. **File full condition**: If the TCATBAL VSAM file reaches its allocated space and cannot extend, the WRITE for a new record would fail. The COBOL program abends in this case. The migrated Azure SQL database does not have this limitation but should monitor storage capacity.
+
+## Domain Expert Notes
+
+- **null** (null): Awaiting domain expert review. Key questions: (1) What are the valid transaction type codes (PU=purchase, CA=cash advance, PA=payment, etc.) and their meanings? (2) What are the valid category codes and is there a category master file? (3) How are category balances used in regulatory reporting — are they aggregated for FSA submissions? (4) Is the TCATBAL file reset at billing cycle close, or does it maintain cumulative balances across cycles? (5) Are there additional balance tracking dimensions beyond type and category?
+
+---
+
+**Template version:** 1.0
+**Last updated:** 2026-02-17


### PR DESCRIPTION
## Summary
- Extract 10 lending business rules (LND-BR-001 through LND-BR-010) covering loan origination, credit limit enforcement, interest calculation, collateral management, disbursement, repayment processing, delinquency management, maturity enforcement, and transaction categorization
- 5 rules extracted directly from available COBOL source (CBTRN02C.cbl credit limit/balance logic); 5 rules derived from regulatory requirements pending dedicated lending COBOL programs from mainframe team
- Full regulatory traceability to FSA FFFS 2014:5, EU Consumer Credit Directive, PSD2, GDPR, AML/KYC, CRR, DORA, and Swedish Inkassolagen

## Changes
- New directory: `docs-site/docs/business-rules/lending/` with 11 files (1 index + 10 rules)
- Each rule follows the established frontmatter and section pattern (Summary, Business Logic, Source COBOL Reference, Acceptance Criteria, Regulatory Mapping, Edge Cases, Domain Expert Notes)
- Index documents source program coverage, regulatory coverage, and migration considerations

## Testing
- [x] `dotnet build /warnaserror` — 0 warnings, 0 errors
- [x] `dotnet test` — 775 tests passed
- [x] `dotnet format --verify-no-changes` — clean
- [x] `npm run build` (docs-site) — builds successfully

Closes #127

🤖 Generated with Claude Code