### PR TITLE
fix(#183): Escape angle brackets in docs for MDX compatibility

### DIFF
--- a/docs-site/docs/batch-processes/cutover-runbook.md
+++ b/docs-site/docs/batch-processes/cutover-runbook.md
@@ -431,8 +431,8 @@ A domain cutover is considered successful when **all** of the following are met:
 
 | Criterion | Measurement | Target |
 |-----------|------------|--------|
-| Error rate | Application Insights error rate | < 0.1% for 48 hours |
-| Latency | Application Insights p99 | < 500ms for 48 hours |
+| Error rate | Application Insights error rate | `< 0.1%` for 48 hours |
+| Latency | Application Insights p99 | `< 500ms` for 48 hours |
 | Batch SLA | Batch completion time | Within SLA window for 2 consecutive cycles |
 | Data integrity | Reconciliation checks | Zero discrepancies |
 | Payment processing | Bankgirot/SWIFT message delivery | Zero lost or duplicated messages |
@@ -471,7 +471,7 @@ Configure an Application Insights dashboard with:
 
 | Panel | Metric | Alert Threshold |
 |-------|--------|----------------|
-| API Health | Request success rate | < 99.9% |
+| API Health | Request success rate | `< 99.9%` |
 | API Latency | p50, p95, p99 response time | p99 > 500ms |
 | Error Breakdown | 4xx and 5xx by endpoint | 5xx > 0.1% |
 | Batch Status | Last batch completion time | Past SLA deadline |

--- a/docs-site/docs/business-rules/billing/bill-br-011.md
+++ b/docs-site/docs/business-rules/billing/bill-br-011.md
@@ -113,7 +113,7 @@ PERFORM LATE-PAYMENT-DETECTION (daily batch — runs after payment posting):
 | Payment Status | Days Past Due | Action | Fee | Rate Impact |
 |---------------|---------------|--------|-----|-------------|
 | Minimum payment received | N/A | Account current — no action | None | Standard rate |
-| Partial payment (< minimum) | 0 | Grace — check again tomorrow | None | Standard rate |
+| Partial payment (`< minimum`) | 0 | Grace — check again tomorrow | None | Standard rate |
 | No payment | 1 | Assess late fee, send reminder | Late fee | Standard rate |
 | No payment | 30+ | First delinquency notice | None (already assessed) | May trigger penalty rate |
 | No payment | 60+ | Restrict new transactions | None | Penalty rate |
@@ -125,7 +125,7 @@ PERFORM LATE-PAYMENT-DETECTION (daily batch — runs after payment posting):
 |-----------|-----------------|
 | First late payment | Lesser of fee-schedule amount or minimum payment due |
 | Subsequent late payment (same cycle) | No additional late fee within same cycle |
-| Balance under threshold (e.g., < 100 SEK) | No late fee if balance is minimal |
+| Balance under threshold (e.g., `< 100 SEK`) | No late fee if balance is minimal |
 | Regulatory cap | Per Swedish consumer credit regulations |
 
 ## Source COBOL Reference

--- a/docs-site/docs/business-rules/billing/bill-br-012.md
+++ b/docs-site/docs/business-rules/billing/bill-br-012.md
@@ -90,8 +90,8 @@ MINIMUM PAYMENT FORMULA (typical Swedish credit card):
 
 | Balance | Past Due | Overlimit | Calculation | Outcome |
 |---------|----------|-----------|-------------|---------|
-| <= 0 | N/A | N/A | No payment due | MinPayment = 0.00 |
-| > 0, <= threshold | No | No | Full balance | MinPayment = Balance |
+| `<= 0` | N/A | N/A | No payment due | MinPayment = 0.00 |
+| `> 0, <= threshold` | No | No | Full balance | MinPayment = Balance |
 | > threshold | No | No | MAX(Fixed, Pct × Balance) | Standard minimum |
 | > threshold | Yes | No | Standard + PastDue | Includes past due |
 | > threshold | No | Yes | Standard + Overlimit | Includes overlimit |

--- a/docs-site/docs/business-rules/lending/lnd-br-005.md
+++ b/docs-site/docs/business-rules/lending/lnd-br-005.md
@@ -64,7 +64,7 @@ PERFORM REPAYMENT-PROCESSING (within 2000-POST-TRANSACTION):
 | Transaction Amount | Classification | Balance Effect | Cycle Field Updated |
 |-------------------|---------------|---------------|-------------------|
 | Positive (>= 0) | Charge/Purchase | Balance increases | ACCT-CURR-CYC-CREDIT |
-| Negative (< 0) | Payment/Repayment | Balance decreases | ACCT-CURR-CYC-DEBIT |
+| Negative (`< 0`) | Payment/Repayment | Balance decreases | ACCT-CURR-CYC-DEBIT |
 
 ## Source COBOL Reference
 

--- a/docs-site/docs/business-rules/reporting/rpt-br-002.md
+++ b/docs-site/docs/business-rules/reporting/rpt-br-002.md
@@ -99,11 +99,11 @@ AML/KYC NIGHTLY SCREENING BATCH:
 |---|---|---|---|---|
 | >= 150,000 | Any | No | No | Threshold report (mandatory) |
 | >= 150,000 | Any | Yes | Any | Sanctions alert + threshold report |
-| < 150,000 | High | No | No | Enhanced monitoring report |
-| < 150,000 | Any | Yes | Any | Sanctions alert (immediate) |
+| `< 150,000` | High | No | No | Enhanced monitoring report |
+| `< 150,000` | Any | Yes | Any | Sanctions alert (immediate) |
 | Any | Any | No | Yes | SAR candidate for review |
 | Cumulative daily >= 150,000 | Any | No | No | Structuring review flag |
-| < 50,000 | Low/Medium | No | No | No action (standard processing) |
+| `< 50,000` | Low/Medium | No | No | No action (standard processing) |
 
 ### AML Threshold Values
 


### PR DESCRIPTION
## Summary
- The Deploy docs site to GitHub Pages workflow was failing because MDX interprets `<` characters in markdown tables as JSX/HTML tag starts
- Wrapped comparison operators (`<=`, `< value`) in inline backticks across 5 docs files to prevent MDX parsing errors
- Verified the docs site builds successfully after the fix

## Changes
- `docs-site/docs/business-rules/billing/bill-br-012.md` — escaped `<=` in decision table
- `docs-site/docs/business-rules/billing/bill-br-011.md` — escaped `< minimum` and `< 100 SEK` in tables
- `docs-site/docs/business-rules/reporting/rpt-br-002.md` — escaped `< 150,000` and `< 50,000` in decision table
- `docs-site/docs/business-rules/lending/lnd-br-005.md` — escaped `< 0` in decision table
- `docs-site/docs/batch-processes/cutover-runbook.md` — escaped `< 0.1%`, `< 500ms`, `< 99.9%` in tables

## Testing
- [x] Docs site builds successfully locally (`npm run build` — zero errors)
- [x] All `<` characters outside code fences are now wrapped in backticks

Closes #183

🤖 Generated with Claude Code