### PR TITLE
docs(#133): Document all JCL batch jobs and process flows

### DIFF
--- a/docs-site/docs/batch-processes/aml-screening.md
+++ b/docs-site/docs/batch-processes/aml-screening.md
@@ -1,0 +1,125 @@
+---
+title: AML/KYC Screening
+sidebar_position: 7
+---
+
+# AML/KYC Screening
+
+**JCL Job Name:** AMLSCRN (estimated &mdash; JCL source pending from mainframe team)
+**Schedule:** Nightly
+**SLA:** Must complete before start of business (by 08:00 CET)
+**Domain:** Account Management
+**Azure Migration:** Azure Functions timer trigger (not yet implemented)
+**Regulation:** Swedish AML Act 2017:630, EU AML Directive 2015/849, FFFS 2017:11 (FSA AML guidelines)
+
+---
+
+## Overview
+
+The AML (Anti-Money Laundering) and KYC (Know Your Customer) screening batch job runs nightly to identify suspicious transaction patterns and customer activity. This is a **regulatory obligation** &mdash; the AML screening batch must not be interrupted during migration, and failure to run constitutes a compliance violation.
+
+---
+
+## Processing Logic (Inferred from Domain)
+
+:::caution JCL Source Pending
+The actual JCL source and COBOL program(s) for AML screening have not yet been obtained from the mainframe team. The processing logic below is inferred from regulatory requirements and the cutover runbook. This document will be updated when the COBOL source is available.
+:::
+
+1. **Read day's transactions** from transaction history
+2. **Screen against sanctions lists** (EU consolidated list, UN sanctions, national lists)
+3. **Apply transaction monitoring rules**:
+   - Large transaction threshold (SEK 150,000+ single transaction)
+   - Structuring detection (multiple transactions just below threshold)
+   - Unusual pattern detection (deviation from customer profile)
+   - Cross-border transaction flagging
+   - High-risk country screening
+4. **Score and flag** suspicious transactions
+5. **Generate alerts** for compliance officer review:
+   - Suspicious Activity Reports (SARs) for confirmed cases
+   - Enhanced Due Diligence (EDD) triggers
+6. **Update customer risk profiles** based on screening results
+7. **Write screening report** with statistics and flagged transactions
+
+---
+
+## Input/Output Datasets (Expected)
+
+| Dataset | Type | Access | Description |
+|---------|------|--------|-------------|
+| Transaction history | VSAM KSDS | Input | Day's posted transactions |
+| Customer master | VSAM KSDS | I-O | Customer records and risk profiles |
+| Sanctions lists | Sequential / DB2 | Input | Current sanctions lists |
+| AML rules table | VSAM KSDS | Input | Screening rules and thresholds |
+| AML alerts output | Sequential | Output | Flagged transactions for review |
+| Screening report | Sequential | Output | Processing summary and statistics |
+
+---
+
+## SLA and Scheduling
+
+| Attribute | Mainframe | Azure (Target) |
+|-----------|-----------|----------------|
+| **Trigger** | JCL schedule (after transaction pipeline) | Azure Functions timer trigger |
+| **Schedule** | Nightly | Same |
+| **SLA deadline** | Before start of business (08:00 CET) | Same |
+| **Dependencies** | Must run after transaction posting is complete | Same |
+
+---
+
+## Error Handling
+
+- AML screening **must complete every night** &mdash; failure is a compliance violation
+- Individual transaction screening failures should be logged and queued for manual review (fail-open for safety, but flag for human review)
+- Sanctions list update failures should trigger operator alert (screening continues with previous list version)
+- All screening decisions must be logged for audit (minimum 5-year retention per AML Act)
+
+---
+
+## Azure Migration Mapping
+
+| Component | Mainframe | Azure Target |
+|-----------|-----------|-------------|
+| **Scheduler** | JCL | Azure Functions timer trigger |
+| **Processing** | COBOL batch program | C# Azure Function |
+| **Data store** | Db2 / VSAM | Azure SQL Database |
+| **Sanctions lists** | Mainframe file / Db2 | Azure SQL + scheduled list updates |
+| **Alert output** | Mainframe spool | Azure Service Bus &rarr; Compliance dashboard |
+| **Monitoring** | JES2 spool | Application Insights |
+| **Audit trail** | Mainframe log | Azure SQL audit table (5-year retention) |
+
+---
+
+## Regulatory Requirements
+
+| Requirement | Regulation | Impact |
+|-------------|-----------|--------|
+| Nightly screening mandatory | AML Act 2017:630 | Failure to screen &rarr; enforcement action |
+| SAR filing within 24 hours | FFFS 2017:11 | Alert-to-filing SLA |
+| 5-year data retention | AML Act 2017:630 | All screening records retained |
+| Sanctions list currency | EU Regulation 2580/2001 | Lists updated within 24 hours of publication |
+| Customer risk profiling | FFFS 2017:11 | Risk scores updated nightly |
+
+---
+
+## Blackout Considerations
+
+AML screening has **no blackout periods** &mdash; it must run every night regardless of other maintenance windows, cutover activities, or holidays. During domain cutover weekends, the AML batch must run on whichever system (mainframe or Azure) is currently processing transactions.
+
+---
+
+## Migration Status
+
+| Phase | Status |
+|-------|--------|
+| COBOL source obtained | Pending |
+| Business rules extracted | Not started |
+| Azure Function implemented | Not started |
+| Parallel-run validation | Not started |
+
+---
+
+## Related Documents
+
+- [Cutover Runbook &mdash; Account Management (Domain 5)](./cutover-runbook.md#55-account-management-domain-5--final)
+- [Regulatory Traceability Matrix](../regulatory-traceability/traceability-matrix.md)

--- a/docs-site/docs/batch-processes/batch-dependency-graph.md
+++ b/docs-site/docs/batch-processes/batch-dependency-graph.md
@@ -1,0 +1,144 @@
+---
+title: Batch Dependency Graph
+sidebar_position: 8
+---
+
+# Batch Dependency Graph
+
+This document shows the execution order and dependencies between all batch jobs in the NordKredit mainframe system and their Azure equivalents.
+
+---
+
+## Nightly Batch Execution DAG
+
+```
+                         ┌─────────────────────────┐
+                         │     JCL Scheduler        │
+                         │   (01:00 UTC nightly)    │
+                         └────────────┬─────────────┘
+                                      │
+                                      ▼
+                    ┌─────────────────────────────────────┐
+                    │  NIGHTLY TRANSACTION PIPELINE        │
+                    │  (JCL chain: CBTRN01C→02C→03C)      │
+                    │  Azure: DailyBatchOrchestrator       │
+                    │  SLA: Complete by 06:00 UTC          │
+                    │                                     │
+                    │  Step 1: Card Verification (CBTRN01C)│
+                    │       │                             │
+                    │       ▼                             │
+                    │  Step 2a: Credit Validation          │
+                    │  Step 2b: Transaction Posting         │
+                    │       │              (CBTRN02C)      │
+                    │       ▼                             │
+                    │  Step 3: Report Generation (CBTRN03C)│
+                    └──────┬──────────────┬───────────────┘
+                           │              │
+              ┌────────────┘              └────────────┐
+              ▼                                        ▼
+┌──────────────────────────┐          ┌──────────────────────────┐
+│ NIGHTLY INTEREST CALC    │          │ AML/KYC SCREENING        │
+│ JCL: INTCALC (est.)     │          │ JCL: AMLSCRN (est.)     │
+│ Azure: Timer trigger     │          │ Azure: Timer trigger     │
+│ Domain: Deposits         │          │ Domain: Acct Mgmt        │
+│ SLA: By 06:00 CET       │          │ SLA: By 08:00 CET       │
+│ Depends on: Txn pipeline │          │ Depends on: Txn pipeline │
+└──────────────────────────┘          └──────────────────────────┘
+
+                    ┌─────────────────────────┐
+                    │     JCL Scheduler        │
+                    │ (Monthly — 1st biz day)  │
+                    └────────────┬─────────────┘
+                                 │
+                                 ▼
+               ┌──────────────────────────────────┐
+               │ MONTHLY STATEMENT GENERATION      │
+               │ JCL: STMTGEN (est.)              │
+               │ Azure: Timer trigger              │
+               │ Domain: Lending / Cross-domain    │
+               │ SLA: Complete by day 3            │
+               │ Depends on: Month-end interest    │
+               │             capitalization        │
+               └──────────────────────────────────┘
+
+                    ┌─────────────────────────┐
+                    │     JCL Scheduler        │
+                    │   (Per FSA calendar)     │
+                    └────────────┬─────────────┘
+                                 │
+                                 ▼
+               ┌──────────────────────────────────┐
+               │ REGULATORY REPORTING (FSA)        │
+               │ JCL: FSAREPT (est.)              │
+               │ Azure: Timer trigger              │
+               │ Domain: Acct Mgmt / Cross-domain  │
+               │ SLA: Per regulatory calendar      │
+               │ Depends on: Month-end closing     │
+               └──────────────────────────────────┘
+```
+
+---
+
+## Dependency Summary Table
+
+| Batch Job | Frequency | Predecessor(s) | Successor(s) |
+|-----------|-----------|-----------------|--------------|
+| **Nightly Transaction Pipeline** | Daily 01:00 UTC | None (first in chain) | Interest Calc, AML Screening |
+| &nbsp;&nbsp;Step 1: Card Verification (CBTRN01C) | — | Pipeline start | Step 2a |
+| &nbsp;&nbsp;Step 2a: Credit Validation (CBTRN02C) | — | Step 1 | Step 2b |
+| &nbsp;&nbsp;Step 2b: Transaction Posting (CBTRN02C) | — | Step 2a | Step 3 |
+| &nbsp;&nbsp;Step 3: Report Generation (CBTRN03C) | — | Step 2b | Pipeline end |
+| **Nightly Interest Calculation** | Daily (after txn pipeline) | Transaction Pipeline | (Month-end: Statement Gen) |
+| **AML/KYC Screening** | Daily (after txn pipeline) | Transaction Pipeline | None |
+| **Monthly Statement Generation** | Monthly (1st biz day) | Month-end interest capitalization | None |
+| **Regulatory Reporting (FSA)** | Per FSA calendar | Month-end/quarter-end closing | None |
+
+---
+
+## Scheduling Constraints
+
+### Nightly Window (01:00&ndash;06:00 CET)
+
+| Time | Job | Notes |
+|------|-----|-------|
+| 01:00 | Transaction Pipeline starts | Triggered by JCL scheduler / Worker |
+| ~01:00&ndash;04:00 | Transaction Pipeline executes | Steps 1&rarr;2a&rarr;2b&rarr;3 sequentially |
+| ~04:00 | Interest Calculation starts | After transaction pipeline completes |
+| ~04:00 | AML Screening starts | Can run in parallel with Interest Calc |
+| 06:00 | **SLA deadline** | Transaction Pipeline + Interest Calc must complete |
+| 08:00 | AML screening deadline | Must complete before start of business |
+
+### Monthly Window
+
+| Time | Job | Notes |
+|------|-----|-------|
+| Month-end | Interest capitalization | Part of nightly interest calc on last business day |
+| Day 1 (1st biz day) | Statement generation starts | Triggered after month-end interest complete |
+| Day 3 | **Statement SLA deadline** | All customer statements must be generated |
+
+### Blackout Periods
+
+| Period | Jobs affected | Reason |
+|--------|--------------|--------|
+| Month-end (last 3 + first 3 biz days) | All except AML | Statement generation, interest capitalization |
+| FSA reporting dates | All except AML | Regulatory submission deadlines |
+| Swedish public holidays | Non-critical maintenance only | Reduced staff |
+| Dec 15 &ndash; Jan 15 | All cutover activities | Year-end processing freeze |
+
+**AML screening has no blackout periods** &mdash; it runs every night without exception.
+
+---
+
+## Azure Migration: Orchestration Strategy
+
+On the mainframe, JCL job scheduling controls batch execution order and dependency chains via JCL `COND` parameters and job schedulers (e.g., TWS/OPC). On Azure, the migration strategy is:
+
+| Mainframe Mechanism | Azure Equivalent |
+|---------------------|------------------|
+| JCL job schedule | `Worker` BackgroundService (timer trigger) |
+| JCL step `COND` parameter | C# `if` / orchestrator step filtering |
+| JCL job dependency chain | Azure Functions chaining / orchestrator pattern |
+| JES2 spool monitoring | Application Insights + Azure Monitor alerts |
+| Operator restart | Manual re-trigger via API or portal |
+
+The `DailyBatchOrchestrator` currently implements the transaction pipeline. Additional orchestrators will be needed for interest calculation, statement generation, regulatory reporting, and AML screening as those domains are migrated.

--- a/docs-site/docs/batch-processes/index.md
+++ b/docs-site/docs/batch-processes/index.md
@@ -5,17 +5,91 @@ sidebar_position: 1
 
 # Batch Processes
 
-JCL batch job documentation and Azure Functions migration mappings.
+Documentation of all JCL batch jobs running on the IBM z/OS mainframe and their Azure Functions migration mappings. The mainframe runs approximately 5 batch job chains covering transaction processing, interest calculation, statement generation, regulatory reporting, and AML screening.
 
-## Status
+---
 
-No batch processes have been documented yet. Job documentation will be added as each batch job is analyzed.
+## Batch Job Inventory
 
-## Expected Coverage
+| Job | JCL Name | COBOL Programs | Schedule | SLA | Domain | Azure Status |
+|-----|----------|---------------|----------|-----|--------|-------------|
+| [Nightly Transaction Pipeline](./nightly-transaction-pipeline.md) | CBTRN01C&rarr;02C&rarr;03C | CBTRN01C, CBTRN02C, CBTRN03C | Daily 01:00 UTC | By 06:00 UTC | Transactions | Implemented (`DailyBatchOrchestrator`) |
+| [Nightly Interest Calculation](./nightly-interest-calculation.md) | INTCALC (est.) | Pending | Daily (after txn pipeline) | By 06:00 CET | Deposits | Not started |
+| [Monthly Statement Generation](./monthly-statement-generation.md) | STMTGEN (est.) | Pending | Monthly (1st biz day) | By day 3 | Lending | Not started |
+| [Regulatory Reporting (FSA)](./regulatory-reporting.md) | FSAREPT (est.) | Pending | Per FSA calendar | Per calendar | Account Mgmt | Not started |
+| [AML/KYC Screening](./aml-screening.md) | AMLSCRN (est.) | Pending | Nightly | By 08:00 CET | Account Mgmt | Not started |
 
-| Job | Current SLA | Target |
-|-----|------------|--------|
-| Nightly interest calculation | Complete by 06:00 | Azure Functions (timer trigger) |
-| Monthly statements | Complete by day 3 | Azure Functions (timer trigger) |
-| Regulatory reporting (FSA) | Per regulatory calendar | Azure Functions (timer trigger) |
-| AML screening | Nightly | Azure Functions (timer trigger) |
+---
+
+## Nightly Execution Order
+
+```
+01:00 UTC ──► Transaction Pipeline (CBTRN01C → CBTRN02C → CBTRN03C)
+                    │
+                    ├──► Interest Calculation (after txn pipeline)
+                    │
+                    └──► AML/KYC Screening (after txn pipeline)
+
+06:00 UTC ──► SLA DEADLINE (Transaction Pipeline + Interest Calc)
+
+08:00 CET ──► AML Screening deadline
+```
+
+See [Batch Dependency Graph](./batch-dependency-graph.md) for the complete execution DAG and scheduling constraints.
+
+---
+
+## SLA Summary
+
+| Job | SLA Deadline | Consequence of Breach |
+|-----|-------------|----------------------|
+| Nightly Transaction Pipeline | 06:00 UTC | Delayed account balances; batch SLA alert |
+| Nightly Interest Calculation | 06:00 CET | Incorrect interest accrual; financial impact |
+| Monthly Statements | Day 3 of month | Customer communication delay; regulatory risk |
+| Regulatory Reporting | Per FSA calendar | FSA enforcement action |
+| AML/KYC Screening | 08:00 CET | Compliance violation (AML Act 2017:630) |
+
+---
+
+## Migration Status Overview
+
+| Phase | Transaction Pipeline | Interest Calc | Statements | Regulatory | AML |
+|-------|---------------------|--------------|------------|-----------|-----|
+| COBOL source obtained | Yes | Pending | Pending | Pending | Pending |
+| Business rules extracted | Yes (TRN-BR-005&ndash;009) | No | No | No | No |
+| Azure implemented | Yes | No | No | No | No |
+| Unit tests | Yes | No | No | No | No |
+| Parallel-run validated | No | No | No | No | No |
+
+---
+
+## Key Documents
+
+- [Batch Dependency Graph](./batch-dependency-graph.md) &mdash; Execution order DAG and scheduling constraints
+- [Cutover Runbook](./cutover-runbook.md) &mdash; Operational cutover procedures including batch timing windows
+- [ADR-001: Batch Pipeline Orchestrator Pattern](/docs/Architecture/ADR-001-batch-pipeline-orchestrator.md) &mdash; Architecture decision for the transaction pipeline
+
+---
+
+## Regulatory Context
+
+All batch jobs operate under the following regulatory frameworks:
+
+| Regulation | Relevance |
+|-----------|-----------|
+| FFFS 2014:5 Ch.4 &sect;3 | Operational risk management during batch processing |
+| DORA Art.11 | ICT system testing and risk monitoring |
+| PSD2 Art.94 | Transaction record retention |
+| AML Act 2017:630 | Mandatory nightly AML screening |
+| FFFS 2017:11 | FSA AML guidelines |
+| EU Consumer Credit Directive 2008/48/EC | Statement accuracy for lending |
+
+---
+
+## Outstanding Actions
+
+1. **Obtain JCL source** from mainframe team for interest calculation, statement generation, regulatory reporting, and AML screening
+2. **Extract business rules** from remaining COBOL batch programs
+3. **Implement Azure Functions** for remaining batch jobs
+4. **Validate parallel-run** for transaction pipeline (first)
+5. **Domain expert sign-off** on all extracted batch business rules

--- a/docs-site/docs/batch-processes/monthly-statement-generation.md
+++ b/docs-site/docs/batch-processes/monthly-statement-generation.md
@@ -1,0 +1,110 @@
+---
+title: Monthly Statement Generation
+sidebar_position: 5
+---
+
+# Monthly Statement Generation
+
+**JCL Job Name:** STMTGEN (estimated &mdash; JCL source pending from mainframe team)
+**Schedule:** Monthly (triggered on first business day after month-end)
+**SLA:** Must complete by day 3 of the new month
+**Domain:** Lending / Cross-domain
+**Azure Migration:** Azure Functions timer trigger (not yet implemented)
+**Regulation:** FFFS 2014:5 Ch.7 (customer reporting), PSD2 Art.94 (transaction records), EU Consumer Credit Directive 2008/48/EC
+
+---
+
+## Overview
+
+The monthly statement generation batch job produces customer statements covering all account activity for the preceding month. Statements include transaction history, balance summaries, interest charges/credits, and fee breakdowns. Statements are generated for both deposit and lending accounts and must be delivered to customers within the first 3 business days of the new month.
+
+---
+
+## Processing Logic (Inferred from Domain)
+
+:::caution JCL Source Pending
+The actual JCL source and COBOL program(s) for this batch job have not yet been obtained from the mainframe team. The processing logic below is inferred from domain requirements and the cutover runbook. This document will be updated when the COBOL source is available.
+:::
+
+1. **Determine statement period** &mdash; first day to last day of previous month
+2. **Iterate over all active accounts** (deposits + lending):
+   - Read account master record
+   - Read all transactions within the statement period
+   - Read interest accrual records for the period
+   - Read fee/charge records for the period
+3. **Generate statement data** for each account:
+   - Opening balance
+   - Transaction listing (date, description, amount, running balance)
+   - Interest credited/charged
+   - Fees charged
+   - Closing balance
+4. **Format statement output** (print-ready and/or digital format)
+5. **Write statement records** to output dataset for printing/delivery
+6. **Generate summary report** &mdash; accounts processed, statement count, exceptions
+
+---
+
+## Input/Output Datasets (Expected)
+
+| Dataset | Type | Access | Description |
+|---------|------|--------|-------------|
+| Account master | VSAM KSDS | Input | All active accounts |
+| Transaction history | VSAM KSDS | Input | Month's transactions |
+| Interest accrual ledger | VSAM KSDS | Input | Interest records |
+| Fee/charge ledger | VSAM KSDS | Input | Fee records |
+| Statement output | Sequential | Output | Formatted statement records |
+| Statement summary report | Sequential | Output | Processing summary |
+
+---
+
+## SLA and Scheduling
+
+| Attribute | Mainframe | Azure (Target) |
+|-----------|-----------|----------------|
+| **Trigger** | JCL schedule (1st business day) | Azure Functions timer trigger |
+| **Schedule** | Monthly | Monthly |
+| **SLA deadline** | Complete by day 3 | Same |
+| **Dependencies** | Month-end interest capitalization must be complete | Same |
+
+---
+
+## Error Handling
+
+- Individual account statement failures should be logged and skipped
+- Missing transaction data for an account should generate a partial statement with a warning
+- Statement delivery failures (print queue, digital channel) require retry and operator notification
+
+---
+
+## Azure Migration Mapping
+
+| Component | Mainframe | Azure Target |
+|-----------|-----------|-------------|
+| **Scheduler** | JCL | Azure Functions timer trigger |
+| **Processing** | COBOL batch program | C# Azure Function |
+| **Data store** | Db2 / VSAM | Azure SQL Database |
+| **Statement delivery** | Print queue / mainframe spool | Azure Blob Storage + delivery pipeline |
+| **Monitoring** | JES2 spool | Application Insights |
+
+---
+
+## Blackout Periods
+
+Per the cutover runbook, no domain cutover may be scheduled during the month-end period (last 3 business days + first 3 business days) to protect statement generation.
+
+---
+
+## Migration Status
+
+| Phase | Status |
+|-------|--------|
+| COBOL source obtained | Pending |
+| Business rules extracted | Not started |
+| Azure Function implemented | Not started |
+| Parallel-run validation | Not started |
+
+---
+
+## Related Documents
+
+- [Cutover Runbook &mdash; Lending (Domain 4)](./cutover-runbook.md#54-lending-domain-4)

--- a/docs-site/docs/batch-processes/nightly-interest-calculation.md
+++ b/docs-site/docs/batch-processes/nightly-interest-calculation.md
@@ -1,0 +1,107 @@
+---
+title: Nightly Interest Calculation
+sidebar_position: 4
+---
+
+# Nightly Interest Calculation
+
+**JCL Job Name:** INTCALC (estimated &mdash; JCL source pending from mainframe team)
+**Schedule:** Nightly (runs after transaction posting completes)
+**SLA:** Must complete by 06:00 CET
+**Domain:** Deposits
+**Azure Migration:** Azure Functions timer trigger (not yet implemented)
+**Regulation:** FFFS 2014:5 Ch.3 (financial reporting), GDPR Art.5(1)(f) (data integrity)
+
+---
+
+## Overview
+
+The nightly interest calculation batch job computes accrued interest for all deposit accounts. It runs after the nightly transaction pipeline completes to ensure all daily transactions are reflected in the balance before interest accrual. This is one of the most financially sensitive batch jobs &mdash; calculation accuracy directly impacts customer balances and regulatory reporting.
+
+---
+
+## Processing Logic (Inferred from Domain)
+
+:::caution JCL Source Pending
+The actual JCL source and COBOL program(s) for this batch job have not yet been obtained from the mainframe team. The processing logic below is inferred from domain requirements, the cutover runbook, and interviews. This document will be updated when the COBOL source is available.
+:::
+
+1. **Read deposit account master** &mdash; iterate over all active deposit accounts
+2. **Calculate daily interest accrual** for each account:
+   - Determine applicable interest rate (fixed, variable, or tiered)
+   - Calculate daily accrual: `(balance * annual_rate) / days_in_year`
+   - Handle day-count conventions (ACT/360 or ACT/365)
+3. **Update interest accrual ledger** &mdash; record daily accrual amount
+4. **Month-end capitalization** (on last business day of month):
+   - Add accumulated accrued interest to account balance
+   - Reset accrual counter
+   - Generate interest statement entries
+5. **Write summary report** &mdash; total interest accrued, account count, exceptions
+
+---
+
+## Input/Output Datasets (Expected)
+
+| Dataset | Type | Access | Description |
+|---------|------|--------|-------------|
+| Deposit account master | VSAM KSDS | I-O | Account balances and interest rates |
+| Interest rate table | VSAM KSDS | Input | Current rate schedules |
+| Interest accrual ledger | VSAM KSDS | I-O | Daily accrual records |
+| Interest calculation report | Sequential | Output | Summary report |
+
+---
+
+## SLA and Scheduling
+
+| Attribute | Mainframe | Azure (Target) |
+|-----------|-----------|----------------|
+| **Trigger** | JCL schedule (after transaction pipeline) | Azure Functions timer trigger |
+| **Schedule** | Nightly | Nightly (after `DailyBatchOrchestrator` completes) |
+| **SLA deadline** | Complete by 06:00 CET | Same |
+| **Dependencies** | Must run after transaction posting | Same |
+
+---
+
+## Error Handling
+
+- Interest calculation errors on individual accounts should be logged and skipped (not ABEND the entire batch)
+- Month-end capitalization failures require immediate operator notification
+- Rounding discrepancies must be logged for audit (regulation requires sub-cent accuracy)
+
+---
+
+## Azure Migration Mapping
+
+| Component | Mainframe | Azure Target |
+|-----------|-----------|-------------|
+| **Scheduler** | JCL | Azure Functions timer trigger |
+| **Processing** | COBOL batch program | C# Azure Function |
+| **Data store** | Db2 / VSAM | Azure SQL Database |
+| **Monitoring** | JES2 spool | Application Insights |
+| **Interest rates** | VSAM table | Azure SQL configuration table |
+
+---
+
+## Validation Requirements
+
+Per the cutover runbook:
+- Interest calculation accuracy must be validated against mainframe output for **30 consecutive days** before cutover
+- Month-end cutover blackout applies (last 3 + first 3 business days)
+- Rounding differences between COBOL packed-decimal and C# decimal types must be within 0.01 SEK
+
+---
+
+## Migration Status
+
+| Phase | Status |
+|-------|--------|
+| COBOL source obtained | Pending |
+| Business rules extracted | Not started |
+| Azure Function implemented | Not started |
+| Parallel-run validation | Not started |
+
+---
+
+## Related Documents
+
+- [Cutover Runbook &mdash; Deposits (Domain 3)](./cutover-runbook.md#53-deposits-domain-3)

--- a/docs-site/docs/batch-processes/nightly-transaction-pipeline.md
+++ b/docs-site/docs/batch-processes/nightly-transaction-pipeline.md
@@ -1,0 +1,265 @@
+---
+title: Nightly Transaction Pipeline
+sidebar_position: 3
+---
+
+# Nightly Transaction Pipeline
+
+**JCL Job Chain:** CBTRN01C &rarr; CBTRN02C &rarr; CBTRN03C
+**Schedule:** Daily at 01:00 UTC (configurable via `BatchSchedule:CronHour` / `BatchSchedule:CronMinute`)
+**SLA:** Must complete by 06:00 UTC
+**Azure Migration:** `DailyBatchOrchestrator` in `NordKredit.Functions`
+**Regulation:** FFFS 2014:5 Ch.4 &sect;3 (operational risk), DORA Art.11 (ICT risk management)
+
+---
+
+## Overview
+
+The nightly transaction pipeline is the primary batch job chain on the mainframe. It processes the daily transaction file through three sequential COBOL programs: card verification, credit validation and posting, and report generation. On the mainframe, a JCL job schedule triggers the chain nightly; on Azure, a `Worker` (BackgroundService) replaces the JCL scheduler.
+
+---
+
+## Pipeline Steps
+
+### Step 1: Card Verification (CBTRN01C)
+
+| Attribute | Value |
+|-----------|-------|
+| **COBOL Program** | `CBTRN01C.cbl` (494 lines) |
+| **COBOL Source Lines** | Lines 154-250 (PROCEDURE DIVISION) |
+| **Azure Implementation** | `CardVerificationFunction` (`ICardVerificationStep`) |
+| **Business Rule** | TRN-BR-005 |
+| **Regulation** | PSD2 Art.97 (SCA), AML/KYC |
+
+**Input files (mainframe):**
+
+| DD Name | Dataset Type | Description |
+|---------|-------------|-------------|
+| DALYTRAN | Sequential (QSAM) | Daily transaction file |
+| CUSTFILE | Indexed (VSAM KSDS) | Customer master file |
+| XREFFILE | Indexed (VSAM KSDS) | Card-to-account cross-reference |
+| CARDFILE | Indexed (VSAM KSDS) | Card master file |
+| ACCTFILE | Indexed (VSAM KSDS) | Account master file |
+| TRANFILE | Indexed (VSAM KSDS) | Transaction history file |
+
+**Output files (mainframe):**
+- Writes to SYSOUT (DISPLAY statements) only; no output file is produced.
+
+**Processing logic:**
+
+1. Open all input files (abend on any open failure)
+2. Read daily transaction file sequentially
+3. For each transaction:
+   - Look up card number in XREFFILE to find account ID
+   - If card not found: log "CARD NUMBER ... COULD NOT BE VERIFIED" and skip
+   - If card found: read account record from ACCTFILE
+   - If account not found: log "ACCOUNT ... NOT FOUND"
+4. Close all files
+5. Return code 0 (advisory-only step)
+
+**Error handling:**
+- File open failure &rarr; ABEND (CEE3ABD, code 999)
+- File read error (non-EOF) &rarr; ABEND
+- Missing card/account &rarr; DISPLAY warning, continue processing
+
+**Azure mapping:** `CardVerificationResult` contains `VerifiedCount`, `FailedCount`, and a list of `VerifiedTransaction` records. Only verified transactions are passed to Step 2.
+
+---
+
+### Step 2: Credit Validation and Transaction Posting (CBTRN02C)
+
+| Attribute | Value |
+|-----------|-------|
+| **COBOL Program** | `CBTRN02C.cbl` (731 lines) |
+| **COBOL Source Lines** | Lines 370-422 (validation), 424-579 (posting) |
+| **Azure Implementation** | `TransactionCreditValidationFunction` + `TransactionPostingFunction` |
+| **Business Rules** | TRN-BR-006 (validation), TRN-BR-007/008 (posting) |
+| **Regulation** | PSD2 Art.97, FFFS 2014:5 Ch.3/Ch.16, EBA creditworthiness |
+
+**Input files (mainframe):**
+
+| DD Name | Dataset Type | Access | Description |
+|---------|-------------|--------|-------------|
+| DALYTRAN | Sequential (QSAM) | Input | Daily transaction file |
+| XREFFILE | Indexed (VSAM KSDS) | Input | Card-to-account cross-reference |
+| ACCTFILE | Indexed (VSAM KSDS) | I-O | Account master file (read + update) |
+| TCATBALF | Indexed (VSAM KSDS) | I-O | Transaction category balance file (read + update/create) |
+
+**Output files (mainframe):**
+
+| DD Name | Dataset Type | Description |
+|---------|-------------|-------------|
+| TRANFILE | Indexed (VSAM KSDS) | Posted transaction records |
+| DALYREJS | Sequential (QSAM) | Rejected transaction records with reason codes |
+
+**Processing logic:**
+
+1. **Validation phase** (lines 370-422):
+   - Look up card number in XREFFILE &rarr; reject code 100 if not found
+   - Look up account in ACCTFILE &rarr; reject code 101 if not found
+   - Check credit limit: `ACCT-CREDIT-LIMIT >= (ACCT-CURR-CYC-CREDIT - ACCT-CURR-CYC-DEBIT + TRAN-AMT)` &rarr; reject code 102 ("OVERLIMIT TRANSACTION")
+   - Check expiration: `ACCT-EXPIRATION-DATE >= TRAN-ORIG-TS(1:10)` &rarr; reject code 103 ("TRANSACTION RECEIVED AFTER ACCT EXPIRATION")
+   - Rejected transactions are written to DALYREJS with a validation trailer
+
+2. **Posting phase** (lines 424-579):
+   - Map daily transaction fields to permanent transaction record fields
+   - Generate DB2-format processing timestamp
+   - **Update TCATBAL** (category balance): read existing record; if not found, create new record; add transaction amount to category balance
+   - **Update ACCTFILE** (account balance): add transaction amount to `ACCT-CURR-BAL`; credit/debit cycle tracking based on amount sign
+   - **Write TRANFILE**: write completed transaction record
+
+3. **Summary** (line 227-231):
+   - Display transaction and reject counts
+   - Set `RETURN-CODE = 4` if any rejections occurred
+
+**Rejection reason codes:**
+
+| Code | Description |
+|------|-------------|
+| 100 | Invalid card number (not in XREF) |
+| 101 | Account record not found |
+| 102 | Over credit limit |
+| 103 | Transaction after account expiration |
+
+**Error handling:**
+- File open/read/write errors &rarr; ABEND (code 999)
+- RETURN-CODE 4 &rarr; warnings (rejections exist but processing completed)
+- RETURN-CODE 0 &rarr; all transactions posted successfully
+
+**Azure mapping:** Split into two steps in the orchestrator:
+- **Step 2a** (`TransactionCreditValidationFunction`): validates transactions, produces `TransactionCreditValidationResult` with `ValidCount`/`RejectedCount` and reason codes. Sets `HasWarnings = true` if rejections exist (replaces `RETURN-CODE = 4`).
+- **Step 2b** (`TransactionPostingFunction`): posts valid transactions, updates category and account balances. Produces `TransactionPostingResult` with `PostedCount`/`SkippedCount`/`FailedCount`. Sets `HasErrors = true` if posting failures exist (replaces `RETURN-CODE = 8`).
+
+---
+
+### Step 3: Report Generation (CBTRN03C)
+
+| Attribute | Value |
+|-----------|-------|
+| **COBOL Program** | `CBTRN03C.cbl` (649 lines) |
+| **COBOL Source Lines** | Lines 159-373 (report logic) |
+| **Azure Implementation** | `TransactionReportFunction` (`IReportGenerationStep`) |
+| **Business Rule** | TRN-BR-009 |
+| **Regulation** | FFFS 2014:5 Ch.7, PSD2 Art.94, AML 2017:11 |
+
+**Input files (mainframe):**
+
+| DD Name | Dataset Type | Description |
+|---------|-------------|-------------|
+| TRANFILE | Sequential (QSAM) | Posted transaction file (output from Step 2) |
+| CARDXREF | Indexed (VSAM KSDS) | Card-to-account cross-reference |
+| TRANTYPE | Indexed (VSAM KSDS) | Transaction type description lookup |
+| TRANCATG | Indexed (VSAM KSDS) | Transaction category description lookup |
+| DATEPARM | Sequential (QSAM) | Date range parameters (start date, end date) |
+
+**Output files (mainframe):**
+
+| DD Name | Dataset Type | Description |
+|---------|-------------|-------------|
+| TRANREPT | Sequential (QSAM) | Transaction detail report (133-character print lines) |
+
+**Processing logic:**
+
+1. Read date parameters (start date, end date) from DATEPARM file
+2. Read transaction file sequentially
+3. Filter transactions by processing timestamp within date range
+4. For each qualifying transaction:
+   - Look up card cross-reference for account ID
+   - Look up transaction type description
+   - Look up transaction category description
+   - Write detail line to report
+5. Pagination: 20 lines per page, with page totals
+6. Group by card number, with account totals on card change
+7. Grand total at end of report
+
+**Report structure:**
+
+```
+TRANSACTION DETAIL REPORT            From: YYYY-MM-DD To: YYYY-MM-DD
+
+Trans ID         Account     Type  Type Desc    Cat   Cat Desc     Source  Amount
+---------------------------------------------------------------------------
+XXXXXXXXXXXXXXXX 99999999999  XX   Description  9999  Description  XX    $999,999.99
+...
+                                                          PAGE TOTAL: $999,999.99
+---------------------------------------------------------------------------
+                                                       ACCOUNT TOTAL: $999,999.99
+---------------------------------------------------------------------------
+                                                         GRAND TOTAL: $999,999.99
+```
+
+**Error handling:**
+- File open failure &rarr; ABEND (code 999)
+- Invalid card XREF, transaction type, or category lookup &rarr; ABEND
+- Date parameter file empty/error &rarr; ABEND
+
+**Azure mapping:** `TransactionReportFunction` generates a `TransactionReportFunctionResult` containing `TotalTransactions`, `DetailLineCount`, `PageCount`, `AccountGroupCount`, and `GrandTotal`. Page size defaults to 20 (matching COBOL `WS-PAGE-SIZE`).
+
+---
+
+## VSAM-to-Azure SQL Dataset Mapping
+
+| Mainframe Dataset (DD) | VSAM Type | Azure SQL Table | Entity Framework Entity |
+|------------------------|-----------|-----------------|------------------------|
+| DALYTRAN | Sequential | DailyTransactions | DailyTransaction |
+| XREFFILE / CARDXREF | KSDS | CardCrossReferences | CardCrossReference |
+| CUSTFILE | KSDS | Customers | Customer |
+| CARDFILE | KSDS | Cards | Card |
+| ACCTFILE | KSDS | Accounts | Account |
+| TRANFILE | KSDS / Sequential | Transactions | Transaction |
+| TCATBALF | KSDS | TransactionCategoryBalances | TransactionCategoryBalance |
+| DALYREJS | Sequential | (logged, not persisted) | RejectedTransaction |
+| TRANREPT | Sequential | (generated in memory) | TransactionReportFunctionResult |
+| DATEPARM | Sequential | (configuration / parameters) | N/A |
+| TRANTYPE | KSDS | TransactionTypes | TransactionType |
+| TRANCATG | KSDS | TransactionCategories | TransactionCategory |
+
+---
+
+## Scheduling and SLA
+
+| Attribute | Mainframe | Azure |
+|-----------|-----------|-------|
+| **Trigger** | JCL job schedule | `Worker` BackgroundService (timer) |
+| **Schedule** | Nightly (defined in JCL) | 01:00 UTC (configurable) |
+| **SLA deadline** | 06:00 CET | 06:00 UTC (hardcoded in `DailyBatchOrchestrator`) |
+| **SLA monitoring** | Manual / JES2 | `IsSlaBreached()` &rarr; Application Insights alert |
+| **Retry on failure** | Manual restart by operator | No automatic retry (operator intervention) |
+
+---
+
+## Error Handling and Recovery
+
+### Mainframe (JCL/COBOL)
+
+- **ABEND handling:** All three programs call `CEE3ABD` with abend code 999 on unrecoverable errors
+- **Restart/recovery:** JCL restart from last successful step; no automatic checkpointing within programs
+- **Return codes:** Step 2 sets `RETURN-CODE = 4` for warnings (rejections); other steps return 0 or ABEND
+- **JCL COND parameter:** Subsequent steps check predecessor return codes to decide whether to execute
+
+### Azure (DailyBatchOrchestrator)
+
+- **Failure handling:** Unrecoverable exception halts the pipeline; `DailyBatchResult.FailedStep` identifies which step failed
+- **Logging:** Structured logging via `ILogger` partial methods &rarr; Application Insights
+- **Metrics:** `BatchMetricsService` tracks pipeline duration, transactions posted, and transactions rejected via OpenTelemetry
+- **SLA breach:** Logged as `LogLevel.Error`; triggers Application Insights alert rule
+
+---
+
+## Telemetry
+
+| Metric | Instrument | Description |
+|--------|-----------|-------------|
+| `NordKredit.Batch.BatchDuration` | Histogram | Pipeline execution time in seconds |
+| `NordKredit.Batch.TransactionsPosted` | Counter | Count of successfully posted transactions |
+| `NordKredit.Batch.TransactionsRejected` | Counter | Count of rejected transactions |
+
+---
+
+## Related Documents
+
+- [ADR-001: Batch Pipeline Orchestrator Pattern](/docs/Architecture/ADR-001-batch-pipeline-orchestrator.md)
+- [UC-TRN-04: Daily Transaction Verification](../requirements/transactions/uc-trn-04-daily-verification.md)
+- [UC-TRN-05: Post Daily Transactions](../requirements/transactions/uc-trn-05-daily-posting.md)
+- [UC-TRN-06: Generate Daily Transaction Report](../requirements/transactions/uc-trn-06-daily-report.md)
+- [TRN-BR-005: Daily Transaction Posting](../business-rules/transactions/trn-br-005-daily-transaction-posting.md)

--- a/docs-site/docs/batch-processes/regulatory-reporting.md
+++ b/docs-site/docs/batch-processes/regulatory-reporting.md
@@ -1,0 +1,121 @@
+---
+title: Regulatory Reporting (FSA)
+sidebar_position: 6
+---
+
+# Regulatory Reporting (FSA)
+
+**JCL Job Name:** FSAREPT (estimated &mdash; JCL source pending from mainframe team)
+**Schedule:** Per FSA regulatory calendar (varies by report type)
+**SLA:** Per regulatory calendar deadlines
+**Domain:** Account Management / Cross-domain
+**Azure Migration:** Azure Functions timer trigger (not yet implemented)
+**Regulation:** FFFS 2014:5 Ch.7-9 (supervisory reporting), DORA Art.11 (ICT reporting)
+
+---
+
+## Overview
+
+The regulatory reporting batch job generates reports required by Finansinspektionen (FSA), the Swedish financial supervisory authority. These reports cover capital adequacy, liquidity, large exposures, and operational risk metrics. Missing or late regulatory submissions can trigger enforcement action, making this one of the highest-priority batch jobs.
+
+---
+
+## Report Types (Known)
+
+| Report | Frequency | Deadline | Regulation |
+|--------|-----------|----------|------------|
+| Capital adequacy (COREP) | Quarterly | Per FSA calendar | FFFS 2014:5 Ch.7 |
+| Liquidity coverage ratio (LCR) | Monthly | Per FSA calendar | FFFS 2014:5 Ch.7 |
+| Large exposure reporting | Quarterly | Per FSA calendar | FFFS 2014:5 Ch.7 |
+| Operational risk events | Quarterly | Per FSA calendar | FFFS 2014:5 Ch.4 |
+| AML suspicious activity reports | As needed | Immediate | AML Act 2017:630 |
+| DORA ICT incident reports | As needed | 4h initial, 72h intermediate | DORA Art.17-19 |
+
+---
+
+## Processing Logic (Inferred from Domain)
+
+:::caution JCL Source Pending
+The actual JCL source and COBOL program(s) for regulatory reporting have not yet been obtained from the mainframe team. The processing logic below is inferred from regulatory requirements and the cutover runbook. This document will be updated when the COBOL source is available.
+:::
+
+1. **Determine reporting period** based on FSA calendar
+2. **Extract data** from relevant domain tables:
+   - Account balances and classifications
+   - Transaction volumes and values
+   - Risk exposure calculations
+   - Operational incident records
+3. **Apply regulatory calculation rules** (capital ratios, liquidity metrics)
+4. **Format output** per FSA submission templates (XBRL or CSV)
+5. **Validate output** against FSA validation rules
+6. **Write report files** for submission
+7. **Generate audit trail** documenting report generation parameters and data sources
+
+---
+
+## Input/Output Datasets (Expected)
+
+| Dataset | Type | Access | Description |
+|---------|------|--------|-------------|
+| Account master | VSAM KSDS | Input | Account classifications and balances |
+| Transaction history | VSAM KSDS | Input | Transaction volumes |
+| Risk classification table | VSAM KSDS | Input | Exposure categories |
+| Regulatory report output | Sequential | Output | Formatted report files |
+| Audit trail | Sequential | Output | Generation audit log |
+
+---
+
+## SLA and Scheduling
+
+| Attribute | Mainframe | Azure (Target) |
+|-----------|-----------|----------------|
+| **Trigger** | JCL schedule per FSA calendar | Azure Functions timer trigger |
+| **Schedule** | Monthly/Quarterly per report type | Same |
+| **SLA deadline** | Per FSA regulatory calendar | Same |
+| **Dependencies** | Month-end closing must be complete | Same |
+
+---
+
+## Error Handling
+
+- Regulatory reports must **never** be submitted with known errors
+- Validation failures halt submission and require operator/compliance review
+- Failed reports must be regenerated and submitted before the deadline
+- All generation attempts are logged for audit purposes (DORA Art.11)
+
+---
+
+## Azure Migration Mapping
+
+| Component | Mainframe | Azure Target |
+|-----------|-----------|-------------|
+| **Scheduler** | JCL | Azure Functions timer trigger |
+| **Processing** | COBOL batch program | C# Azure Function |
+| **Data store** | Db2 / VSAM | Azure SQL Database |
+| **Report output** | Mainframe spool / file transfer | Azure Blob Storage + secure transfer |
+| **Monitoring** | JES2 spool | Application Insights |
+| **Audit trail** | Mainframe log | Azure SQL audit table |
+
+---
+
+## Blackout Periods
+
+Per the cutover runbook, no domain cutover may be scheduled during FSA regulatory reporting dates.
+
+---
+
+## Migration Status
+
+| Phase | Status |
+|-------|--------|
+| COBOL source obtained | Pending |
+| Business rules extracted | Not started |
+| Azure Function implemented | Not started |
+| Parallel-run validation | Not started |
+
+---
+
+## Related Documents
+
+- [Cutover Runbook &mdash; Account Management (Domain 5)](./cutover-runbook.md#55-account-management-domain-5--final)
+- [Regulatory Traceability Matrix](../regulatory-traceability/traceability-matrix.md)


### PR DESCRIPTION
## Summary
- Comprehensive documentation of all 5 JCL batch jobs in the NordKredit mainframe system
- Nightly transaction pipeline (CBTRN01C→02C→03C) fully documented from COBOL source with file layouts, processing logic, error handling, and VSAM-to-Azure SQL mapping
- Four additional batch jobs (interest calculation, statements, regulatory reporting, AML screening) documented from domain knowledge and cutover runbook — marked as pending COBOL source
- Batch dependency graph (DAG) showing execution order, scheduling constraints, and blackout periods
- Index updated from placeholder to comprehensive batch process catalog with SLA summary and migration status

## Changes
- `docs-site/docs/batch-processes/index.md` — Replaced placeholder with comprehensive batch job index
- `docs-site/docs/batch-processes/nightly-transaction-pipeline.md` — New: detailed 3-step pipeline docs from COBOL source
- `docs-site/docs/batch-processes/nightly-interest-calculation.md` — New: deposits domain batch job (COBOL source pending)
- `docs-site/docs/batch-processes/monthly-statement-generation.md` — New: lending domain batch job (COBOL source pending)
- `docs-site/docs/batch-processes/regulatory-reporting.md` — New: FSA reporting batch job (COBOL source pending)
- `docs-site/docs/batch-processes/aml-screening.md` — New: AML/KYC screening batch job (COBOL source pending)
- `docs-site/docs/batch-processes/batch-dependency-graph.md` — New: execution DAG and scheduling constraints

## Testing
- [x] `dotnet build /warnaserror` — 0 warnings, 0 errors
- [x] `dotnet test` — 775 tests passed (614 unit + 88 BDD + 73 comparison)
- [x] Documentation-only change, no code modifications

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)